### PR TITLE
Fix frustum culling artifacts in instanced meshes

### DIFF
--- a/src/viser/client/src/mesh/BatchedMeshBase.tsx
+++ b/src/viser/client/src/mesh/BatchedMeshBase.tsx
@@ -152,6 +152,10 @@ export const BatchedMeshBase = React.forwardRef<
       capacity: instanceCount,
       renderer: gl,
     });
+
+    // Disable global frustum culling. Leaving this on would require calling
+    // `computeBoundingSphere()` on the full mesh whenever instances move. Note
+    // that we still benefit from per-instance culling in IM2!
     newMesh.frustumCulled = false;
 
     // Create LODs if needed.


### PR DESCRIPTION
Instanced meshes have global frustum culling enabled by default, which can cause artifacts if we don't call `computeBoundingSphere()` after instance poses are updated:

https://github.com/user-attachments/assets/cc7f9858-7533-4578-8dc4-835c6d6462da

https://github.com/user-attachments/assets/000d60b9-31a3-4ef9-9613-c5908429dccf

Thanks @agargaro again for the discussion 🙏 