### PR TITLE
Fix uPlot autoscale when `xMin == xMax`

### DIFF
--- a/src/viser/client/src/components/UplotComponent.tsx
+++ b/src/viser/client/src/components/UplotComponent.tsx
@@ -155,6 +155,10 @@ function PlotComponent({
       return;
     }
     const span = xMax - xMin;
+    if (span === 0) {
+      // Avoid degenerate spans.
+      return;
+    }
     plotObj.setScale(xScaleKey, {
       min: xMin + xScaleState.current.relMin * span,
       max: xMin + xScaleState.current.relMax * span,


### PR DESCRIPTION
Cases like `x = np.empty(1)`, `x = np.zeros(2)` were putting uPlot plots into an invalid state. 

Addresses #611!