### PR TITLE
Restore initial camera FOV, disable unintended animation

### DIFF
--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -63,8 +63,8 @@ class InitialCameraConfig:
         self._look_at: npt.NDArray[np.float64] = np.array([0.0, 0.0, 0.0])
         # None means "same as the scene up direction".
         self._up: npt.NDArray[np.float64] | None = None
-        # 50 degrees in radians; matches three.js PerspectiveCamera default.
-        self._fov: float = 50.0 * np.pi / 180.0
+        # 75 degrees in radians; matches three.js PerspectiveCamera default.
+        self._fov: float = 75.0 * np.pi / 180.0
         self._near: float = 0.01
         self._far: float = 1000.0
 

--- a/src/viser/client/src/CameraControls.tsx
+++ b/src/viser/client/src/CameraControls.tsx
@@ -292,7 +292,7 @@ export function SynchronizedCameraControls() {
     pivotRef.current.updateMatrixWorld(true);
   };
 
-  viewerMutable.resetCameraPose = () => {
+  viewerMutable.resetCameraPose = (animate: boolean) => {
     // Read initial camera state from the Zustand store.
     const initialCameraState = viewer.useInitialCamera.getState();
     const T_threeworld_world = computeT_threeworld_world(viewer);
@@ -314,15 +314,32 @@ export function SynchronizedCameraControls() {
 
     camera.up.set(initialUp.x, initialUp.y, initialUp.z);
     viewerMutable.cameraControl!.updateCameraUp();
-    viewerMutable.cameraControl!.setLookAt(
-      initialPos.x,
-      initialPos.y,
-      initialPos.z,
-      initialLookAt.x,
-      initialLookAt.y,
-      initialLookAt.z,
-      true,
-    );
+    if (animate) {
+      viewerMutable.cameraControl!.setLookAt(
+        initialPos.x,
+        initialPos.y,
+        initialPos.z,
+        initialLookAt.x,
+        initialLookAt.y,
+        initialLookAt.z,
+        true,
+      );
+    } else {
+      // Calling setLookAt with animate = false seems to break future calls to
+      // setLookAt. Possible dpeendency bug.
+      viewerMutable.cameraControl!.setPosition(
+        initialPos.x,
+        initialPos.y,
+        initialPos.z,
+        false,
+      );
+      viewerMutable.cameraControl!.setTarget(
+        initialLookAt.x,
+        initialLookAt.y,
+        initialLookAt.z,
+        false,
+      );
+    }
   };
 
   // Callback for sending cameras.
@@ -418,7 +435,7 @@ export function SynchronizedCameraControls() {
   React.useEffect(() => {
     if (!initialCameraPositionSet.current) {
       // Reset position, orientation, and up direction.
-      viewerMutable.resetCameraPose!();
+      viewerMutable.resetCameraPose!(false);
 
       // Read initial camera state from the Zustand store.
       // This contains defaults, URL params, or will be updated by server messages.

--- a/src/viser/client/src/ControlPanel/ServerControls.tsx
+++ b/src/viser/client/src/ControlPanel/ServerControls.tsx
@@ -122,7 +122,7 @@ export default function ServerControls() {
           </Button>
           <Button
             onClick={() => {
-              viewerMutable.resetCameraPose!();
+              viewerMutable.resetCameraPose!(true);
             }}
             flex={1}
             leftSection={

--- a/src/viser/client/src/InitialCameraState.ts
+++ b/src/viser/client/src/InitialCameraState.ts
@@ -14,7 +14,7 @@
  * - position: [3, 3, 3]
  * - lookAt: [0, 0, 0]
  * - up: [0, 1, 0]
- * - fov: 50 degrees (≈0.873 radians, Three.js PerspectiveCamera default)
+ * - fov: 75 degrees (≈1.309 radians, Three.js PerspectiveCamera default)
  * - near: 0.01
  * - far: 1000
  *
@@ -115,10 +115,10 @@ export function useInitialCameraState(urlParams: InitialCameraConfig) {
       up: urlParams.up
         ? { value: urlParams.up, source: "url" as const }
         : { value: [0, 1, 0], source: "default" as const },
-      // Default FOV matches Three.js PerspectiveCamera default of 50 degrees.
+      // Default FOV matches Three.js PerspectiveCamera default of 75 degrees.
       fov: urlParams.fov
         ? { value: urlParams.fov, source: "url" as const }
-        : { value: (50.0 * Math.PI) / 180.0, source: "default" as const },
+        : { value: (75.0 * Math.PI) / 180.0, source: "default" as const },
       near: urlParams.near
         ? { value: urlParams.near, source: "url" as const }
         : { value: 0.01, source: "default" as const },

--- a/src/viser/client/src/ViewerContext.ts
+++ b/src/viser/client/src/ViewerContext.ts
@@ -17,7 +17,7 @@ export type ViewerMutable = {
   // Function references.
   sendMessage: (message: Message) => void;
   sendCamera: (() => void) | null;
-  resetCameraPose: (() => void) | null;
+  resetCameraPose: ((animate: boolean) => void) | null;
 
   // DOM/Three.js references.
   canvas: HTMLCanvasElement | null;


### PR DESCRIPTION
The most recent release inadvertently:
- Changed the initial camera FOV from 75 deg (`react-three-fiber` default) to 50 deg (`three.js` default).
- Added an animation when applying the initial camera pose.

This PR restores the previous behavior.