### PR TITLE
Remove opencv-python from strict dependencies, add imageio fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "numpy>=1.0.0,<3.0.0",
     "msgspec>=0.18.6,<1.0.0",
     "imageio>=2.0.0,<3.0.0",
-    "opencv-python>=4.0.0.21,<5.0.0",
     "scikit-image>=0.18.0,<1.0.0",
     "scipy>=1.7.3,<2.0.0",
     "tqdm>=4.0.0,<5.0.0",
@@ -59,6 +58,7 @@ dev = [
     "pre-commit==3.3.2",
     "pytest",
     "hypothesis[numpy]",
+    "opencv-python>=4.0.0.21,<5.0.0",
 ]
 examples = [
     "torch>=1.13.1",

--- a/src/viser/_image_encoding.py
+++ b/src/viser/_image_encoding.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import numpy as np
+from typing_extensions import assert_never
+
+
+def cv2_imencode_with_fallback(
+    format: Literal["png", "jpeg"],
+    image: np.ndarray,
+    jpeg_quality: int | None,
+    channel_ordering: Literal["rgb", "bgr"],
+) -> bytes:
+    """Helper for encoding images to bytes using OpenCV or imageio.
+
+    We default to OpenCV if available, which we find is usually faster:
+        https://github.com/nerfstudio-project/viser/pull/494
+
+    We fall back to imageio if OpenCV is not available. This lets us avoid
+    adding OpenCV as a strict dependency, since it can be annoying to install
+    on some machines:
+        https://github.com/nerfstudio-project/viser/issues/535
+    """
+    if jpeg_quality is None:
+        jpeg_quality = 75  # Default JPEG quality if not specified.
+
+    try:
+        import cv2
+    except ImportError:
+        # Fall back to imageio if cv2 is not available.
+        import imageio.v3 as iio
+
+        if channel_ordering == "bgr":
+            image = image[:, :, ::-1]  # Convert to BGR if needed.
+        return (
+            iio.imwrite("<bytes>", image, extension=".jpeg", quality=jpeg_quality)
+            if format == "jpeg"
+            else iio.imwrite("<bytes>", image, extension=".png")
+        )
+
+    # OpenCV is available!
+    if channel_ordering == "rgb":
+        image = image[:, :, ::-1]  # Convert from BGR to RGB.
+    if format == "png":
+        success, encoded_image = cv2.imencode(".png", image)
+    elif format == "jpeg":
+        if jpeg_quality is not None:
+            success, encoded_image = cv2.imencode(
+                ".jpeg", image, [int(cv2.IMWRITE_JPEG_QUALITY), jpeg_quality]
+            )
+        else:
+            success, encoded_image = cv2.imencode(format, image)
+    else:
+        assert_never(format)
+
+    if not success:
+        raise RuntimeError("Failed to encode image.")
+
+    return encoded_image.tobytes()

--- a/sync_client_server.py
+++ b/sync_client_server.py
@@ -19,26 +19,25 @@ from viser._messages import Message
 
 
 def main(sync_messages: bool = True, sync_version: bool = True) -> None:
+    messages_path = pathlib.Path(__file__).parent / pathlib.Path(
+        "src/viser/client/src/WebsocketMessages.ts"
+    )
+    version_path = pathlib.Path(__file__).parent / pathlib.Path(
+        "src/viser/client/src/VersionInfo.ts"
+    )
+
     if sync_messages:
         # Generate TypeScript message interfaces
         defs = viser.infra.generate_typescript_interfaces(Message)
 
-        # Write message interfaces to file
-        target_path = pathlib.Path(__file__).parent / pathlib.Path(
-            "src/viser/client/src/WebsocketMessages.ts"
-        )
         # Create directory if it doesn't exist
-        target_path.parent.mkdir(parents=True, exist_ok=True)
+        messages_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Write to file even if it doesn't exist yet
-        target_path.write_text(defs)
-        print(f"{target_path} updated")
+        messages_path.write_text(defs)
+        print(f"{messages_path} updated")
 
     if sync_version:
-        # Generate version and contributors information file
-        version_path = pathlib.Path(__file__).parent / pathlib.Path(
-            "src/viser/client/src/VersionInfo.ts"
-        )
         # Create directory if it doesn't exist
         version_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -46,9 +45,7 @@ def main(sync_messages: bool = True, sync_version: bool = True) -> None:
         contributors_data = []
         try:
             # GitHub API endpoint for contributors
-            api_url = (
-                "https://api.github.com/repos/nerfstudio-project/viser/contributors?per_page=500"
-            )
+            api_url = "https://api.github.com/repos/nerfstudio-project/viser/contributors?per_page=500"
             req = urllib.request.Request(
                 api_url,
                 headers={
@@ -94,14 +91,14 @@ def main(sync_messages: bool = True, sync_version: bool = True) -> None:
             version_path.write_text(version_content)
             print(f"Version and contributors info generated: {version_path}")
 
-        # Run prettier on all generated files if it's available
-        try:
-            subprocess.run(
-                args=["npx", "prettier", "-w", str(target_path), str(version_path)],
-                check=False,
-            )
-        except FileNotFoundError:
-            print("Warning: npx/prettier not found, skipping formatting")
+    # Run prettier on all generated files if it's available
+    try:
+        subprocess.run(
+            args=["npx", "prettier", "-w", str(messages_path), str(version_path)],
+            check=False,
+        )
+    except FileNotFoundError:
+        print("Warning: npx/prettier not found, skipping formatting")
 
     print("Synchronization complete")
 

--- a/tests/test_image_encode.py
+++ b/tests/test_image_encode.py
@@ -1,0 +1,54 @@
+import sys
+
+import imageio.v3 as iio
+import numpy as np
+
+from viser._image_encoding import cv2_imencode_with_fallback
+
+
+def test_image_encode_png(monkeypatch) -> None:
+    image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+    bytes_cv2 = cv2_imencode_with_fallback(
+        "png", image, jpeg_quality=None, channel_ordering="rgb"
+    )
+    monkeypatch.setitem(sys.modules, "cv2", None)
+    bytes_no_cv2 = cv2_imencode_with_fallback(
+        "png", image, jpeg_quality=None, channel_ordering="rgb"
+    )
+    assert bytes_cv2 != bytes_no_cv2, (
+        "Expected different byte outputs for PNG encoding with and without cv2."
+    )
+    np.testing.assert_array_equal(
+        iio.imread(bytes_cv2, extension=".png"),
+        iio.imread(bytes_no_cv2, extension=".png"),
+    )
+
+
+def test_image_encode_jpeg_quality_75(monkeypatch) -> None:
+    image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+    bytes_cv2 = cv2_imencode_with_fallback(
+        "jpeg", image, jpeg_quality=75, channel_ordering="rgb"
+    )
+    monkeypatch.setitem(sys.modules, "cv2", None)
+    bytes_no_cv2 = cv2_imencode_with_fallback(
+        "jpeg", image, jpeg_quality=75, channel_ordering="rgb"
+    )
+    np.testing.assert_array_equal(
+        iio.imread(bytes_cv2, extension=".jpeg"),
+        iio.imread(bytes_no_cv2, extension=".jpeg"),
+    )
+
+
+def test_image_encode_jpeg_no_quality(monkeypatch) -> None:
+    image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+    bytes_cv2 = cv2_imencode_with_fallback(
+        "jpeg", image, jpeg_quality=None, channel_ordering="rgb"
+    )
+    monkeypatch.setitem(sys.modules, "cv2", None)
+    bytes_no_cv2 = cv2_imencode_with_fallback(
+        "jpeg", image, jpeg_quality=None, channel_ordering="rgb"
+    )
+    np.testing.assert_array_equal(
+        iio.imread(bytes_cv2, extension=".jpeg"),
+        iio.imread(bytes_no_cv2, extension=".jpeg"),
+    )


### PR DESCRIPTION
OpenCV is a pretty heavy dependency and very rarely needed, so I think it makes sense to remove.

The new behavior is:
- Use `cv2.imencode` when available. This should retain the performance benefits documented in #494.
- Otherwise, fall back to `imageio.v3`'s `imwrite`.

I'll add a note in the docs that `opencv-python` can be installed manually if image encoding is a bottleneck.  cc @alberthli

Addresses #535