### PR TITLE
Fixed autobuild failure on Windows.

### DIFF
--- a/src/viser/_client_autobuild.py
+++ b/src/viser/_client_autobuild.py
@@ -115,6 +115,11 @@ def _build_viser_client(out_dir: Path, cached: bool = True) -> None:
         + subprocess_env["PATH"]
     )
     npm_path = node_bin_dir / "npm"
+
+    if sys.platform == "win32":
+        npx_path = npx_path.with_suffix(".cmd")
+        npm_path = npm_path.with_suffix(".cmd")
+
     subprocess.run(
         args=[str(npm_path), "install"],
         env=subprocess_env,


### PR DESCRIPTION
Failed to build on Windows, error reported:

```
(viser) Client build looks out of date. Building now...
(viser) nodejs is set up!
Traceback (most recent call last):
  File "C:\Users\heyu\PycharmProjects\motion-tracking\main.py", line 22, in <module>
    main()
  File "C:\Users\heyu\PycharmProjects\motion-tracking\main.py", line 6, in main
    server = viser.ViserServer()
             ^^^^^^^^^^^^^^^^^^^
  File "C:\Users\heyu\PycharmProjects\motion-tracking\.venv\Lib\site-packages\viser\_viser.py", line 640, in __init__
    _client_autobuild.ensure_client_is_built()
  File "C:\Users\heyu\PycharmProjects\motion-tracking\.venv\Lib\site-packages\viser\_client_autobuild.py", line 86, in ensure_client_is_built
    _build_viser_client(out_dir=build_dir, cached=False)
  File "C:\Users\heyu\PycharmProjects\motion-tracking\.venv\Lib\site-packages\viser\_client_autobuild.py", line 118, in _build_viser_client
    subprocess.run(
  File "C:\Users\heyu\AppData\Roaming\uv\python\cpython-3.12.12-windows-x86_64-none\Lib\subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\heyu\AppData\Roaming\uv\python\cpython-3.12.12-windows-x86_64-none\Lib\subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "C:\Users\heyu\AppData\Roaming\uv\python\cpython-3.12.12-windows-x86_64-none\Lib\subprocess.py", line 1538, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: [WinError 193] %1 is not a valid Win32 application
```

The build program should call the cmd script located in the same directory on Windows.

<img width="218" height="220" alt="image" src="https://github.com/user-attachments/assets/b44c5e8e-2ea8-478b-a126-22b06559dbd8" />

I modified the `_build_viser_client` function to replace the file extension with `.cmd` on Windows. It now works.

```python
    if sys.platform == "win32":
        npx_path = npx_path.with_suffix(".cmd")
        npm_path = npm_path.with_suffix(".cmd")
```