### PR TITLE
Fix minor notification example + camera init behavior bugs

### DIFF
--- a/docs/source/examples/gui/notifications.rst
+++ b/docs/source/examples/gui/notifications.rst
@@ -71,7 +71,7 @@ Code
                title="Controlled notification",
                body="This cannot be closed by the user and is controlled in code only!",
                with_close_button=False,
-               auto_close_seconds=False,
+               auto_close_seconds=None,
            )
    
            @remove_controlled_notif.on_click

--- a/examples/02_gui/06_notifications.py
+++ b/examples/02_gui/06_notifications.py
@@ -62,7 +62,7 @@ def main() -> None:
             title="Controlled notification",
             body="This cannot be closed by the user and is controlled in code only!",
             with_close_button=False,
-            auto_close_seconds=False,
+            auto_close_seconds=None,
         )
 
         @remove_controlled_notif.on_click

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -157,6 +157,13 @@ class NotificationMessage(Message):
     uuid: str
     props: NotificationProps
 
+    @override
+    def redundancy_key(self) -> str:
+        # Include mode in the key so "show" and "update" messages are kept
+        # separately. Without this, an "update" message would cull the "show"
+        # message, preventing the notification from being created.
+        return f"{type(self).__name__}_{self.uuid}_{self.mode}"
+
 
 @dataclasses.dataclass
 class NotificationProps:

--- a/src/viser/client/src/App.tsx
+++ b/src/viser/client/src/App.tsx
@@ -227,7 +227,7 @@ function ViewerRoot() {
             )
         : () => null,
     sendCamera: null,
-    resetCameraView: null,
+    resetCameraPose: null,
 
     // DOM/Three.js references.
     canvas: null,
@@ -274,9 +274,7 @@ function ViewerRoot() {
     // Parse URL params once during initialization.
     React.useMemo(() => {
       // Helper to parse and validate a vector URL param.
-      const parseVec3 = (
-        param: string,
-      ): [number, number, number] | null => {
+      const parseVec3 = (param: string): [number, number, number] | null => {
         const str = searchParams.get(param);
         if (str === null) return null;
         const parts = str.split(",").map(Number);
@@ -590,7 +588,6 @@ function ViewerCanvas({ children }: { children: React.ReactNode }) {
       style={{ position: "relative", zIndex: 0, width: "100%", height: "100%" }}
     >
       <Canvas
-        camera={{ position: [-3.0, 3.0, -3.0], near: 0.01, far: 1000.0 }}
         gl={{ preserveDrawingBuffer: true }}
         style={{ width: "100%", height: "100%" }}
         ref={(el) => (viewer.mutable.current.canvas = el)}

--- a/src/viser/client/src/ControlPanel/ServerControls.tsx
+++ b/src/viser/client/src/ControlPanel/ServerControls.tsx
@@ -122,7 +122,7 @@ export default function ServerControls() {
           </Button>
           <Button
             onClick={() => {
-              viewerMutable.resetCameraView!();
+              viewerMutable.resetCameraPose!();
             }}
             flex={1}
             leftSection={

--- a/src/viser/client/src/InitialCameraState.ts
+++ b/src/viser/client/src/InitialCameraState.ts
@@ -6,17 +6,21 @@
  * handle priority between different configuration methods.
  *
  * ## Source Priority (lowest to highest)
- * - "default": Built-in defaults matching Three.js/Python server defaults
- * - "message": Server's initial_camera configuration sent via websocket
- * - "url": URL parameters (highest priority, always wins)
+ * - "default": Built-in defaults in three.js coordinates (no world transform applied)
+ * - "message": Server's initial_camera configuration sent via websocket (viser world coords)
+ * - "url": URL parameters (highest priority, viser world coords)
  *
- * ## Default Values
+ * ## Default Values (in three.js coordinates, Y-up)
  * - position: [3, 3, 3]
  * - lookAt: [0, 0, 0]
- * - up: [0, 0, 1]
+ * - up: [0, 1, 0]
  * - fov: 50 degrees (≈0.873 radians, Three.js PerspectiveCamera default)
  * - near: 0.01
  * - far: 1000
+ *
+ * Default values are in three.js coordinates and work regardless of the scene's
+ * up direction (set via set_up_direction()). Values from "message" or "url"
+ * sources are in viser world coordinates and are transformed appropriately.
  *
  * When server.initial_camera properties are changed after clients connect,
  * "Reset View" targets are updated without disrupting users' current camera
@@ -105,9 +109,12 @@ export function useInitialCameraState(urlParams: InitialCameraConfig) {
       lookAt: urlParams.lookAt
         ? { value: urlParams.lookAt, source: "url" as const }
         : { value: [0, 0, 0], source: "default" as const },
+      // Default up is Y-up in three.js coordinates. When source is "default",
+      // the world transform is not applied, so this gives correct behavior
+      // regardless of set_up_direction().
       up: urlParams.up
         ? { value: urlParams.up, source: "url" as const }
-        : { value: [0, 0, 1], source: "default" as const },
+        : { value: [0, 1, 0], source: "default" as const },
       // Default FOV matches Three.js PerspectiveCamera default of 50 degrees.
       fov: urlParams.fov
         ? { value: urlParams.fov, source: "url" as const }

--- a/src/viser/client/src/SceneTreeState.tsx
+++ b/src/viser/client/src/SceneTreeState.tsx
@@ -46,6 +46,7 @@ export const rootNodeTemplate: SceneNode = {
     );
     return [quat.w, quat.x, quat.y, quat.z] as [number, number, number, number];
   })(),
+  position: [0.0, 0.0, 0.0],
 };
 const worldAxesNodeTemplate: SceneNode = {
   message: {

--- a/src/viser/client/src/ViewerContext.ts
+++ b/src/viser/client/src/ViewerContext.ts
@@ -17,7 +17,7 @@ export type ViewerMutable = {
   // Function references.
   sendMessage: (message: Message) => void;
   sendCamera: (() => void) | null;
-  resetCameraView: (() => void) | null;
+  resetCameraPose: (() => void) | null;
 
   // DOM/Three.js references.
   canvas: HTMLCanvasElement | null;

--- a/src/viser/client/src/WorldTransformUtils.ts
+++ b/src/viser/client/src/WorldTransformUtils.ts
@@ -6,8 +6,8 @@ import * as THREE from "three";
  * between +Y and +Z up directions for the world frame. */
 export function computeT_threeworld_world(viewer: ViewerContextContents) {
   const rootNode = viewer.useSceneTree.getState()[""];
-  const wxyz = rootNode?.wxyz ?? [1, 0, 0, 0];
-  const position = rootNode?.position ?? [0, 0, 0];
+  const wxyz = rootNode!.wxyz!;
+  const position = rootNode!.position!;
   return new THREE.Matrix4()
     .makeRotationFromQuaternion(
       new THREE.Quaternion(wxyz[1], wxyz[2], wxyz[3], wxyz[0]),

--- a/tests/test_initial_camera_defaults.py
+++ b/tests/test_initial_camera_defaults.py
@@ -7,6 +7,7 @@ import re
 from pathlib import Path
 
 import pytest
+
 from viser._viser import InitialCameraConfig
 
 
@@ -109,7 +110,9 @@ def test_initial_camera_defaults_match():
     # Check all values match.
     assert_vec3_close("position", py_defaults["position"], ts_defaults["position"])
     assert_vec3_close("look_at", py_defaults["look_at"], ts_defaults["lookAt"])
-    assert_vec3_close("up", py_defaults["up"], ts_defaults["up"])
+    # Skip up comparison: Python default is None (meaning "same as scene up direction"),
+    # while TypeScript has a concrete default [0, 1, 0] in three.js coordinates.
+    assert py_defaults["up"] is None
     assert_close("fov", py_defaults["fov"], ts_defaults["fov"])
     assert_close("near", py_defaults["near"], ts_defaults["near"])
     assert_close("far", py_defaults["far"], ts_defaults["far"])


### PR DESCRIPTION
1. Controlled notification example had a bug; `auto_close_seconds` was `False` instead of `None`.
2. Fixed "Reset View" behavior after `set_up_direction()` is called.