### PR TITLE
Click events for GUI images

### DIFF
--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -659,6 +659,7 @@ class GuiApi:
                 [0.0, 0.0],
                 props=message.props,
                 parent_container_id=message.container_uuid,
+                is_button=True,
             ),
             _image=image,
             _jpeg_quality=jpeg_quality,

--- a/src/viser/_gui_handles.py
+++ b/src/viser/_gui_handles.py
@@ -64,7 +64,7 @@ if TYPE_CHECKING:
 
 
 T = TypeVar("T")
-TGuiHandle = TypeVar("TGuiHandle", bound="_GuiInputHandle")
+TGuiHandle = TypeVar("TGuiHandle", bound="_GuiHandle")
 NoneOrCoroutine = TypeVar("NoneOrCoroutine", None, Coroutine)
 
 
@@ -165,8 +165,7 @@ class _GuiHandle(
         ]
         parent._children[self._impl.uuid] = self
 
-        if isinstance(self, _GuiInputHandle):
-            self._impl.gui_api._gui_input_handle_from_uuid[self._impl.uuid] = self
+        self._impl.gui_api._gui_handle_from_uuid[self._impl.uuid] = self
 
     def remove(self) -> None:
         """Permanently remove this GUI element from the visualizer."""
@@ -191,8 +190,7 @@ class _GuiHandle(
         parent = gui_api._container_handle_from_uuid[self._impl.parent_container_id]
         parent._children.pop(self._impl.uuid)
 
-        if isinstance(self, _GuiInputHandle):
-            gui_api._gui_input_handle_from_uuid.pop(self._impl.uuid)
+        gui_api._gui_handle_from_uuid.pop(self._impl.uuid)
 
 
 class _GuiInputHandle(
@@ -818,7 +816,7 @@ class GuiPlotlyHandle(_GuiHandle[None], GuiPlotlyProps):
         self._plotly_json_str = json_str
 
 
-class GuiImageHandle(_GuiHandle[None], GuiImageProps):
+class GuiImageHandle(_GuiHandle[Tuple[float, float]], GuiImageProps):
     """Handle for updating and removing images."""
 
     def __init__(
@@ -830,6 +828,36 @@ class GuiImageHandle(_GuiHandle[None], GuiImageProps):
         super().__init__(_impl=_impl)
         self._image = _image
         self._jpeg_quality = _jpeg_quality
+
+    @property
+    def clicked_xy(self) -> Tuple[float, float]:
+        """Last-clicked XY coordinate of the image. Normalized [0, 1]."""
+        return self._impl.value
+
+    def on_click(
+        self, func: Callable[[GuiEvent[TGuiHandle]], NoneOrCoroutine]
+    ) -> Callable[[GuiEvent[TGuiHandle]], NoneOrCoroutine]:
+        """Attach a function to call when an image is clicked."""
+        self._impl.update_cb.append(func)
+        self._clickable = True
+        return func
+
+    def remove_click_callback(
+        self, callback: Literal["all"] | Callable = "all"
+    ) -> None:
+        """Remove click callbacks from the GUI input.
+
+        Args:
+            callback: Either "all" to remove all callbacks, or a specific callback function to remove.
+        """
+        if callback == "all":
+            self._impl.update_cb.clear()
+        else:
+            self._impl.update_cb = [cb for cb in self._impl.update_cb if cb != callback]
+
+        # Set clickable to False if not more callbacks.
+        if len(self._impl.update_cb) == 0:
+            self._clickable = False
 
     @property
     def image(self) -> np.ndarray:

--- a/src/viser/_gui_handles.py
+++ b/src/viser/_gui_handles.py
@@ -33,6 +33,7 @@ from ._icons_enum import IconName
 from ._messages import (
     GuiBaseProps,
     GuiButtonGroupProps,
+    GuiButtonProps,
     GuiCheckboxProps,
     GuiCloseModalMessage,
     GuiDropdownProps,
@@ -395,7 +396,7 @@ class GuiEvent(Generic[TGuiHandle]):
     """GUI element that was affected."""
 
 
-class GuiButtonHandle(_GuiInputHandle[bool]):
+class GuiButtonHandle(_GuiInputHandle[bool], GuiButtonProps):
     """Handle for a button input in our visualizer.
 
     .. attribute:: value

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -915,6 +915,8 @@ class GuiImageProps:
     """Format of the provided image ('image/jpeg' or 'image/png'). Synchronized automatically when assigned."""
     visible: bool
     """Visibility state of the image. Synchronized automatically when assigned."""
+    _clickable: bool
+    """(Private) Whether the image is clickable. Synchronized automatically when assigned."""
 
 
 @dataclasses.dataclass

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -414,6 +414,7 @@ export interface GuiImageMessage {
     _data: Uint8Array | null;
     media_type: "image/jpeg" | "image/png";
     visible: boolean;
+    _clickable: boolean;
   };
 }
 /** GuiTabGroupMessage(uuid: 'str', container_uuid: 'str', props: 'GuiTabGroupProps')
@@ -522,7 +523,7 @@ export interface GuiSliderMessage {
     _marks: { value: number; label: string | null }[] | null;
   };
 }
-/** GuiMultiSliderMessage(uuid: 'str', value: 'tuple[float, ...]', container_uuid: 'str', props: 'GuiMultiSliderProps')
+/** GuiMultiSliderMessage(uuid: 'str', value: 'Tuple[float, ...]', container_uuid: 'str', props: 'GuiMultiSliderProps')
  *
  * (automatically generated)
  */

--- a/src/viser/client/src/components/Image.tsx
+++ b/src/viser/client/src/components/Image.tsx
@@ -1,11 +1,14 @@
+import React from "react";
 import { useEffect, useState } from "react";
 import { GuiImageMessage } from "../WebsocketMessages";
 import { Box, Text } from "@mantine/core";
+import { ViewerContext } from "../ViewerContext";
 
-function ImageComponent({ props }: GuiImageMessage) {
+function ImageComponent({ uuid, props }: GuiImageMessage) {
   if (!props.visible) return <></>;
 
   const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const viewer = React.useContext(ViewerContext)!;
 
   useEffect(() => {
     if (props._data === null) {
@@ -28,11 +31,24 @@ function ImageComponent({ props }: GuiImageMessage) {
           {props.label}
         </Text>
       )}
+
       <img
         src={imageUrl}
         style={{
           maxWidth: "100%",
           height: "auto",
+          cursor: props._clickable === false ? "default" : "pointer",
+        }}
+        onClick={(e) => {
+          if (props._clickable === false) return;
+          const rect = e.currentTarget.getBoundingClientRect();
+          const x = (e.clientX - rect.left) / rect.width;
+          const y = (e.clientY - rect.top) / rect.height;
+          viewer.sendMessageRef.current({
+            type: "GuiUpdateMessage",
+            uuid: uuid,
+            updates: { value: [x, y] },
+          });
         }}
       />
     </Box>


### PR DESCRIPTION

https://github.com/user-attachments/assets/43f99662-f237-4692-83ed-687994d8bd4e

```python
import numpy as np
import viser

server = viser.ViserServer()

# Create an empty image + add it to the GUI.
image = np.zeros((150, 300, 3), dtype=np.uint8)
image_handle = server.gui.add_image(image)
remove_button = server.gui.add_button("Remove click callback forever")

# Draw red squares at clicked locations.
@image_handle.on_click
def _(_):
    x, y = image_handle.clicked_xy
    assert 0 <= x <= 1.0
    assert 0 <= y <= 1.0

    # Scale click to image coordinates.
    h, w, _ = image.shape
    x = int(x * w)
    y = int(y * h)

    # Update the image.
    image[y - 5 : y + 5, x - 5 : x + 5] = (255, 0, 0)
    image_handle.image = image

# Remove callback when button is clicked.
@remove_button.on_click
def _(_) -> None:
    image_handle.remove_click_callback()
    remove_button.label = "Click callback removed!"
    remove_button.color = "green"

server.sleep_forever()
```
