### PR TITLE
Fix slow image encoding in `_encode_image_binary()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "numpy>=1.0.0",
     "msgspec>=0.18.6",
     "imageio>=2.0.0",
-    "opencv-python",
+    "opencv-python>=4.0.0.21",
     "scikit-image>=0.18.0",
     "scipy>=1.7.3",
     "tqdm>=4.0.0",

--- a/src/viser/client/src/App.tsx
+++ b/src/viser/client/src/App.tsx
@@ -734,7 +734,8 @@ function BackgroundImage() {
 
     float readDepth(sampler2D depthMap, vec2 coord) {
       vec4 rgbPacked = texture(depthMap, coord);
-      float depth = rgbPacked.r * 0.00255 + rgbPacked.g * 0.6528 + rgbPacked.b * 167.1168;
+      // Important: BGR format, because buffer was encoded using OpenCV.
+      float depth = rgbPacked.b * 0.00255 + rgbPacked.g * 0.6528 + rgbPacked.r * 167.1168;
       return depth;
     }
 


### PR DESCRIPTION
Hi, thanks for developing `viser`, it's amazing!

I'm using `viser` as part of a live viewer in a multi-threaded application of mine that's connected to multiple (ZED) cameras that are supposed to be grabbing frames at 100Hz. Specifically, I allocate one thread for polling each camera and storing the image stream in buffers (one per camera). Then, from a final thread, I read from the buffers and visualize the images live with `viser`.

I noticed when using the `GuiImageHandle`'s setter function to do this, I was getting jittery timings for the rate at which I read my cameras on their own threads! However, when commenting the setter out, the timings went back to nearly exactly 100Hz.

My `viser` code looks like this:
```python
# this starts the server in my visualizer class
def my_setup_function():
    self.server = ViserServer()
    with self.server.gui.add_folder("Cameras"):
        self.gui_image_handles = [
            self.server.gui.add_image(
                np.zeros((*self.cams.img_size, 3), dtype=np.uint8),
                label=f"Image {i}",
                format="jpeg",
            )
            for i in range(len(self.serial_numbers))
        ]

# this is a callback running at ~10Hz w/most recent frame
def my_threaded_callback_function():
    for i, data in enumerate(camera_data.values()):
        if "rgb" in data and data["rgb"]:
            frame = data["rgb"][-1]
            self.gui_image_handles[i].image = frame  # this makes my cam reads jittery!
```

Using the setter:
```
99.67392670847006
100.08811757315004
76.4519622891055
99.34604472751255
146.24520551948856
100.78841738285192
100.65435394435737
93.79557291877579
91.06933153729824
109.0153634295049
109.61287363069823
95.51790813130594
96.87533452042892
105.54559791749915
103.4160920640681
97.29044174049082
```
Commenting it out:
```
101.50417000052565
101.23093783812001
99.16629900599206
99.94371169473465
101.13010874266612
98.58878047125367
98.77904166015273
100.6314928121725
98.52646770934624
100.12594843047793
100.81659424949136
100.64619892660343
100.319165418596
100.04875375404501
100.08005402838535
100.35992077706504
```

Looking at the setter source code, I've narrowed down the bottleneck to the `imageio.imwrite()` calls. By instead encoding the images using `cv2`, I've managed to pretty much eliminate the jittery timing (this holds for both JPEG and PNG):
```
99.49102381686278
99.56813318909543
99.83064729912472
99.6385015446378
100.24151187558287
100.49181699410214
100.28481891437688
101.07273547935216
100.01368187034457
98.26815157269847
100.00195003795828
100.36163307498154
99.904870586586
99.96409290262044
100.74862271361273
```

My best guess for this performance gap is that a lot of the calls under the hood in `imageio` don't release the GIL, which locks up my application. The major downside of this PR is that it adds `opencv` as an extra dependency - if there are other lightweight alternatives here, I would be glad to try them out!

As an aside, `SceneApi.set_background_image()` also has an `iio.imwrite` call that could potentially also be replaced by a `cv2.imencode` call as well.