### PR TITLE
Performance and visibility fixes for batched meshes, Gaussian splats

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 *.mjs
 build/
 csm/
+vendor/

--- a/docs/source/performance_tips.rst
+++ b/docs/source/performance_tips.rst
@@ -17,6 +17,7 @@ will start to sputter on most machines:
 
 .. code-block:: python
 
+    import numpy as np
     import viser
 
     server = viser.ViserServer()

--- a/src/viser/_gui_handles.py
+++ b/src/viser/_gui_handles.py
@@ -20,7 +20,6 @@ from typing import (
     overload,
 )
 
-import imageio.v3 as iio
 import numpy as np
 from typing_extensions import Protocol, override
 
@@ -193,15 +192,25 @@ class _GuiInputHandle(
             assert len(value.shape) <= 1, f"{value.shape} should be at most 1D!"
             value = tuple(map(float, value))  # type: ignore
 
+        # Convert to internal type early so we can compare.
+        value = type(self._impl.value)(value)  # type: ignore
+
+        # Skip if value hasn't changed (but always process buttons).
+        if not self._impl.is_button:
+            try:
+                if self._impl.value == value:
+                    return
+            except (TypeError, ValueError):
+                pass
+
         # Send to client, except for buttons.
         if not self._impl.is_button:
             self._impl.gui_api._websock_interface.queue_message(
                 GuiUpdateMessage(self._impl.uuid, {"value": value})
             )
 
-        # Set internal state. We automatically convert numpy arrays to the expected
-        # internal type. (eg 1D arrays to tuples)
-        self._impl.value = type(self._impl.value)(value)  # type: ignore
+        # Set internal state.
+        self._impl.value = value  # type: ignore
         self._impl.update_timestamp = time.time()
 
         # Call update callbacks.
@@ -848,6 +857,8 @@ def _get_data_url(url: str, image_root: Path | None) -> str:
     if image_root is None:
         image_root = Path(__file__).parent
     try:
+        import imageio.v3 as iio
+
         image = iio.imread(image_root / url)
         _, binary = _encode_image_binary(image, "png")
         url = base64.b64encode(binary).decode("utf-8")

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -13,7 +13,6 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, ContextManager, TypeVar, cast, overload
 
-import imageio.v3 as iio
 import numpy as np
 import numpy.typing as npt
 from typing_extensions import Literal, deprecated
@@ -666,6 +665,8 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 _messages.GetRenderResponseMessage, got_render_cb
             )
             nonlocal out
+            import imageio.v3 as iio
+
             out = iio.imread(
                 io.BytesIO(message.payload),
                 extension=f".{transport_format}",

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -564,7 +564,10 @@ function createObjectFactory(
         makeObject: (ref, children) => (
           <group ref={ref}>
             <group scale={normalizeScale(message.props.scale)}>
-              <SplatObject buffer={message.props.buffer} />
+              <SplatObject
+                buffer={message.props.buffer}
+                sceneNodeName={message.name}
+              />
             </group>
             {children}
           </group>

--- a/src/viser/client/src/Splatting/GaussianSplats.tsx
+++ b/src/viser/client/src/Splatting/GaussianSplats.tsx
@@ -44,6 +44,7 @@ import {
   useGaussianSplatStore,
   type GaussianMeshProps,
 } from "./GaussianSplatsHelpers";
+import { ViewerContext } from "../ViewerContext";
 
 /**Provider for creating splat rendering context.*/
 export function SplatRenderContext({
@@ -69,13 +70,17 @@ export const SplatObject = React.forwardRef<
   THREE.Group,
   {
     buffer: Uint32Array;
+    sceneNodeName?: string;
     children?: React.ReactNode;
   }
->(function SplatObject({ buffer, children }, ref) {
+>(function SplatObject({ buffer, sceneNodeName, children }, ref) {
   const splatContext = React.useContext(GaussianSplatsContext)!;
   const { setBuffer, removeBuffer } = splatContext.gaussianSplatState.actions;
   const nodeRefFromId = splatContext.gaussianSplatState.store(
     (state) => state.nodeRefFromId,
+  );
+  const sceneNodeNameFromId = splatContext.gaussianSplatState.store(
+    (state) => state.sceneNodeNameFromId,
   );
   // Use stable ID per component instance (not dependent on buffer).
   const name = React.useMemo(() => uuidv4(), []);
@@ -85,8 +90,9 @@ export const SplatObject = React.forwardRef<
     return () => {
       removeBuffer(name);
       delete nodeRefFromId.current[name];
+      delete sceneNodeNameFromId.current[name];
     };
-  }, [name, removeBuffer, nodeRefFromId]);
+  }, [name, removeBuffer, nodeRefFromId, sceneNodeNameFromId]);
 
   // Update buffer when it changes.
   React.useEffect(() => {
@@ -107,6 +113,9 @@ export const SplatObject = React.forwardRef<
           }
         }
         nodeRefFromId.current[name] = obj;
+        if (sceneNodeName !== undefined) {
+          sceneNodeNameFromId.current[name] = sceneNodeName;
+        }
       }}
     >
       {children}
@@ -130,11 +139,15 @@ function SplatRenderer() {
 
 function SplatRendererImpl() {
   const splatContext = React.useContext(GaussianSplatsContext)!;
+  const viewer = React.useContext(ViewerContext)!;
   const groupBufferFromId = splatContext.gaussianSplatState.store(
     (state) => state.groupBufferFromId,
   );
   const nodeRefFromId = splatContext.gaussianSplatState.store(
     (state) => state.nodeRefFromId,
+  );
+  const sceneNodeNameFromId = splatContext.gaussianSplatState.store(
+    (state) => state.sceneNodeNameFromId,
   );
   const maxTextureSize = useThree((state) => state.gl).capabilities
     .maxTextureSize;
@@ -155,7 +168,12 @@ function SplatRendererImpl() {
   const [, forceUpdate] = React.useReducer((x) => x + 1, 0);
 
   // Consolidate Gaussian groups into a single buffer.
-  const merged = mergeGaussianGroups(groupBufferFromId);
+  // Memoized on groupBufferFromId reference -- zustand returns the same
+  // reference when state hasn't changed, so this avoids re-merging every render.
+  const merged = React.useMemo(
+    () => mergeGaussianGroups(groupBufferFromId),
+    [groupBufferFromId],
+  );
 
   // Helper function to post messages to worker.
   const postToWorker = React.useCallback((message: SorterWorkerIncoming) => {
@@ -164,12 +182,10 @@ function SplatRendererImpl() {
     }
   }, []);
 
-  // Check if buffer content has changed.
+  // Check if buffer content has changed (reference equality, since merged is memoized).
   const bufferChanged =
     !prevMergedRef.current ||
-    merged.gaussianBuffer.length !==
-      prevMergedRef.current.gaussianBuffer.length ||
-    !arraysEqual(merged.gaussianBuffer, prevMergedRef.current.gaussianBuffer);
+    merged.gaussianBuffer !== prevMergedRef.current.gaussianBuffer;
 
   // Check if number of Gaussians or groups changed (requires texture resize).
   const sizeChanged =
@@ -186,6 +202,20 @@ function SplatRendererImpl() {
       maxTextureSize,
     );
 
+    // Show splats immediately with identity sort order. This makes splats
+    // visible before the WASM sorter finishes compiling + first sort, at the
+    // cost of incorrect back-to-front ordering until the sort completes.
+    const numGaussians = meshPropsRef.current.numGaussians;
+    const identityIndices = meshPropsRef.current.sortedIndexAttribute
+      .array as Uint32Array;
+    for (let i = 0; i < numGaussians; i++) {
+      identityIndices[i] = i;
+    }
+    meshPropsRef.current.sortedIndexAttribute.needsUpdate = true;
+    meshPropsRef.current.material.uniforms.numGaussians.value = numGaussians;
+    meshPropsRef.current.textureBuffer.needsUpdate = true;
+    initializedBufferTextureRef.current = true;
+
     // Create sorting worker.
     sortWorkerRef.current = new SplatSortWorker();
     sortWorkerRef.current.onmessage = (e) => {
@@ -195,14 +225,6 @@ function SplatRendererImpl() {
         if (sortedIndices.length === meshPropsRef.current.numGaussians) {
           meshPropsRef.current.sortedIndexAttribute.set(sortedIndices);
           meshPropsRef.current.sortedIndexAttribute.needsUpdate = true;
-        }
-
-        // Trigger initial render.
-        if (!initializedBufferTextureRef.current) {
-          meshPropsRef.current.material.uniforms.numGaussians.value =
-            meshPropsRef.current.numGaussians;
-          meshPropsRef.current.textureBuffer.needsUpdate = true;
-          initializedBufferTextureRef.current = true;
         }
       }
     };
@@ -252,9 +274,8 @@ function SplatRendererImpl() {
       // Same size - update texture data in place.
       const textureData = meshPropsRef.current.textureBuffer.image
         .data as Uint32Array;
-      const bufferPadded = new Uint32Array(textureData.length);
-      bufferPadded.set(merged.gaussianBuffer);
-      textureData.set(bufferPadded);
+      textureData.fill(0);
+      textureData.set(merged.gaussianBuffer);
       meshPropsRef.current.textureBuffer.needsUpdate = true;
 
       // Update worker with new buffer.
@@ -415,9 +436,16 @@ function SplatRendererImpl() {
           groupIndex * 12,
         );
 
-        // Determine visibility.
-        const visibleNow = node.visible && node.parent !== null;
-        groupVisibles.push(visibleNow && prevVisibles[groupIndex] === true);
+        // Determine visibility from the scene tree's precomputed
+        // effectiveVisibility, which accounts for the full parent chain.
+        const sceneNodeName = sceneNodeNameFromId.current[name];
+        const sceneNode = sceneNodeName
+          ? viewer.useSceneTree.get(sceneNodeName)
+          : undefined;
+        const visibleNow =
+          node.parent !== null &&
+          (sceneNode?.effectiveVisibility ?? true);
+        groupVisibles.push(visibleNow);
         if (prevVisibles[groupIndex] !== visibleNow) {
           prevVisibles[groupIndex] = visibleNow;
           visibilitiesChanged = true;
@@ -494,7 +522,7 @@ function SplatRendererImpl() {
         params.far = far;
       }
     },
-    [groupBufferFromId, nodeRefFromId, tmpT_camera_group, postToWorker],
+    [groupBufferFromId, nodeRefFromId, sceneNodeNameFromId, viewer, tmpT_camera_group, postToWorker],
   );
   splatContext.updateCamera.current = updateCamera;
 
@@ -532,15 +560,6 @@ function SplatRendererImpl() {
       renderOrder={10000.0 /*Generally, we want to render last.*/}
     />
   );
-}
-
-/** Fast comparison of two Uint32Arrays. */
-function arraysEqual(a: Uint32Array, b: Uint32Array): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
 }
 
 /**Consolidate groups of Gaussians into a single buffer, to make it possible

--- a/src/viser/client/src/Splatting/GaussianSplats.tsx
+++ b/src/viser/client/src/Splatting/GaussianSplats.tsx
@@ -443,8 +443,7 @@ function SplatRendererImpl() {
           ? viewer.useSceneTree.get(sceneNodeName)
           : undefined;
         const visibleNow =
-          node.parent !== null &&
-          (sceneNode?.effectiveVisibility ?? true);
+          node.parent !== null && (sceneNode?.effectiveVisibility ?? true);
         groupVisibles.push(visibleNow);
         if (prevVisibles[groupIndex] !== visibleNow) {
           prevVisibles[groupIndex] = visibleNow;
@@ -522,7 +521,14 @@ function SplatRendererImpl() {
         params.far = far;
       }
     },
-    [groupBufferFromId, nodeRefFromId, sceneNodeNameFromId, viewer, tmpT_camera_group, postToWorker],
+    [
+      groupBufferFromId,
+      nodeRefFromId,
+      sceneNodeNameFromId,
+      viewer,
+      tmpT_camera_group,
+      postToWorker,
+    ],
   );
   splatContext.updateCamera.current = updateCamera;
 

--- a/src/viser/client/src/Splatting/GaussianSplatsHelpers.ts
+++ b/src/viser/client/src/Splatting/GaussianSplatsHelpers.ts
@@ -291,9 +291,9 @@ interface SplatActions {
 /**Hook for creating global splat state.*/
 export function useGaussianSplatStore() {
   const nodeRefFromId = React.useRef({});
-  const sceneNodeNameFromId = React.useRef<{ [id: string]: string | undefined }>(
-    {},
-  );
+  const sceneNodeNameFromId = React.useRef<{
+    [id: string]: string | undefined;
+  }>({});
   return React.useState(() => {
     const store = createStore<SplatState>({
       groupBufferFromId: {},

--- a/src/viser/client/src/Splatting/GaussianSplatsHelpers.ts
+++ b/src/viser/client/src/Splatting/GaussianSplatsHelpers.ts
@@ -278,6 +278,9 @@ interface SplatState {
   nodeRefFromId: React.MutableRefObject<{
     [name: string]: undefined | Object3D;
   }>;
+  sceneNodeNameFromId: React.MutableRefObject<{
+    [id: string]: string | undefined;
+  }>;
 }
 
 interface SplatActions {
@@ -288,10 +291,14 @@ interface SplatActions {
 /**Hook for creating global splat state.*/
 export function useGaussianSplatStore() {
   const nodeRefFromId = React.useRef({});
+  const sceneNodeNameFromId = React.useRef<{ [id: string]: string | undefined }>(
+    {},
+  );
   return React.useState(() => {
     const store = createStore<SplatState>({
       groupBufferFromId: {},
       nodeRefFromId: nodeRefFromId,
+      sceneNodeNameFromId: sceneNodeNameFromId,
     });
 
     const actions: SplatActions = {

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -258,11 +258,11 @@ export const InstancedAxes = React.forwardRef<
   THREE.Group,
   {
     /** Float32 quaternion values (wxyz) */
-    batched_wxyzs: Float32Array | Uint8Array;
+    batched_wxyzs: Float32Array;
     /** Float32 position values (xyz) */
-    batched_positions: Float32Array | Uint8Array;
+    batched_positions: Float32Array;
     /** Float32 scale values (uniform or per-axis XYZ) */
-    batched_scales: Float32Array | Uint8Array | null;
+    batched_scales: Float32Array | null;
     axes_length?: number;
     axes_radius?: number;
     scale?: number | [number, number, number];
@@ -331,75 +331,51 @@ export const InstancedAxes = React.forwardRef<
     const { T_frame_framex, T_frame_framey, T_frame_framez, red, green, blue } =
       axesTransformations;
 
-    // Create DataViews to read float values directly.
-    const positionsView = new DataView(
-      batched_positions.buffer,
-      batched_positions.byteOffset,
-      batched_positions.byteLength,
-    );
-
-    const wxyzsView = new DataView(
-      batched_wxyzs.buffer,
-      batched_wxyzs.byteOffset,
-      batched_wxyzs.byteLength,
-    );
-
-    const scalesView = batched_scales
-      ? new DataView(
-          batched_scales.buffer,
-          batched_scales.byteOffset,
-          batched_scales.byteLength,
-        )
-      : null;
-
     // Calculate number of instances.
-    const numInstances = batched_wxyzs.byteLength / (4 * 4); // 4 floats, 4 bytes per float
+    const numInstances = batched_wxyzs.length / 4;
+
+    // Determine scaling mode.
+    const perAxisScaling =
+      batched_scales !== null &&
+      batched_scales.length === (batched_wxyzs.length / 4) * 3;
 
     for (let i = 0; i < numInstances; i++) {
-      // Calculate byte offsets for reading float values.
       // Use modulo as a defensive check to prevent out-of-bounds reads when
       // array lengths don't match.
-      const posOffset = (i * 3 * 4) % batched_positions.byteLength;
-      const wxyzOffset = (i * 4 * 4) % batched_wxyzs.byteLength;
-      const scaleOffset =
-        batched_scales &&
-        batched_scales.byteLength === (batched_wxyzs.byteLength / 4) * 3
-          ? (i * 3 * 4) % batched_scales.byteLength // Per-axis scaling: 3 floats, 4 bytes per float
-          : (i * 4) % (batched_scales?.byteLength ?? 4); // Uniform scaling: 1 float, 4 bytes per float
+      const posIdx = (i * 3) % batched_positions.length;
+      const wxyzIdx = (i * 4) % batched_wxyzs.length;
 
       // Read scale value if available.
-      if (scalesView && batched_scales) {
-        // Check if we have per-axis scaling (N,3) or uniform scaling (N,).
-        if (batched_scales.byteLength === (batched_wxyzs.byteLength / 4) * 3) {
-          // Per-axis scaling: read 3 floats.
+      if (batched_scales !== null) {
+        if (perAxisScaling) {
+          const scaleIdx = (i * 3) % batched_scales.length;
           tmpScale.set(
-            scalesView.getFloat32(scaleOffset, true), // x scale
-            scalesView.getFloat32(scaleOffset + 4, true), // y scale
-            scalesView.getFloat32(scaleOffset + 8, true), // z scale
+            batched_scales[scaleIdx], // x scale
+            batched_scales[scaleIdx + 1], // y scale
+            batched_scales[scaleIdx + 2], // z scale
           );
         } else {
-          // Uniform scaling: read 1 float and apply to all axes.
-          const scale = scalesView.getFloat32(scaleOffset, true);
+          const scale = batched_scales[i % batched_scales.length];
           tmpScale.set(scale, scale, scale);
         }
       } else {
         tmpScale.set(1, 1, 1);
       }
 
-      // Set position from DataView.
+      // Set transform from Float32Array values directly.
       T_world_frame.makeRotationFromQuaternion(
         tmpQuat.set(
-          wxyzsView.getFloat32(wxyzOffset + 4, true), // x
-          wxyzsView.getFloat32(wxyzOffset + 8, true), // y
-          wxyzsView.getFloat32(wxyzOffset + 12, true), // z
-          wxyzsView.getFloat32(wxyzOffset, true), // w (first value)
+          batched_wxyzs[wxyzIdx + 1], // x
+          batched_wxyzs[wxyzIdx + 2], // y
+          batched_wxyzs[wxyzIdx + 3], // z
+          batched_wxyzs[wxyzIdx], // w (first value)
         ),
       )
         .scale(tmpScale)
         .setPosition(
-          positionsView.getFloat32(posOffset, true), // x
-          positionsView.getFloat32(posOffset + 4, true), // y
-          positionsView.getFloat32(posOffset + 8, true), // z
+          batched_positions[posIdx], // x
+          batched_positions[posIdx + 1], // y
+          batched_positions[posIdx + 2], // z
         );
 
       T_world_framex.copy(T_world_frame).multiply(T_frame_framex);

--- a/src/viser/client/src/components/Folder.tsx
+++ b/src/viser/client/src/components/Folder.tsx
@@ -21,9 +21,8 @@ export default function FolderComponent({
   );
   const guiContext = React.useContext(GuiComponentContext)!;
   const isEmpty = guiIdSet === undefined || Object.keys(guiIdSet).length === 0;
-  const nextGuiType = viewer.useGuiConfig(
-    nextGuiUuid ?? "",
-    (conf) => (nextGuiUuid == null ? null : conf?.type ?? null),
+  const nextGuiType = viewer.useGuiConfig(nextGuiUuid ?? "", (conf) =>
+    nextGuiUuid == null ? null : (conf?.type ?? null),
   );
 
   const ToggleIcon = opened ? IconChevronUp : IconChevronDown;

--- a/src/viser/client/src/mesh/BatchedMeshBase.tsx
+++ b/src/viser/client/src/mesh/BatchedMeshBase.tsx
@@ -117,12 +117,12 @@ export const BatchedMeshBase = React.forwardRef<
   InstancedMesh2,
   {
     // Data for instance positions and orientations.
-    batched_positions: Float32Array | Uint8Array;
-    batched_wxyzs: Float32Array | Uint8Array;
-    batched_scales: Float32Array | Uint8Array | null;
+    batched_positions: Float32Array;
+    batched_wxyzs: Float32Array;
+    batched_scales: Float32Array | null;
     batched_colors: Uint8Array<ArrayBuffer> | null;
     opacity: number | null;
-    batched_opacities: Float32Array | Uint8Array | null;
+    batched_opacities: Float32Array | null;
 
     // Geometry info.
     geometry: THREE.BufferGeometry;
@@ -209,67 +209,50 @@ export const BatchedMeshBase = React.forwardRef<
       mesh.addInstances(instanceCount, () => {});
     }
 
-    // Create views to efficiently read float values.
-    const positionsView = new DataView(
-      props.batched_positions.buffer,
-      props.batched_positions.byteOffset,
-      props.batched_positions.byteLength,
-    );
-    const wxyzsView = new DataView(
-      props.batched_wxyzs.buffer,
-      props.batched_wxyzs.byteOffset,
-      props.batched_wxyzs.byteLength,
-    );
-    const scalesView = props.batched_scales
-      ? new DataView(
-          props.batched_scales.buffer,
-          props.batched_scales.byteOffset,
-          props.batched_scales.byteLength,
-        )
-      : null;
+    const positions = props.batched_positions;
+    const wxyzs = props.batched_wxyzs;
+    const scales = props.batched_scales;
+    const posLength = positions.length;
+    const wxyzLength = wxyzs.length;
+    const scalesLength = scales ? scales.length : 0;
+
+    // Determine scaling mode: per-axis (N,3) or uniform (N,).
+    const perAxisScaling =
+      scales !== null && scalesLength === (wxyzLength / 4) * 3;
 
     // Update all instances.
     mesh.updateInstances((obj, index) => {
-      // Calculate byte offsets for reading float values.
       // Use modulo as a defensive check to prevent out-of-bounds reads when
-      // array lengths don't match (e.g., if batched_wxyzs has fewer elements
-      // than batched_positions).
-      const posOffset = (index * 3 * 4) % props.batched_positions.byteLength;
-      const wxyzOffset = (index * 4 * 4) % props.batched_wxyzs.byteLength;
+      // array lengths don't match.
+      const posIdx = (index * 3) % posLength;
+      const wxyzIdx = (index * 4) % wxyzLength;
 
       // Read position values.
       tempPosition.set(
-        positionsView.getFloat32(posOffset, true), // x.
-        positionsView.getFloat32(posOffset + 4, true), // y.
-        positionsView.getFloat32(posOffset + 8, true), // z.
+        positions[posIdx], // x.
+        positions[posIdx + 1], // y.
+        positions[posIdx + 2], // z.
       );
 
-      // Read quaternion values.
+      // Read quaternion values (wxyz layout -> xyzw for Three.js).
       tempQuaternion.set(
-        wxyzsView.getFloat32(wxyzOffset + 4, true), // x.
-        wxyzsView.getFloat32(wxyzOffset + 8, true), // y.
-        wxyzsView.getFloat32(wxyzOffset + 12, true), // z.
-        wxyzsView.getFloat32(wxyzOffset, true), // w (first value).
+        wxyzs[wxyzIdx + 1], // x.
+        wxyzs[wxyzIdx + 2], // y.
+        wxyzs[wxyzIdx + 3], // z.
+        wxyzs[wxyzIdx], // w (first value).
       );
 
       // Read scale value if available.
-      if (scalesView && props.batched_scales) {
-        // Check if we have per-axis scaling (N,3) or uniform scaling (N,).
-        if (
-          props.batched_scales.byteLength ===
-          (props.batched_wxyzs.byteLength / 4) * 3
-        ) {
-          // Per-axis scaling: read 3 floats.
-          const scaleOffset = (index * 3 * 4) % props.batched_scales.byteLength;
+      if (scales !== null) {
+        if (perAxisScaling) {
+          const scaleIdx = (index * 3) % scalesLength;
           tempScale.set(
-            scalesView.getFloat32(scaleOffset, true), // x scale.
-            scalesView.getFloat32(scaleOffset + 4, true), // y scale.
-            scalesView.getFloat32(scaleOffset + 8, true), // z scale.
+            scales[scaleIdx], // x scale.
+            scales[scaleIdx + 1], // y scale.
+            scales[scaleIdx + 2], // z scale.
           );
         } else {
-          // Uniform scaling: read 1 float and apply to all axes.
-          const scaleOffset = (index * 4) % props.batched_scales.byteLength;
-          const scale = scalesView.getFloat32(scaleOffset, true);
+          const scale = scales[index % scalesLength];
           tempScale.setScalar(scale);
         }
       } else {
@@ -370,15 +353,10 @@ export const BatchedMeshBase = React.forwardRef<
       return;
     }
 
-    const opacityView = new DataView(
-      props.batched_opacities.buffer,
-      props.batched_opacities.byteOffset,
-      props.batched_opacities.byteLength,
-    );
+    const opacities = props.batched_opacities;
 
     for (let i = 0; i < mesh.instancesCount; i++) {
-      const instanceOpacity = opacityView.getFloat32(i * 4, true);
-      mesh.setOpacityAt(i, globalOpacity * instanceOpacity);
+      mesh.setOpacityAt(i, globalOpacity * opacities[i]);
     }
   }, [props.opacity, props.batched_opacities, mesh]);
 

--- a/src/viser/client/src/mesh/BatchedMeshHoverOutlines.tsx
+++ b/src/viser/client/src/mesh/BatchedMeshHoverOutlines.tsx
@@ -10,11 +10,11 @@ import { OutlinesMaterial } from "../OutlinesMaterial";
 interface BatchedMeshHoverOutlinesProps {
   geometry: THREE.BufferGeometry;
   /** Float32 position values (xyz) */
-  batched_positions: Float32Array | Uint8Array;
+  batched_positions: Float32Array;
   /** Float32 quaternion values (wxyz) */
-  batched_wxyzs: Float32Array | Uint8Array;
+  batched_wxyzs: Float32Array;
   /** Float32 scale values (uniform or per-axis XYZ) */
-  batched_scales: Float32Array | Uint8Array | null;
+  batched_scales: Float32Array | null;
   meshTransform?: {
     position: THREE.Vector3;
     rotation: THREE.Quaternion;
@@ -128,68 +128,41 @@ export const BatchedMeshHoverOutlines: React.FC<
         ? computeBatchIndexFromInstanceIndex(hoveredInstanceId)
         : hoveredInstanceId; // Default is identity mapping
 
-      // Create DataViews to read float values.
-      const positionsView = new DataView(
-        batched_positions.buffer,
-        batched_positions.byteOffset,
-        batched_positions.byteLength,
-      );
-
-      const wxyzsView = new DataView(
-        batched_wxyzs.buffer,
-        batched_wxyzs.byteOffset,
-        batched_wxyzs.byteLength,
-      );
-
-      const scalesView = batched_scales
-        ? new DataView(
-            batched_scales.buffer,
-            batched_scales.byteOffset,
-            batched_scales.byteLength,
-          )
-        : null;
-
-      // Only show outline if the batch index is valid (check bytes per position = 3 floats * 4 bytes)
-      if (batchIndex >= 0 && batchIndex * 12 < batched_positions.byteLength) {
-        // Calculate byte offsets.
+      // Only show outline if the batch index is valid.
+      if (batchIndex >= 0 && batchIndex * 3 < batched_positions.length) {
         // Use modulo as a defensive check to prevent out-of-bounds reads.
-        const posOffset = (batchIndex * 3 * 4) % batched_positions.byteLength;
-        const wxyzOffset = (batchIndex * 4 * 4) % batched_wxyzs.byteLength;
+        const posIdx = (batchIndex * 3) % batched_positions.length;
+        const wxyzIdx = (batchIndex * 4) % batched_wxyzs.length;
 
         // Position the outline at the hovered instance.
         outlineRef.current.position.set(
-          positionsView.getFloat32(posOffset, true), // x
-          positionsView.getFloat32(posOffset + 4, true), // y
-          positionsView.getFloat32(posOffset + 8, true), // z
+          batched_positions[posIdx], // x
+          batched_positions[posIdx + 1], // y
+          batched_positions[posIdx + 2], // z
         );
 
-        // Set rotation to match the hovered instance.
+        // Set rotation to match the hovered instance (wxyz -> xyzw).
         outlineRef.current.quaternion.set(
-          wxyzsView.getFloat32(wxyzOffset + 4, true), // x
-          wxyzsView.getFloat32(wxyzOffset + 8, true), // y
-          wxyzsView.getFloat32(wxyzOffset + 12, true), // z
-          wxyzsView.getFloat32(wxyzOffset, true), // w
+          batched_wxyzs[wxyzIdx + 1], // x
+          batched_wxyzs[wxyzIdx + 2], // y
+          batched_wxyzs[wxyzIdx + 3], // z
+          batched_wxyzs[wxyzIdx], // w
         );
 
-        // Set scale to match the hovered instance
-        if (scalesView && batched_scales) {
+        // Set scale to match the hovered instance.
+        if (batched_scales !== null) {
           // Check if we have per-axis scaling (N,3) or uniform scaling (N,).
-          if (
-            batched_scales.byteLength ===
-            (batched_wxyzs.byteLength / 4) * 3
-          ) {
-            // Per-axis scaling: read 3 floats.
-            const scaleOffset =
-              (batchIndex * 3 * 4) % batched_scales.byteLength;
+          const perAxisScaling =
+            batched_scales.length === (batched_wxyzs.length / 4) * 3;
+          if (perAxisScaling) {
+            const scaleIdx = (batchIndex * 3) % batched_scales.length;
             outlineRef.current.scale.set(
-              scalesView.getFloat32(scaleOffset, true), // x scale
-              scalesView.getFloat32(scaleOffset + 4, true), // y scale
-              scalesView.getFloat32(scaleOffset + 8, true), // z scale
+              batched_scales[scaleIdx], // x scale
+              batched_scales[scaleIdx + 1], // y scale
+              batched_scales[scaleIdx + 2], // z scale
             );
           } else {
-            // Uniform scaling: read 1 float and apply to all axes.
-            const scaleOffset = (batchIndex * 4) % batched_scales.byteLength;
-            const scale = scalesView.getFloat32(scaleOffset, true);
+            const scale = batched_scales[batchIndex % batched_scales.length];
             outlineRef.current.scale.setScalar(scale);
           }
         } else {

--- a/tests/e2e/test_gaussian_splat_visibility.py
+++ b/tests/e2e/test_gaussian_splat_visibility.py
@@ -1,0 +1,77 @@
+"""E2E test for Gaussian splat visibility toggling.
+
+Verifies that hiding a Gaussian splat node via `.visible = False` correctly
+hides the splats (pixels change), and re-showing them works.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import numpy as np
+from PIL import Image
+from playwright.sync_api import Page
+
+import viser
+
+from .utils import wait_for_scene_node, wait_for_scene_node_hidden, wait_for_scene_node_visible
+
+
+def _count_colored_pixels(page: Page, min_r: int = 200, max_gb: int = 100) -> int:
+    """Count red pixels on the canvas (not the full page, to exclude UI chrome)."""
+    canvas = page.locator("canvas").first
+    screenshot = canvas.screenshot()
+    img = np.array(Image.open(BytesIO(screenshot)).convert("RGB"))
+    red_mask = (img[:, :, 0] > min_r) & (img[:, :, 1] < max_gb) & (img[:, :, 2] < max_gb)
+    return int(red_mask.sum())
+
+
+def test_gaussian_splat_visibility_pixel_check(
+    viser_server: viser.ViserServer,
+    viser_page: Page,
+) -> None:
+    """Test that toggling splat visibility actually changes rendered pixels."""
+    # Create bright red splats at the origin.
+    num_gaussians = 100
+    gs_handle = viser_server.scene.add_gaussian_splats(
+        "/test_splat",
+        centers=np.zeros((num_gaussians, 3), dtype=np.float32),
+        rgbs=np.tile(np.array([[1.0, 0.0, 0.0]], dtype=np.float32), (num_gaussians, 1)),
+        opacities=np.ones((num_gaussians, 1), dtype=np.float32),
+        covariances=np.tile(
+            np.eye(3, dtype=np.float32) * 1.0, (num_gaussians, 1, 1)
+        ),
+    )
+
+    # Wait for node and give time for WASM init + sort + rendering.
+    wait_for_scene_node(viser_page, "/test_splat")
+    viser_page.wait_for_timeout(3000)
+
+    # Splats should be rendering -- canvas should have red pixels.
+    pixels_visible = _count_colored_pixels(viser_page)
+    assert pixels_visible > 1000, (
+        f"Expected red splat pixels but only found {pixels_visible}"
+    )
+
+    # Hide the splats.
+    gs_handle.visible = False
+    wait_for_scene_node_hidden(viser_page, "/test_splat")
+    # Wait for the splat renderer's useFrame to detect the visibility change.
+    viser_page.wait_for_timeout(1000)
+
+    # Canvas should have no red pixels now.
+    pixels_hidden = _count_colored_pixels(viser_page)
+    assert pixels_hidden < 100, (
+        f"Expected no red pixels after hiding splats but found {pixels_hidden}"
+    )
+
+    # Re-show.
+    gs_handle.visible = True
+    wait_for_scene_node_visible(viser_page, "/test_splat")
+    viser_page.wait_for_timeout(1000)
+
+    # Should have red pixels again.
+    pixels_reshown = _count_colored_pixels(viser_page)
+    assert pixels_reshown > 1000, (
+        f"Expected red pixels after re-showing splats but only found {pixels_reshown}"
+    )

--- a/tests/e2e/test_gaussian_splat_visibility.py
+++ b/tests/e2e/test_gaussian_splat_visibility.py
@@ -14,7 +14,11 @@ from playwright.sync_api import Page
 
 import viser
 
-from .utils import wait_for_scene_node, wait_for_scene_node_hidden, wait_for_scene_node_visible
+from .utils import (
+    wait_for_scene_node,
+    wait_for_scene_node_hidden,
+    wait_for_scene_node_visible,
+)
 
 
 def _count_colored_pixels(page: Page, min_r: int = 200, max_gb: int = 100) -> int:
@@ -22,7 +26,9 @@ def _count_colored_pixels(page: Page, min_r: int = 200, max_gb: int = 100) -> in
     canvas = page.locator("canvas").first
     screenshot = canvas.screenshot()
     img = np.array(Image.open(BytesIO(screenshot)).convert("RGB"))
-    red_mask = (img[:, :, 0] > min_r) & (img[:, :, 1] < max_gb) & (img[:, :, 2] < max_gb)
+    red_mask = (
+        (img[:, :, 0] > min_r) & (img[:, :, 1] < max_gb) & (img[:, :, 2] < max_gb)
+    )
     return int(red_mask.sum())
 
 
@@ -38,9 +44,7 @@ def test_gaussian_splat_visibility_pixel_check(
         centers=np.zeros((num_gaussians, 3), dtype=np.float32),
         rgbs=np.tile(np.array([[1.0, 0.0, 0.0]], dtype=np.float32), (num_gaussians, 1)),
         opacities=np.ones((num_gaussians, 1), dtype=np.float32),
-        covariances=np.tile(
-            np.eye(3, dtype=np.float32) * 1.0, (num_gaussians, 1, 1)
-        ),
+        covariances=np.tile(np.eye(3, dtype=np.float32) * 1.0, (num_gaussians, 1, 1)),
     )
 
     # Wait for node and give time for WASM init + sort + rendering.


### PR DESCRIPTION
- Python nits: lazy import for imageio, GUI value deduplication.
- Fixed visibility toggle for splat objects, e2e test.
- Fixed bug that was causing slow splat loading. Most splat objects load instantaneously now, instead of needing many seconds in recent releases.
- Removed unnecessary `DataView` objects for batched meshes; this should speed up data reads.