### PR TITLE
add_uplot: expose padding and fixed height options

### DIFF
--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -884,6 +884,8 @@ class GuiApi:
         cursor: uplot.Cursor | None = None,
         focus: uplot.Focus | None = None,
         aspect: float = 1.0,
+        height: int | None = None,
+        padding: tuple[int, int, int, int] | None = None,
         order: float | None = None,
         visible: bool = True,
     ) -> GuiUplotHandle:
@@ -928,6 +930,9 @@ class GuiApi:
                 transparency of non-focused series to emphasize the active one.
             aspect: Width-to-height ratio for the chart display in the control panel.
                 1.0 creates a square chart, values > 1.0 create wider charts.
+                Used when height is None.
+            height: Fixed height in pixels. Overrides aspect ratio when set.
+            padding: Chart padding [top, right, bottom, left] in pixels.
             order: Display ordering relative to other GUI elements (lower values first).
             visible: Whether the chart is visible in the interface.
 
@@ -981,6 +986,8 @@ class GuiApi:
                 cursor=cursor,
                 focus=focus,
                 aspect=aspect,
+                height=height,
+                padding=padding,
                 visible=visible,
             ),
         )

--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -932,7 +932,8 @@ class GuiApi:
                 1.0 creates a square chart, values > 1.0 create wider charts.
                 Used when height is None.
             height: Fixed height in pixels. Overrides aspect ratio when set.
-            padding: Chart padding [top, right, bottom, left] in pixels.
+            padding: Chart padding (top, right, bottom, left) in pixels. Defaults
+                to (0, 24, 0, 0) when omitted.
             order: Display ordering relative to other GUI elements (lower values first).
             visible: Whether the chart is visible in the interface.
 

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -1320,7 +1320,11 @@ class GuiUplotProps:
     non-focused series to emphasize the active one."""
     aspect: float
     """Width-to-height ratio for chart display (width/height). 1.0 = square, >1.0 = wider.
-    """
+    Used when height is None."""
+    height: Union[int, None]
+    """Fixed height in pixels. Overrides aspect ratio when set."""
+    padding: Union[Tuple[int, int, int, int], None]
+    """Padding [top, right, bottom, left] in pixels."""
     visible: bool
     """Whether the chart is visible in the interface."""
 

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -1324,7 +1324,7 @@ class GuiUplotProps:
     height: Union[int, None]
     """Fixed height in pixels. Overrides aspect ratio when set."""
     padding: Union[Tuple[int, int, int, int], None]
-    """Padding [top, right, bottom, left] in pixels."""
+    """Padding (top, right, bottom, left) in pixels."""
     visible: bool
     """Whether the chart is visible in the interface."""
 

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -764,6 +764,8 @@ export interface GuiUplotMessage {
     } | null;
     focus: { alpha: number } | null;
     aspect: number;
+    height: number | null;
+    padding: [number, number, number, number] | null;
     visible: boolean;
   };
 }

--- a/src/viser/client/src/components/UplotComponent.tsx
+++ b/src/viser/client/src/components/UplotComponent.tsx
@@ -112,6 +112,8 @@ function PlotComponent({
   }, [
     containerWidth,
     props.aspect,
+    props.height,
+    props.padding,
     props.title,
     props.mode,
     props.series,

--- a/src/viser/client/src/components/UplotComponent.tsx
+++ b/src/viser/client/src/components/UplotComponent.tsx
@@ -96,7 +96,7 @@ function PlotComponent({
 
     return {
       width: containerWidth,
-      height: (containerWidth / props.aspect) as any,
+      height: (props.height ?? containerWidth / props.aspect) as any,
       title: props.title || undefined,
       mode: props.mode || undefined,
       series: (props.series as any) || [],
@@ -107,7 +107,7 @@ function PlotComponent({
       legend: (props.legend as any) || undefined,
       focus: props.focus || undefined,
       // Set tighter default padding [top, right, bottom, left].
-      padding: [0, 24, 0, 0] as [number, number, number, number],
+      padding: (props.padding ?? [0, 24, 0, 0]) as [number, number, number, number],
     };
   }, [
     containerWidth,


### PR DESCRIPTION
## Summary
- Add `height` parameter: fixed pixel height, overrides aspect ratio
- Add `padding` parameter: `[top, right, bottom, left]` in pixels (default `[0, 24, 0, 0]`)

Both are optional — existing behavior unchanged.

```python
gui.add_uplot(data, series, padding=[8, 24, 8, 8], height=200)
```

Closes #682