### PR TITLE
Fix mesh color inconsistency bug (np.array vs tuple)

### DIFF
--- a/viser/_message_api.py
+++ b/viser/_message_api.py
@@ -63,6 +63,8 @@ def _encode_rgb(
     | Tuple[float, float, float]
     | onp.ndarray = (80, 120, 255),
 ) -> int:
+    if isinstance(rgb, onp.ndarray):
+        assert rgb.shape == (3,)
     rgb_fixed = tuple(
         value if onp.issubdtype(type(value), onp.integer) else int(value * 255) for value in rgb
     )

--- a/viser/_message_api.py
+++ b/viser/_message_api.py
@@ -64,7 +64,7 @@ def _encode_rgb(
     | onp.ndarray = (80, 120, 255),
 ) -> int:
     rgb_fixed = tuple(
-        value if isinstance(value, int) else int(value * 255) for value in rgb
+        value if onp.issubdtype(type(value), onp.integer) else int(value * 255) for value in rgb
     )
     assert len(rgb_fixed) == 3
     return int(rgb_fixed[0] * (256**2) + rgb_fixed[1] * 256 + rgb_fixed[2])


### PR DESCRIPTION
one line change + tested on 

blue = (90, 200, 255)
blue = onp.array([90, 200, 255])