### PR TITLE
Resolve symlinks when setting http server root

### DIFF
--- a/src/viser/_client_autobuild.py
+++ b/src/viser/_client_autobuild.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-client_dir = Path(__file__).absolute().parent / "client"
+client_dir = Path(__file__).resolve().parent / "client"
 build_dir = client_dir / "build"
 
 

--- a/src/viser/_icons.py
+++ b/src/viser/_icons.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from ._icons_enum import IconName
 
-ICONS_DIR = Path(__file__).absolute().parent / "_icons"
+ICONS_DIR = Path(__file__).resolve().parent / "_icons"
 
 
 @lru_cache(maxsize=32)

--- a/src/viser/_icons_generate_enum.py
+++ b/src/viser/_icons_generate_enum.py
@@ -3,7 +3,7 @@
 import zipfile
 from pathlib import Path
 
-HERE_DIR = Path(__file__).absolute().parent
+HERE_DIR = Path(__file__).resolve().parent
 ICON_DIR = HERE_DIR / "_icons"
 
 

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -742,7 +742,7 @@ class ViserServer(DeprecatedAttributeShim if not TYPE_CHECKING else object):
             host=host,
             port=port,
             message_class=_messages.Message,
-            http_server_root=Path(__file__).absolute().parent / "client" / "build",
+            http_server_root=Path(__file__).resolve().parent / "client" / "build",
             verbose=verbose,
             client_api_version=1,
         )


### PR DESCRIPTION
I ran into 404 error when trying to open ` http://localhost:8080 ` after upgrading from version `0.2.23` to  `1.0.26`. [This](https://github.com/viser-project/viser/commit/86212d7eae69672b206b0804e5097a5e994d1c32#diff-e89b760ad68f5ad72275b1fdd0cf1eca81ba42ce3bf781b4548b81309cbccb75) looks like the place where the issue was introduced. My environment relies on symlinks, which breaks the current way `http_server_root` is set for `infra.WebsockServer`. 
This change resolves the path to take of environments with symlinks. 
