### PR TITLE
Increase websocket message size limit to 50MB

### DIFF
--- a/src/viser/infra/_infra.py
+++ b/src/viser/infra/_infra.py
@@ -568,6 +568,9 @@ class WebsockServer(WebsockMessageHandler):
                         ws_handler,
                         host,
                         port_attempt,
+                        # Increase ws message size limit to 50MB to allow for large messages 
+                        # (e.g. via client.get_render()).
+                        max_size=50 * 1024 * 1024,
                         # Compression can be too slow for our use cases.
                         compression=None,
                         process_request=(


### PR DESCRIPTION
Hi @brentyi thank you for this great package! 

When I am using viser to do screen capture (via `client.get_render()`) with a large resolution in PNG format, I find out that it is pretty easy for the websocket server to disconnect. After some investigtations I find out that by default `websocket` server from python enforces a 1MB limit which is usually not enough to get a high resolution PNG screen capture. Hence this PR tries to bump  this limit further.