### PR TITLE
Fix URDF string path support and Windows npx issue

### DIFF
--- a/src/viser/_client_autobuild.py
+++ b/src/viser/_client_autobuild.py
@@ -84,7 +84,7 @@ def _build_viser_client(out_dir: Path, cached: bool = True) -> None:
         return
 
     node_bin_dir = _install_sandboxed_node()
-    npx_path = node_bin_dir / "npx"
+    npx_path = node_bin_dir / ("npx.cmd" if sys.platform == "win32" else "npx")
 
     subprocess_env = os.environ.copy()
     subprocess_env["NODE_VIRTUAL_ENV"] = str(node_bin_dir.parent)
@@ -145,7 +145,8 @@ def _install_sandboxed_node() -> Path:
         return node_bin_dir
 
     node_bin_dir = get_node_bin_dir()
-    if (node_bin_dir / "npx").exists():
+    npx_name = "npx.cmd" if sys.platform == "win32" else "npx"
+    if (node_bin_dir / npx_name).exists():
         rich.print("[bold](viser)[/bold] nodejs is set up!")
         return node_bin_dir
 
@@ -155,7 +156,7 @@ def _install_sandboxed_node() -> Path:
     )
 
     node_bin_dir = get_node_bin_dir()
-    assert (node_bin_dir / "npx").exists()
+    assert (node_bin_dir / npx_name).exists()
     return node_bin_dir
 
 

--- a/src/viser/extras/_urdf.py
+++ b/src/viser/extras/_urdf.py
@@ -62,7 +62,7 @@ class ViserUrdf:
 
     Args:
         target: ViserServer or ClientHandle object to add URDF to.
-        urdf_or_path: Either a path to a URDF file or a yourdfpy URDF object.
+        urdf_or_path: Either a path to a URDF file (str or Path) or a yourdfpy URDF object.
         scale: Scale factor to apply to resize the URDF.
         root_node_name: Viser scene tree name for the root of the URDF geometry.
         mesh_color_override: Optional color to override the URDF's visual mesh colors. RGB or RGBA tuple.
@@ -78,7 +78,7 @@ class ViserUrdf:
     def __init__(
         self,
         target: viser.ViserServer | viser.ClientHandle,
-        urdf_or_path: yourdfpy.URDF | Path,
+        urdf_or_path: yourdfpy.URDF | Path | str,
         scale: float = 1.0,
         root_node_name: str = "/",
         mesh_color_override: tuple[float, float, float]
@@ -93,16 +93,18 @@ class ViserUrdf:
         assert root_node_name.startswith("/")
         assert len(root_node_name) == 1 or not root_node_name.endswith("/")
 
-        if isinstance(urdf_or_path, Path):
+        if isinstance(urdf_or_path, (Path, str)):
+            # Convert string path to Path object for consistent handling
+            path_obj = Path(urdf_or_path) if isinstance(urdf_or_path, str) else urdf_or_path
             urdf = yourdfpy.URDF.load(
-                urdf_or_path,
+                path_obj,
                 build_scene_graph=load_meshes,
                 build_collision_scene_graph=load_collision_meshes,
                 load_meshes=load_meshes,
                 load_collision_meshes=load_collision_meshes,
                 filename_handler=partial(
                     yourdfpy.filename_handler_magic,
-                    dir=urdf_or_path.parent,
+                    dir=path_obj.parent,
                 ),
             )
         else:


### PR DESCRIPTION
- Add support for string paths in ViserUrdf constructor
- Fix Windows compatibility by using npx.cmd instead of npx
- Update type hints and documentation for string path support