### PR TITLE
Introduce `gui.add_form()` for events on Enter/submit

### DIFF
--- a/docs/source/api/handles/gui_handles.rst
+++ b/docs/source/api/handles/gui_handles.rst
@@ -14,6 +14,8 @@ GUI Handles
 
 .. autoclass:: viser.GuiFolderHandle
 
+.. autoclass:: viser.GuiFormHandle
+
 .. autoclass:: viser.GuiHtmlHandle
 
 .. autoclass:: viser.GuiImageHandle

--- a/docs/source/api/handles/scene_handles.rst
+++ b/docs/source/api/handles/scene_handles.rst
@@ -31,6 +31,8 @@ methods like :func:`viser.ViserServer.add_frame()` or
 
 .. autoclass:: viser.CameraFrustumHandle
 
+.. autoclass:: viser.CylinderHandle
+
 .. autoclass:: viser.DirectionalLightHandle
 
 .. autoclass:: viser.FrameHandle

--- a/docs/source/examples/_example_gallery.rst
+++ b/docs/source/examples/_example_gallery.rst
@@ -173,7 +173,7 @@ GUI Controls
                <img src="_static/examples/thumbs/02_gui_02_layouts.png" alt="GUI layouts" style="width: 100%; height: auto; aspect-ratio: 16/9; object-fit: cover; display: block;">
                <div style="padding: 15px;">
                    <h4 style="margin: 0; padding: 0; font-size: 16px; font-weight: 600; color: #333; margin-bottom: 8px;">GUI layouts</h4>
-                   <p style="margin: 0; padding: 0; color: #666; font-size: 13px; line-height: 1.4;">Organize GUI controls using folders, tabs, and nested structures for better user experience.</p>
+                   <p style="margin: 0; padding: 0; color: #666; font-size: 13px; line-height: 1.4;">Organize GUI controls using folders, forms, tabs, and nested structures for better user experience.</p>
                </div>
            </a>
        </div>

--- a/docs/source/examples/gui/layouts.rst
+++ b/docs/source/examples/gui/layouts.rst
@@ -1,11 +1,12 @@
 GUI layouts
 ===========
 
-Organize GUI controls using folders, tabs, and nested structures for better user experience.
+Organize GUI controls using folders, forms, tabs, and nested structures for better user experience.
 
 **Features:**
 
 * :meth:`viser.GuiApi.add_folder` for grouping related controls
+* :meth:`viser.GuiApi.add_form` for groups that commit together on submit
 * :meth:`viser.GuiApi.add_tab_group` and :meth:`viser.GuiTabGroupHandle.add_tab` for tabbed interfaces
 * Nested folder hierarchies for complex layouts
 * Context managers for automatic grouping
@@ -77,6 +78,29 @@ Code
                server.gui.add_dropdown(
                    "Quality", options=["Low", "Medium", "High"], initial_value="Medium"
                )
+   
+       # Example 4: A form, which is a folder whose contents are committed
+       # together. on_update callbacks on child inputs still fire per-keystroke,
+       # but the form's on_submit only fires when the user commits the form,
+       # either via form.submit() (typically from a button) or by pressing Enter
+       # in a single-line input. A dirty indicator is shown next to the form
+       # label whenever any descendant has been edited since the last submit.
+       with server.gui.add_form("Profile") as profile_form:
+           name = server.gui.add_text("Name", initial_value="")
+           age = server.gui.add_number("Age", initial_value=0)
+           role = server.gui.add_dropdown(
+               "Role", options=("guest", "user", "admin"), initial_value="user"
+           )
+           save_button = server.gui.add_button("Save")
+   
+       # Buttons inside a form are just normal buttons. Wire one to submit().
+       save_button.on_click(lambda _: profile_form.submit())
+   
+       @profile_form.on_submit
+       def _(_) -> None:
+           print(
+               f"Profile saved: name={name.value!r}, age={age.value}, role={role.value}"
+           )
    
        # Add some visual objects to demonstrate the controls
        server.scene.add_icosphere(

--- a/examples/02_gui/02_layouts.py
+++ b/examples/02_gui/02_layouts.py
@@ -19,17 +19,22 @@ import viser
 def main() -> None:
     server = viser.ViserServer()
 
-    # Example 1: Organizing with folders
-    with server.gui.add_folder("Camera Controls"):
-        with server.gui.add_folder("Position"):
-            server.gui.add_slider("X", min=-5.0, max=5.0, step=0.1, initial_value=0.0)
-            server.gui.add_slider("Y", min=-5.0, max=5.0, step=0.1, initial_value=2.0)
-            server.gui.add_slider("Z", min=-5.0, max=5.0, step=0.1, initial_value=3.0)
+    # A form groups inputs that are committed together. on_update callbacks on
+    # child inputs still fire per-keystroke, but on_submit only fires when the
+    # user presses Enter or clicks the button. A dirty indicator (*) appears
+    # next to the label whenever any input has been edited since the last submit.
+    with server.gui.add_form("Camera Controls") as camera_form:
+        cam_x = server.gui.add_number("X", initial_value=0.0, step=0.1)
+        cam_y = server.gui.add_number("Y", initial_value=2.0, step=0.1)
+        cam_z = server.gui.add_number("Z", initial_value=3.0, step=0.1)
+        go_button = server.gui.add_button("Go")
 
-        with server.gui.add_folder("Rotation"):
-            server.gui.add_slider("Pitch", min=-180, max=180, step=1, initial_value=0)
-            server.gui.add_slider("Yaw", min=-180, max=180, step=1, initial_value=0)
-            server.gui.add_slider("Roll", min=-180, max=180, step=1, initial_value=0)
+    go_button.on_click(lambda _: camera_form.submit())
+
+    @camera_form.on_submit
+    def _(_) -> None:
+        for client in server.get_clients().values():
+            client.camera.position = (cam_x.value, cam_y.value, cam_z.value)
 
     # Example 2: Scene objects organization
     with server.gui.add_folder("Scene Objects"):
@@ -40,7 +45,7 @@ def main() -> None:
             )
             server.gui.add_rgb("Color", initial_value=(255, 255, 255))
 
-        with server.gui.add_folder("Objects"):  # GUI objects folder
+        with server.gui.add_folder("Objects"):
             show_axes = server.gui.add_checkbox(
                 "Show Coordinate Axes", initial_value=True
             )
@@ -67,27 +72,6 @@ def main() -> None:
                 "Quality", options=["Low", "Medium", "High"], initial_value="Medium"
             )
 
-    # Example 4: A form, which is a folder whose contents are committed
-    # together. on_update callbacks on child inputs still fire per-keystroke,
-    # but the form's on_submit only fires when the user commits the form,
-    # either via form.submit() (typically from a button) or by pressing Enter
-    # in a single-line input. A dirty indicator is shown next to the form
-    # label whenever any descendant has been edited since the last submit.
-    with server.gui.add_form("Profile") as profile_form:
-        name = server.gui.add_text("Name", initial_value="")
-        age = server.gui.add_number("Age", initial_value=0)
-        role = server.gui.add_dropdown(
-            "Role", options=("guest", "user", "admin"), initial_value="user"
-        )
-        save_button = server.gui.add_button("Save")
-
-    # Buttons inside a form are just normal buttons. Wire one to submit().
-    save_button.on_click(lambda _: profile_form.submit())
-
-    @profile_form.on_submit
-    def _(_) -> None:
-        print(f"Profile saved: name={name.value!r}, age={age.value}, role={role.value}")
-
     # Add some visual objects to demonstrate the controls
     server.scene.add_icosphere(
         name="demo_sphere",
@@ -103,12 +87,6 @@ def main() -> None:
 
     if show_axes.value:
         server.scene.add_frame("axes", axes_length=1.0, axes_radius=0.02)
-
-    print("This example shows GUI organization with folders.")
-    print("The sphere demonstrates some interactive controls.")
-
-    print("Explore the organized GUI controls!")
-    print("Notice how folders help group related functionality.")
 
     while True:
         time.sleep(0.1)

--- a/examples/02_gui/02_layouts.py
+++ b/examples/02_gui/02_layouts.py
@@ -1,10 +1,11 @@
 """GUI layouts
 
-Organize GUI controls using folders, tabs, and nested structures for better user experience.
+Organize GUI controls using folders, forms, tabs, and nested structures for better user experience.
 
 **Features:**
 
 * :meth:`viser.GuiApi.add_folder` for grouping related controls
+* :meth:`viser.GuiApi.add_form` for groups that commit together on submit
 * :meth:`viser.GuiApi.add_tab_group` and :meth:`viser.GuiTabGroupHandle.add_tab` for tabbed interfaces
 * Nested folder hierarchies for complex layouts
 * Context managers for automatic grouping
@@ -65,6 +66,27 @@ def main() -> None:
             server.gui.add_dropdown(
                 "Quality", options=["Low", "Medium", "High"], initial_value="Medium"
             )
+
+    # Example 4: A form, which is a folder whose contents are committed
+    # together. on_update callbacks on child inputs still fire per-keystroke,
+    # but the form's on_submit only fires when the user commits the form,
+    # either via form.submit() (typically from a button) or by pressing Enter
+    # in a single-line input. A dirty indicator is shown next to the form
+    # label whenever any descendant has been edited since the last submit.
+    with server.gui.add_form("Profile") as profile_form:
+        name = server.gui.add_text("Name", initial_value="")
+        age = server.gui.add_number("Age", initial_value=0)
+        role = server.gui.add_dropdown(
+            "Role", options=("guest", "user", "admin"), initial_value="user"
+        )
+        save_button = server.gui.add_button("Save")
+
+    # Buttons inside a form are just normal buttons. Wire one to submit().
+    save_button.on_click(lambda _: profile_form.submit())
+
+    @profile_form.on_submit
+    def _(_) -> None:
+        print(f"Profile saved: name={name.value!r}, age={age.value}, role={role.value}")
 
     # Add some visual objects to demonstrate the controls
     server.scene.add_icosphere(

--- a/src/viser/__init__.py
+++ b/src/viser/__init__.py
@@ -5,6 +5,7 @@ from ._gui_handles import GuiCheckboxHandle as GuiCheckboxHandle
 from ._gui_handles import GuiDropdownHandle as GuiDropdownHandle
 from ._gui_handles import GuiEvent as GuiEvent
 from ._gui_handles import GuiFolderHandle as GuiFolderHandle
+from ._gui_handles import GuiFormHandle as GuiFormHandle
 from ._gui_handles import GuiHtmlHandle as GuiHtmlHandle
 from ._gui_handles import GuiImageHandle as GuiImageHandle
 from ._gui_handles import GuiInputHandle as GuiInputHandle

--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -228,6 +228,9 @@ class GuiApi:
             _messages.GuiFormSubmitMessage, self._handle_gui_form_submit
         )
         self._websock_interface.register_handler(
+            _messages.GuiFormDirtyMessage, self._handle_gui_form_dirty
+        )
+        self._websock_interface.register_handler(
             _messages.FileTransferStartUpload, self._handle_file_transfer_start
         )
         self._websock_interface.register_handler(
@@ -378,6 +381,13 @@ class GuiApi:
         self._websock_interface.queue_message(
             _messages.GuiFormSubmitMessage(uuid=message.uuid)
         )
+
+    async def _handle_gui_form_dirty(
+        self, client_id: ClientId, message: _messages.GuiFormDirtyMessage
+    ) -> None:
+        """Broadcast form dirty signal to all other clients."""
+        message.excluded_self_client = client_id
+        self._websock_interface.queue_message(message)
 
     def _handle_file_transfer_start(
         self, client_id: ClientId, message: _messages.FileTransferStartUpload

--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -42,6 +42,7 @@ from ._gui_handles import (
     GuiDropdownHandle,
     GuiEvent,
     GuiFolderHandle,
+    GuiFormHandle,
     GuiHtmlHandle,
     GuiImageHandle,
     GuiMarkdownHandle,
@@ -224,6 +225,9 @@ class GuiApi:
             _messages.GuiButtonHoldMessage, self._handle_gui_button_hold
         )
         self._websock_interface.register_handler(
+            _messages.GuiFormSubmitMessage, self._handle_gui_form_submit
+        )
+        self._websock_interface.register_handler(
             _messages.FileTransferStartUpload, self._handle_file_transfer_start
         )
         self._websock_interface.register_handler(
@@ -337,6 +341,43 @@ class GuiApi:
                 self._thread_executor.submit(
                     cb, GuiEvent(client, client_id, handle)
                 ).add_done_callback(print_threadpool_errors)
+
+    async def _handle_gui_form_submit(
+        self, client_id: ClientId, message: _messages.GuiFormSubmitMessage
+    ) -> None:
+        """Callback for client-initiated form submits (Cmd/Ctrl+Enter).
+
+        Fires the form's on_submit callbacks and broadcasts the message back
+        to all clients so they reset their dirty indicators.
+        """
+        handle = self._container_handle_from_uuid.get(message.uuid, None)
+        if not isinstance(handle, GuiFormHandle):
+            return
+
+        # Resolve the originating client.
+        from ._viser import ClientHandle, ViserServer
+
+        if isinstance(self._owner, ClientHandle):
+            client = self._owner
+        elif isinstance(self._owner, ViserServer):
+            client = self._owner._connected_clients.get(client_id, None)
+            if client is None:
+                return
+        else:
+            assert False
+
+        for cb in handle._submit_cb:
+            if asyncio.iscoroutinefunction(cb):
+                await cb(GuiEvent(client, client_id, handle))
+            else:
+                self._thread_executor.submit(
+                    cb, GuiEvent(client, client_id, handle)
+                ).add_done_callback(print_threadpool_errors)
+
+        # Broadcast to clients so they clear their dirty indicators.
+        self._websock_interface.queue_message(
+            _messages.GuiFormSubmitMessage(uuid=message.uuid)
+        )
 
     def _handle_file_transfer_start(
         self, client_id: ClientId, message: _messages.FileTransferStartUpload
@@ -524,7 +565,7 @@ class GuiApi:
     @deprecated_positional_shim
     def add_folder(
         self,
-        label: str,
+        label: str | None,
         *,
         order: float | None = None,
         expand_by_default: bool = True,
@@ -533,10 +574,12 @@ class GuiApi:
         """Add a folder, and return a handle that can be used to populate it.
 
         Args:
-            label: Label to display on the folder.
+            label: Label to display on the folder. If ``None``, the folder is
+                rendered without a header or border, which is useful for pure
+                layout grouping.
             order: Optional ordering, smallest values will be displayed first.
             expand_by_default: Open the folder by default. Set to False to collapse it by
-                default.
+                default. Ignored when ``label`` is ``None``.
             visible: Whether the component is visible.
 
         Returns:
@@ -560,6 +603,71 @@ class GuiApi:
         return GuiFolderHandle(
             _GuiHandleState(
                 folder_container_id,
+                self,
+                None,
+                props=props,
+                parent_container_id=self._get_container_uuid(),
+            )
+        )
+
+    @deprecated_positional_shim
+    def add_form(
+        self,
+        label: str | None,
+        *,
+        order: float | None = None,
+        expand_by_default: bool = True,
+        visible: bool = True,
+    ) -> GuiFormHandle:
+        """Add a form, and return a handle that can be used to populate it.
+
+        See :class:`GuiFormHandle` for usage and semantics.
+
+        Args:
+            label: Label to display on the form. If ``None``, the form is
+                rendered without a header or border.
+            order: Optional ordering, smallest values will be displayed first.
+            expand_by_default: Open the form by default. Set to False to
+                collapse it by default. Ignored when ``label`` is ``None``.
+            visible: Whether the component is visible.
+
+        Returns:
+            A handle that can be used as a context to populate the form.
+        """
+        # Nested forms would produce invalid HTML on the client (nested
+        # <form> elements are not allowed and the browser flattens them).
+        container = self._get_container_uuid()
+        while container != "root":
+            parent = self._container_handle_from_uuid.get(container)
+            if isinstance(parent, GuiFormHandle):
+                raise ValueError(
+                    "Nested forms are not supported: add_form() was called "
+                    "inside an existing form's context."
+                )
+            # Only folder-like handles have an _impl.parent_container_id we
+            # can walk. For other container types (modals, tabs), stop.
+            if not isinstance(parent, GuiFolderHandle):
+                break
+            container = parent._impl.parent_container_id
+
+        form_container_id = _make_uuid()
+        order = _apply_default_order(order)
+        props = _messages.GuiFolderProps(
+            order=order,
+            label=label,
+            expand_by_default=expand_by_default,
+            visible=visible,
+        )
+        self._websock_interface.queue_message(
+            _messages.GuiFormMessage(
+                uuid=form_container_id,
+                container_uuid=self._get_container_uuid(),
+                props=props,
+            )
+        )
+        return GuiFormHandle(
+            _GuiHandleState(
+                form_container_id,
                 self,
                 None,
                 props=props,
@@ -1218,7 +1326,6 @@ class GuiApi:
         initial_value: str,
         *,
         multiline: bool = False,
-        update_on: Literal["change", "submit"] = "change",
         disabled: bool = False,
         visible: bool = True,
         hint: str | None = None,
@@ -1231,8 +1338,6 @@ class GuiApi:
             initial_value: Initial value of the text input.
             multiline: Whether the text input supports multiple lines, delimited with
                 the \n character.
-            update_on: When to fire on_update callbacks. ``"change"`` fires on every
-                keystroke (default). ``"submit"`` fires only on Enter key or blur.
             disabled: Whether the text input is disabled.
             visible: Whether the text input is visible.
             hint: Optional hint to display on hover.
@@ -1259,7 +1364,6 @@ class GuiApi:
                         disabled=disabled,
                         visible=visible,
                         multiline=multiline,
-                        update_on=update_on,
                     ),
                 ),
             )

--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -1218,6 +1218,7 @@ class GuiApi:
         initial_value: str,
         *,
         multiline: bool = False,
+        update_on: Literal["change", "submit"] = "change",
         disabled: bool = False,
         visible: bool = True,
         hint: str | None = None,
@@ -1230,6 +1231,8 @@ class GuiApi:
             initial_value: Initial value of the text input.
             multiline: Whether the text input supports multiple lines, delimited with
                 the \n character.
+            update_on: When to fire on_update callbacks. ``"change"`` fires on every
+                keystroke (default). ``"submit"`` fires only on Enter key or blur.
             disabled: Whether the text input is disabled.
             visible: Whether the text input is visible.
             hint: Optional hint to display on hover.
@@ -1256,6 +1259,7 @@ class GuiApi:
                         disabled=disabled,
                         visible=visible,
                         multiline=multiline,
+                        update_on=update_on,
                     ),
                 ),
             )

--- a/src/viser/_gui_handles.py
+++ b/src/viser/_gui_handles.py
@@ -21,7 +21,7 @@ from typing import (
 )
 
 import numpy as np
-from typing_extensions import Protocol, override
+from typing_extensions import Protocol, Self, override
 
 from ._assignable_props_api import AssignablePropsBase
 from ._icons import svg_from_icon
@@ -34,6 +34,7 @@ from ._messages import (
     GuiCloseModalMessage,
     GuiDropdownProps,
     GuiFolderProps,
+    GuiFormSubmitMessage,
     GuiHtmlProps,
     GuiImageProps,
     GuiMarkdownProps,
@@ -64,7 +65,7 @@ if TYPE_CHECKING:
 
 
 T = TypeVar("T")
-TGuiHandle = TypeVar("TGuiHandle", bound="_GuiInputHandle")
+TGuiHandle = TypeVar("TGuiHandle", bound="_GuiHandle")
 NoneOrCoroutine = TypeVar("NoneOrCoroutine", None, Coroutine)
 
 
@@ -766,7 +767,7 @@ class GuiFolderHandle(_GuiHandle[None], GuiFolderProps):
         ]
         parent._children[self._impl.uuid] = self
 
-    def __enter__(self) -> GuiFolderHandle:
+    def __enter__(self) -> Self:
         self._container_id_restore = self._impl.gui_api._get_container_uuid()
         self._impl.gui_api._set_container_uuid(self._impl.uuid)
         return self
@@ -804,6 +805,96 @@ class GuiFolderHandle(_GuiHandle[None], GuiFolderProps):
         parent = gui_api._container_handle_from_uuid[self._impl.parent_container_id]
         parent._children.pop(self._impl.uuid)
         gui_api._container_handle_from_uuid.pop(self._impl.uuid)
+
+
+class GuiFormHandle(GuiFolderHandle):
+    """Use as a context to place GUI elements into a form.
+
+    A form is a folder whose children's values can be committed together by
+    calling :meth:`submit` (typically from a button's ``on_click`` handler) or
+    by pressing Enter in a single-line text input inside the form.
+
+    Children of a form behave exactly like children of a folder. ``on_update``
+    callbacks on individual inputs continue to fire on every keystroke; the
+    form's :meth:`on_submit` callback fires only when the form is submitted.
+    Register one or both depending on whether you want live or commit
+    semantics.
+
+    The form's client-side dirty indicator highlights when any descendant
+    input has been edited since the last submit.
+
+    Forms cannot be nested. Calling :meth:`GuiApi.add_form` inside an
+    existing form's context will raise :class:`ValueError`, because nested
+    ``<form>`` elements are invalid HTML on the client.
+
+    Example::
+
+        with server.gui.add_form("Profile") as form:
+            name = server.gui.add_text("Name", "")
+            age = server.gui.add_number("Age", 0)
+            save = server.gui.add_button("Save")
+
+        save.on_click(lambda _: form.submit())
+
+        @form.on_submit
+        def _(event):
+            print(name.value, age.value)
+    """
+
+    def __init__(self, _impl: _GuiHandleState[None]) -> None:
+        super().__init__(_impl)
+        self._submit_cb: list[
+            Callable[[GuiEvent[GuiFormHandle]], None | Coroutine]
+        ] = []
+
+    def on_submit(
+        self,
+        func: Callable[[GuiEvent[GuiFormHandle]], NoneOrCoroutine],
+    ) -> Callable[[GuiEvent[GuiFormHandle]], NoneOrCoroutine]:
+        """Attach a function to call when the form is submitted.
+
+        ``on_submit`` is independent from ``on_update`` callbacks on child
+        inputs: child ``on_update`` callbacks fire on every keystroke (as
+        normal), and the form's ``on_submit`` fires when commit happens (via
+        ``form.submit()`` or Enter in a single-line text input).
+
+        Note:
+        - If `func` is a regular function (defined with `def`), it will be executed in a thread pool.
+        - If `func` is an async function (defined with `async def`), it will be executed in the event loop.
+        """
+        self._submit_cb.append(func)
+        return func
+
+    def remove_submit_callback(
+        self, callback: Literal["all"] | Callable = "all"
+    ) -> None:
+        """Remove submit callbacks from the form.
+
+        Args:
+            callback: Either "all" to remove all callbacks, or a specific callback function to remove.
+        """
+        if callback == "all":
+            self._submit_cb.clear()
+        else:
+            self._submit_cb = [cb for cb in self._submit_cb if cb != callback]
+
+    def submit(self) -> None:
+        """Programmatically submit this form.
+
+        Fires all registered ``on_submit`` callbacks and broadcasts a
+        :class:`GuiFormSubmitMessage` to all clients so their dirty indicators
+        are cleared.
+        """
+        gui_api = self._impl.gui_api
+        # Fire on_submit callbacks. Server-initiated submits have no client.
+        for cb in self._submit_cb:
+            cb_out = cb(GuiEvent(client_id=None, client=None, target=self))
+            if isinstance(cb_out, Coroutine):
+                gui_api._event_loop.create_task(cb_out)
+        # Broadcast to clients so they reset dirty state.
+        gui_api._websock_interface.queue_message(
+            GuiFormSubmitMessage(uuid=self._impl.uuid)
+        )
 
 
 @dataclasses.dataclass

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -1577,6 +1577,8 @@ class GuiVector3Message(_CreateGuiComponentMessage):
 @dataclasses.dataclass
 class GuiTextProps(GuiBaseProps):
     multiline: bool
+    update_on: str
+    """When to fire on_update: 'change' (every keystroke) or 'submit' (Enter/blur)."""
 
 
 @dataclasses.dataclass

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -1242,6 +1242,18 @@ class GuiFormSubmitMessage(Message):
 
 
 @dataclasses.dataclass
+class GuiFormDirtyMessage(Message):
+    """Bidirectional form dirty signal.
+
+    - Sent client->server when any input inside the form first changes since
+      the last submit. The server broadcasts this to all other clients.
+    - Sent server->client (broadcast) to propagate dirty state. Clients show
+      a dirty indicator on the form header on receipt."""
+
+    uuid: str
+
+
+@dataclasses.dataclass
 class GuiMarkdownProps:
     order: float
     """Order value for arranging GUI elements. """

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -1200,8 +1200,9 @@ class GuiBaseProps:
 class GuiFolderProps:
     order: float
     """Order value for arranging GUI elements. """
-    label: str
-    """Label text for the GUI folder."""
+    label: Optional[str]
+    """Label text for the GUI folder. If None, the folder is rendered without
+    a header or border (useful for pure layout grouping)."""
     visible: bool
     """Visibility state of the GUI folder."""
     expand_by_default: bool
@@ -1212,6 +1213,32 @@ class GuiFolderProps:
 class GuiFolderMessage(_CreateGuiComponentMessage):
     container_uuid: str
     props: GuiFolderProps
+
+
+@dataclasses.dataclass
+class GuiFormMessage(_CreateGuiComponentMessage):
+    """A form is a folder whose children's values can be committed together.
+
+    Reuses ``GuiFolderProps`` because the visual shape is identical to a
+    folder; the form-specific behavior (``on_submit`` callbacks, dirty
+    indicator, Cmd/Ctrl+Enter) is keyed off the message type alone."""
+
+    container_uuid: str
+    props: GuiFolderProps
+
+
+@dataclasses.dataclass
+class GuiFormSubmitMessage(Message):
+    """Bidirectional form submit signal.
+
+    - Sent client->server when the user presses Cmd/Ctrl+Enter inside a form.
+      The server fires the form's ``on_submit`` callbacks and broadcasts this
+      message to all clients.
+    - Sent server->client (broadcast) after any submit (client-initiated or
+      via Python ``form.submit()``). Clients clear their dirty indicator on
+      receipt."""
+
+    uuid: str
 
 
 @dataclasses.dataclass
@@ -1577,8 +1604,6 @@ class GuiVector3Message(_CreateGuiComponentMessage):
 @dataclasses.dataclass
 class GuiTextProps(GuiBaseProps):
     multiline: bool
-    update_on: str
-    """When to fire on_update: 'change' (every keystroke) or 'submit' (Enter/blur)."""
 
 
 @dataclasses.dataclass

--- a/src/viser/client/package-lock.json
+++ b/src/viser/client/package-lock.json
@@ -113,6 +113,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1081,7 +1082,6 @@
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -1108,6 +1108,7 @@
       "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.3.tgz",
       "integrity": "sha512-OdTAQ0lsXjEqfea0KyXJ1rV9cZb/Rtqv5l3luG2m8Sx5BTGMqXas6mKHtdj4LwIiUKeFkIkZYjNmH6ri1HXjSA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
         "clsx": "^2.1.1",
@@ -1140,6 +1141,7 @@
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.3.tgz",
       "integrity": "sha512-nmspxbFSjFkimRXYhgAujnyBwGeAWDSP1WKHFR+Yl5x3Q0IkmsiOTE9yJPjMjmjffZfunFXQFwQDl1OF3m42Pw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^18.x || ^19.x"
       }
@@ -1370,6 +1372,7 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.3.0.tgz",
       "integrity": "sha512-myPe3YL/C8+Eq939/4qIVEPBW/uxV0iiUbmjfwrs9sGKYDG8ib8Dz3Okq7BQt8P+0k4igedONbjXMQy84aDFmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.32.0",
@@ -1890,6 +1893,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -2121,6 +2125,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2155,6 +2160,7 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.0.tgz",
       "integrity": "sha512-AaGkvloQhxdrfMm/HbY8cpOz1K1jkEELn6zjFoY3yhAiC7zhhZE19+gDBybYwKk+GqXmWKxqDCB43NqyW3+QZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -2237,6 +2243,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -2527,6 +2534,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2868,6 +2876,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -2929,8 +2938,7 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/bvh.js": {
       "version": "0.0.13",
@@ -3871,6 +3879,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4917,18 +4926,6 @@
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "license": "MIT"
-    },
-    "node_modules/immer": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
-      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -7365,6 +7362,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7374,6 +7372,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -7927,6 +7926,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.49.0.tgz",
       "integrity": "sha512-3IVq0cGJ6H7fKXXEdVt+RcYvRCt8beYY9K1760wGQwSAHZcS9eot1zDG5axUbcp/kWRi5zKIIDX8MoKv/TzvZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8249,7 +8249,6 @@
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -8261,7 +8260,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8525,7 +8523,6 @@
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -8544,8 +8541,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -8558,7 +8554,8 @@
       "version": "0.183.2",
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
       "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -8811,6 +8808,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8985,7 +8983,8 @@
       "version": "1.6.32",
       "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.32.tgz",
       "integrity": "sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/uplot-react": {
       "version": "1.2.4",
@@ -9162,6 +9161,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/viser/client/src/ControlPanel/Generated.tsx
+++ b/src/viser/client/src/ControlPanel/Generated.tsx
@@ -21,6 +21,7 @@ import PlotlyComponent from "../components/PlotlyComponent";
 import UplotComponent from "../components/UplotComponent";
 import TabGroupComponent from "../components/TabGroup";
 import FolderComponent from "../components/Folder";
+import FormComponent from "../components/Form";
 import MultiSliderComponent from "../components/MultiSlider";
 import UploadButtonComponent from "../components/UploadButton";
 import ProgressBarComponent from "../components/ProgressBar";
@@ -59,7 +60,15 @@ export default function GeneratedGuiContainer({
   );
 }
 
-function GuiContainer({ containerUuid }: { containerUuid: string }) {
+function GuiContainer({
+  containerUuid,
+  unwrapped = false,
+}: {
+  containerUuid: string;
+  /** If true, don't wrap children in a padded Box. Used by label=null
+   * folders and forms, which should be transparent for layout purposes. */
+  unwrapped?: boolean;
+}) {
   const viewer = React.useContext(ViewerContext)!;
 
   // Use a fallback empty object for containers that don't exist yet. Containers
@@ -80,18 +89,17 @@ function GuiContainer({ containerUuid }: { containerUuid: string }) {
   guiUuidOrderPairArray = guiUuidOrderPairArray.sort(
     (a, b) => a.order - b.order,
   );
-  const out = (
-    <Box pt="xs">
-      {guiUuidOrderPairArray.map((pair, index) => (
-        <GeneratedInput
-          key={pair.uuid}
-          guiUuid={pair.uuid}
-          nextGuiUuid={guiUuidOrderPairArray[index + 1]?.uuid ?? null}
-        />
-      ))}
-    </Box>
-  );
-  return out;
+  const children = guiUuidOrderPairArray.map((pair, index) => (
+    <GeneratedInput
+      key={pair.uuid}
+      guiUuid={pair.uuid}
+      nextGuiUuid={guiUuidOrderPairArray[index + 1]?.uuid ?? null}
+    />
+  ));
+  if (unwrapped) {
+    return <>{children}</>;
+  }
+  return <Box pt="xs">{children}</Box>;
 }
 
 /** A single generated GUI element. */
@@ -108,6 +116,8 @@ function GeneratedInput(props: {
   switch (conf.type) {
     case "GuiFolderMessage":
       return <FolderComponent {...conf} nextGuiUuid={props.nextGuiUuid} />;
+    case "GuiFormMessage":
+      return <FormComponent {...conf} nextGuiUuid={props.nextGuiUuid} />;
     case "GuiTabGroupMessage":
       return <TabGroupComponent {...conf} />;
     case "GuiMarkdownMessage":

--- a/src/viser/client/src/ControlPanel/GuiComponentContext.ts
+++ b/src/viser/client/src/ControlPanel/GuiComponentContext.ts
@@ -5,7 +5,7 @@ interface GuiComponentContext {
   folderDepth: number;
   setValue: (id: string, value: NonNullable<unknown>) => void;
   messageSender: (message: Messages.Message) => void;
-  GuiContainer: React.FC<{ containerUuid: string }>;
+  GuiContainer: React.FC<{ containerUuid: string; unwrapped?: boolean }>;
 }
 
 export const GuiComponentContext = React.createContext<GuiComponentContext>({

--- a/src/viser/client/src/ControlPanel/GuiState.ts
+++ b/src/viser/client/src/ControlPanel/GuiState.ts
@@ -21,6 +21,10 @@ export interface GuiState {
   };
   modals: GuiModalMessage[];
   guiOrderFromUuid: { [id: string]: number };
+  /** Monotonic submit counter per form UUID. Incremented on any incoming
+   * GuiFormSubmitMessage. Form components use this to reset their dirty
+   * indicator. */
+  guiFormSubmitCountFromUuid: { [uuid: string]: number };
   uploadsInProgress: {
     [uuid: string]: {
       notificationId: string;
@@ -46,6 +50,7 @@ export interface GuiActions {
       | GuiState["uploadsInProgress"][string]
     ) & { componentId: string },
   ) => void;
+  bumpFormSubmitCount: (uuid: string) => void;
 }
 
 const searchParams = new URLSearchParams(window.location.search);
@@ -70,6 +75,7 @@ const cleanGuiState: GuiState = {
   guiUuidSetFromContainerUuid: { root: {} },
   modals: [],
   guiOrderFromUuid: {},
+  guiFormSubmitCountFromUuid: {},
   uploadsInProgress: {},
 };
 
@@ -180,6 +186,9 @@ export function useGuiState(initialServer: string) {
         }
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { [id]: _2, ...remainingOrders } = store.get().guiOrderFromUuid;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { [id]: _3, ...remainingSubmitCounts } =
+          store.get().guiFormSubmitCountFromUuid;
         const containerUuid = guiConfig.container_uuid;
         const containerSet = {
           ...store.get().guiUuidSetFromContainerUuid[containerUuid],
@@ -195,6 +204,7 @@ export function useGuiState(initialServer: string) {
         }
         store.set({
           guiOrderFromUuid: remainingOrders,
+          guiFormSubmitCountFromUuid: remainingSubmitCounts,
           guiUuidSetFromContainerUuid: newContainerMap,
         });
         configStore.set({ [id]: undefined });
@@ -208,6 +218,7 @@ export function useGuiState(initialServer: string) {
             cleanGuiState.guiUuidSetFromContainerUuid,
           modals: cleanGuiState.modals,
           guiOrderFromUuid: cleanGuiState.guiOrderFromUuid,
+          guiFormSubmitCountFromUuid: cleanGuiState.guiFormSubmitCountFromUuid,
           uploadsInProgress: cleanGuiState.uploadsInProgress,
         });
         configStore.setAll({}, true);
@@ -224,6 +235,14 @@ export function useGuiState(initialServer: string) {
             },
           },
         });
+      },
+      bumpFormSubmitCount: (uuid) => {
+        store.set((state) => ({
+          guiFormSubmitCountFromUuid: {
+            ...state.guiFormSubmitCountFromUuid,
+            [uuid]: (state.guiFormSubmitCountFromUuid[uuid] ?? 0) + 1,
+          },
+        }));
       },
       updateGuiProps: (id, updates) => {
         const config = configStore.get(id);

--- a/src/viser/client/src/ControlPanel/GuiState.ts
+++ b/src/viser/client/src/ControlPanel/GuiState.ts
@@ -21,10 +21,9 @@ export interface GuiState {
   };
   modals: GuiModalMessage[];
   guiOrderFromUuid: { [id: string]: number };
-  /** Monotonic submit counter per form UUID. Incremented on any incoming
-   * GuiFormSubmitMessage. Form components use this to reset their dirty
-   * indicator. */
-  guiFormSubmitCountFromUuid: { [uuid: string]: number };
+  /** Set of form UUIDs that currently have unsaved changes. Updated by
+   * GuiFormDirtyMessage (adds) and GuiFormSubmitMessage (removes). */
+  dirtyFormUuids: { [uuid: string]: true | undefined };
   uploadsInProgress: {
     [uuid: string]: {
       notificationId: string;
@@ -50,7 +49,8 @@ export interface GuiActions {
       | GuiState["uploadsInProgress"][string]
     ) & { componentId: string },
   ) => void;
-  bumpFormSubmitCount: (uuid: string) => void;
+  setFormDirty: (uuid: string) => void;
+  clearFormDirty: (uuid: string) => void;
 }
 
 const searchParams = new URLSearchParams(window.location.search);
@@ -75,7 +75,7 @@ const cleanGuiState: GuiState = {
   guiUuidSetFromContainerUuid: { root: {} },
   modals: [],
   guiOrderFromUuid: {},
-  guiFormSubmitCountFromUuid: {},
+  dirtyFormUuids: {},
   uploadsInProgress: {},
 };
 
@@ -186,9 +186,8 @@ export function useGuiState(initialServer: string) {
         }
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { [id]: _2, ...remainingOrders } = store.get().guiOrderFromUuid;
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { [id]: _3, ...remainingSubmitCounts } =
-          store.get().guiFormSubmitCountFromUuid;
+        const dirtyFormUuids = { ...store.get().dirtyFormUuids };
+        delete dirtyFormUuids[id];
         const containerUuid = guiConfig.container_uuid;
         const containerSet = {
           ...store.get().guiUuidSetFromContainerUuid[containerUuid],
@@ -204,7 +203,7 @@ export function useGuiState(initialServer: string) {
         }
         store.set({
           guiOrderFromUuid: remainingOrders,
-          guiFormSubmitCountFromUuid: remainingSubmitCounts,
+          dirtyFormUuids,
           guiUuidSetFromContainerUuid: newContainerMap,
         });
         configStore.set({ [id]: undefined });
@@ -218,7 +217,7 @@ export function useGuiState(initialServer: string) {
             cleanGuiState.guiUuidSetFromContainerUuid,
           modals: cleanGuiState.modals,
           guiOrderFromUuid: cleanGuiState.guiOrderFromUuid,
-          guiFormSubmitCountFromUuid: cleanGuiState.guiFormSubmitCountFromUuid,
+          dirtyFormUuids: cleanGuiState.dirtyFormUuids,
           uploadsInProgress: cleanGuiState.uploadsInProgress,
         });
         configStore.setAll({}, true);
@@ -236,13 +235,17 @@ export function useGuiState(initialServer: string) {
           },
         });
       },
-      bumpFormSubmitCount: (uuid) => {
+      setFormDirty: (uuid) => {
         store.set((state) => ({
-          guiFormSubmitCountFromUuid: {
-            ...state.guiFormSubmitCountFromUuid,
-            [uuid]: (state.guiFormSubmitCountFromUuid[uuid] ?? 0) + 1,
-          },
+          dirtyFormUuids: { ...state.dirtyFormUuids, [uuid]: true },
         }));
+      },
+      clearFormDirty: (uuid) => {
+        store.set((state) => {
+          const next = { ...state.dirtyFormUuids };
+          delete next[uuid];
+          return { dirtyFormUuids: next };
+        });
       },
       updateGuiProps: (id, updates) => {
         const config = configStore.get(id);

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -41,7 +41,8 @@ function useMessageHandler() {
   const removeModal = viewer.guiActions.removeModal;
   const removeGui = viewer.guiActions.removeGui;
   const updateUploadState = viewer.guiActions.updateUploadState;
-  const bumpFormSubmitCount = viewer.guiActions.bumpFormSubmitCount;
+  const setFormDirty = viewer.guiActions.setFormDirty;
+  const clearFormDirty = viewer.guiActions.clearFormDirty;
 
   // Same as addSceneNode, but make a parent in the form of a dummy coordinate
   // frame if it doesn't exist yet.
@@ -561,7 +562,12 @@ function useMessageHandler() {
       }
       // Broadcast to clients that a form was submitted; reset dirty state.
       case "GuiFormSubmitMessage": {
-        bumpFormSubmitCount(message.uuid);
+        clearFormDirty(message.uuid);
+        return;
+      }
+      // Broadcast to clients that a form has unsaved changes.
+      case "GuiFormDirtyMessage": {
+        setFormDirty(message.uuid);
         return;
       }
 

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -41,6 +41,7 @@ function useMessageHandler() {
   const removeModal = viewer.guiActions.removeModal;
   const removeGui = viewer.guiActions.removeGui;
   const updateUploadState = viewer.guiActions.updateUploadState;
+  const bumpFormSubmitCount = viewer.guiActions.bumpFormSubmitCount;
 
   // Same as addSceneNode, but make a parent in the form of a dummy coordinate
   // frame if it doesn't exist yet.
@@ -556,6 +557,11 @@ function useMessageHandler() {
       // Remove a GUI input.
       case "GuiRemoveMessage": {
         removeGui(message.uuid);
+        return;
+      }
+      // Broadcast to clients that a form was submitted; reset dirty state.
+      case "GuiFormSubmitMessage": {
+        bumpFormSubmitCount(message.uuid);
         return;
       }
 

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -1438,6 +1438,17 @@ export interface GuiFormSubmitMessage {
   type: "GuiFormSubmitMessage";
   uuid: string;
 }
+/** Bidirectional form dirty signal.
+ *
+ * - Sent client->server when any input inside the form first changes since
+ *   the last submit. The server broadcasts this to all other clients.
+ * - Sent server->client (broadcast) to propagate dirty state. Clients show
+ *   a dirty indicator on the form header on receipt.
+ */
+export interface GuiFormDirtyMessage {
+  type: "GuiFormDirtyMessage";
+  uuid: string;
+}
 /** GuiModalMessage(order: 'float', uuid: 'str', title: 'str')
  *
  * (automatically generated)
@@ -1714,6 +1725,7 @@ export type Message =
   | SceneNodeClickMessage
   | ResetGuiMessage
   | GuiFormSubmitMessage
+  | GuiFormDirtyMessage
   | GuiModalMessage
   | GuiCloseModalMessage
   | GuiButtonHoldMessage

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -503,7 +503,26 @@ export interface GuiFolderMessage {
   container_uuid: string;
   props: {
     order: number;
-    label: string;
+    label: string | null;
+    visible: boolean;
+    expand_by_default: boolean;
+  };
+}
+/** A form is a folder whose children's values can be committed together.
+ *
+ * Reuses ``GuiFolderProps`` because the visual shape is identical to a
+ * folder; the form-specific behavior (``on_submit`` callbacks, dirty
+ * indicator, Cmd/Ctrl+Enter) is keyed off the message type alone.
+ *
+ * (automatically generated)
+ */
+export interface GuiFormMessage {
+  type: "GuiFormMessage";
+  uuid: string;
+  container_uuid: string;
+  props: {
+    order: number;
+    label: string | null;
     visible: boolean;
     expand_by_default: boolean;
   };
@@ -1404,6 +1423,21 @@ export interface SceneNodeClickMessage {
 export interface ResetGuiMessage {
   type: "ResetGuiMessage";
 }
+/** Bidirectional form submit signal.
+ *
+ * - Sent client->server when the user presses Cmd/Ctrl+Enter inside a form.
+ * The server fires the form's ``on_submit`` callbacks and broadcasts this
+ * message to all clients.
+ * - Sent server->client (broadcast) after any submit (client-initiated or
+ * via Python ``form.submit()``). Clients clear their dirty indicator on
+ * receipt.
+ *
+ * (automatically generated)
+ */
+export interface GuiFormSubmitMessage {
+  type: "GuiFormSubmitMessage";
+  uuid: string;
+}
 /** GuiModalMessage(order: 'float', uuid: 'str', title: 'str')
  *
  * (automatically generated)
@@ -1630,6 +1664,7 @@ export type Message =
   | GaussianSplatsMessage
   | RemoveSceneNodeMessage
   | GuiFolderMessage
+  | GuiFormMessage
   | GuiMarkdownMessage
   | GuiHtmlMessage
   | GuiProgressBarMessage
@@ -1678,6 +1713,7 @@ export type Message =
   | SetSceneNodeClickableMessage
   | SceneNodeClickMessage
   | ResetGuiMessage
+  | GuiFormSubmitMessage
   | GuiModalMessage
   | GuiCloseModalMessage
   | GuiButtonHoldMessage
@@ -1724,6 +1760,7 @@ export type SceneNodeMessage =
   | GaussianSplatsMessage;
 export type GuiComponentMessage =
   | GuiFolderMessage
+  | GuiFormMessage
   | GuiMarkdownMessage
   | GuiHtmlMessage
   | GuiProgressBarMessage
@@ -1780,6 +1817,7 @@ export function isSceneNodeMessage(
 }
 const typeSetGuiComponentMessage = new Set([
   "GuiFolderMessage",
+  "GuiFormMessage",
   "GuiMarkdownMessage",
   "GuiHtmlMessage",
   "GuiProgressBarMessage",

--- a/src/viser/client/src/components/Folder.tsx
+++ b/src/viser/client/src/components/Folder.tsx
@@ -25,8 +25,24 @@ export default function FolderComponent({
     nextGuiUuid == null ? null : (conf?.type ?? null),
   );
 
-  const ToggleIcon = opened ? IconChevronUp : IconChevronDown;
   if (!visible) return null;
+
+  // No label: render children only, no header/border/collapse. Use
+  // `unwrapped` so we don't introduce extra padding above the first child.
+  if (label === null) {
+    return (
+      <GuiComponentContext.Provider
+        value={{
+          ...guiContext,
+          folderDepth: guiContext.folderDepth + 1,
+        }}
+      >
+        <guiContext.GuiContainer containerUuid={uuid} unwrapped />
+      </GuiComponentContext.Provider>
+    );
+  }
+
+  const ToggleIcon = opened ? IconChevronUp : IconChevronDown;
   return (
     <Paper
       withBorder

--- a/src/viser/client/src/components/Folder.tsx
+++ b/src/viser/client/src/components/Folder.tsx
@@ -47,7 +47,7 @@ export default function FolderComponent({
     <Paper
       withBorder
       className={folderWrapper}
-      mb={nextGuiType === "GuiFolderMessage" ? "md" : undefined}
+      mb={nextGuiType === "GuiFolderMessage" || nextGuiType === "GuiFormMessage" ? "md" : undefined}
     >
       <Paper
         className={folderLabel}

--- a/src/viser/client/src/components/Form.tsx
+++ b/src/viser/client/src/components/Form.tsx
@@ -1,0 +1,122 @@
+import * as React from "react";
+import { useDisclosure } from "@mantine/hooks";
+import { GuiFormMessage } from "../WebsocketMessages";
+import { IconChevronDown, IconChevronUp } from "@tabler/icons-react";
+import { Box, Collapse, Paper, Tooltip } from "@mantine/core";
+import { GuiComponentContext } from "../ControlPanel/GuiComponentContext";
+import { ViewerContext } from "../ViewerContext";
+import { folderLabel, folderToggleIcon, folderWrapper } from "./Folder.css";
+import { shallowObjectKeysEqual } from "../utils/shallowObjectKeysEqual";
+
+/** A form: a folder whose contents can be committed together.
+ *
+ * Children are wrapped in a native `<form>` element so the browser handles
+ * implicit Enter submission for single-line inputs. The hidden submit button
+ * below is required because HTML only guarantees implicit submission when
+ * the form has a submit button or exactly one text input — otherwise
+ * multi-input forms would not submit on Enter.
+ */
+export default function FormComponent({
+  uuid,
+  props: { label, visible, expand_by_default },
+  nextGuiUuid,
+}: GuiFormMessage & { nextGuiUuid: string | null }) {
+  const viewer = React.useContext(ViewerContext)!;
+  const guiContext = React.useContext(GuiComponentContext)!;
+  const [opened, { toggle }] = useDisclosure(expand_by_default);
+  const [isDirty, setIsDirty] = React.useState(false);
+
+  const guiIdSet = viewer.useGui(
+    (state) => state.guiUuidSetFromContainerUuid[uuid],
+    shallowObjectKeysEqual,
+  );
+  const nextGuiType = viewer.useGuiConfig(nextGuiUuid ?? "", (conf) =>
+    nextGuiUuid == null ? null : (conf?.type ?? null),
+  );
+
+  const submitCount = viewer.useGui(
+    (state) => state.guiFormSubmitCountFromUuid[uuid] ?? 0,
+  );
+  React.useEffect(() => {
+    setIsDirty(false);
+  }, [submitCount]);
+
+  const messageSender = guiContext.messageSender;
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    messageSender({ type: "GuiFormSubmitMessage", uuid });
+  };
+
+  const onChangeAny = () => {
+    if (!isDirty) setIsDirty(true);
+  };
+
+  if (!visible) return null;
+
+  const isEmpty = guiIdSet === undefined || Object.keys(guiIdSet).length === 0;
+
+  const hiddenSubmitButton = <button type="submit" hidden tabIndex={-1} />;
+
+  const innerFormContents = (unwrapped: boolean) => (
+    <GuiComponentContext.Provider
+      value={{
+        ...guiContext,
+        folderDepth: guiContext.folderDepth + 1,
+      }}
+    >
+      <guiContext.GuiContainer containerUuid={uuid} unwrapped={unwrapped} />
+    </GuiComponentContext.Provider>
+  );
+
+  if (label === null) {
+    return (
+      <form onSubmit={handleSubmit} onChange={onChangeAny}>
+        {hiddenSubmitButton}
+        {innerFormContents(true)}
+      </form>
+    );
+  }
+
+  const ToggleIcon = opened ? IconChevronUp : IconChevronDown;
+  return (
+    <Paper
+      component="form"
+      withBorder
+      className={folderWrapper}
+      mb={nextGuiType === "GuiFormMessage" ? "md" : undefined}
+      onSubmit={handleSubmit}
+      onChange={onChangeAny}
+    >
+      {hiddenSubmitButton}
+      <Tooltip
+        label="Contains unsubmitted changes."
+        withArrow
+        openDelay={300}
+        disabled={!isDirty}
+      >
+        <Paper
+          className={folderLabel}
+          style={{
+            cursor: isEmpty ? undefined : "pointer",
+          }}
+          onClick={toggle}
+        >
+          {label}
+          {isDirty ? <span style={{ opacity: 0.5 }}>*</span> : null}
+          <ToggleIcon
+            className={folderToggleIcon}
+            style={{
+              display: isEmpty ? "none" : undefined,
+            }}
+          />
+        </Paper>
+      </Tooltip>
+      <Collapse in={opened && !isEmpty}>
+        <Box pt="0.2em">{innerFormContents(false)}</Box>
+      </Collapse>
+      <Collapse in={!(opened && !isEmpty)}>
+        <Box p="xs"></Box>
+      </Collapse>
+    </Paper>
+  );
+}

--- a/src/viser/client/src/components/Form.tsx
+++ b/src/viser/client/src/components/Form.tsx
@@ -24,7 +24,7 @@ export default function FormComponent({
   const viewer = React.useContext(ViewerContext)!;
   const guiContext = React.useContext(GuiComponentContext)!;
   const [opened, { toggle }] = useDisclosure(expand_by_default);
-  const [isDirty, setIsDirty] = React.useState(false);
+  const isDirty = viewer.useGui((state) => state.dirtyFormUuids[uuid] === true);
 
   const guiIdSet = viewer.useGui(
     (state) => state.guiUuidSetFromContainerUuid[uuid],
@@ -34,13 +34,7 @@ export default function FormComponent({
     nextGuiUuid == null ? null : (conf?.type ?? null),
   );
 
-  const submitCount = viewer.useGui(
-    (state) => state.guiFormSubmitCountFromUuid[uuid] ?? 0,
-  );
-  React.useEffect(() => {
-    setIsDirty(false);
-  }, [submitCount]);
-
+  const setFormDirty = viewer.guiActions.setFormDirty;
   const messageSender = guiContext.messageSender;
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -48,7 +42,10 @@ export default function FormComponent({
   };
 
   const onChangeAny = () => {
-    if (!isDirty) setIsDirty(true);
+    if (!isDirty) {
+      setFormDirty(uuid);
+      messageSender({ type: "GuiFormDirtyMessage", uuid });
+    }
   };
 
   if (!visible) return null;

--- a/src/viser/client/src/components/Form.tsx
+++ b/src/viser/client/src/components/Form.tsx
@@ -83,7 +83,7 @@ export default function FormComponent({
       component="form"
       withBorder
       className={folderWrapper}
-      mb={nextGuiType === "GuiFormMessage" ? "md" : undefined}
+      mb={nextGuiType === "GuiFolderMessage" || nextGuiType === "GuiFormMessage" ? "md" : undefined}
       onSubmit={handleSubmit}
       onChange={onChangeAny}
     >

--- a/src/viser/client/src/components/TextInput.tsx
+++ b/src/viser/client/src/components/TextInput.tsx
@@ -7,48 +7,19 @@ import { GuiComponentContext } from "../ControlPanel/GuiComponentContext";
 export default function TextInputComponent({
   uuid,
   value,
-  props: { hint, label, disabled, visible, multiline, update_on },
+  props: { hint, label, disabled, visible, multiline },
 }: GuiTextMessage) {
   const { setValue } = React.useContext(GuiComponentContext)!;
-  const [localValue, setLocalValue] = React.useState(value);
-
-  // Sync local value when server pushes a new value.
-  React.useEffect(() => {
-    setLocalValue(value);
-  }, [value]);
-
-  const submitMode = update_on === "submit";
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const newValue = e.target.value;
-    setLocalValue(newValue);
-    if (!submitMode) {
-      setValue(uuid, newValue);
-    }
-  };
-
-  const handleSubmit = () => {
-    if (submitMode) {
-      setValue(uuid, localValue);
-    }
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (submitMode && e.key === "Enter" && !multiline) {
-      setValue(uuid, localValue);
-    }
-  };
-
   if (!visible) return null;
   return (
     <ViserInputComponent {...{ uuid, hint, label }}>
       {multiline ? (
         <Textarea
-          value={localValue}
+          value={value}
           size="xs"
-          onChange={handleChange}
-          onBlur={handleSubmit}
-          onKeyDown={handleKeyDown}
+          onChange={(value) => {
+            setValue(uuid, value.target.value);
+          }}
           styles={{
             input: {
               padding: "0 0.5em",
@@ -62,11 +33,11 @@ export default function TextInputComponent({
         />
       ) : (
         <TextInput
-          value={localValue}
+          value={value}
           size="xs"
-          onChange={handleChange}
-          onBlur={handleSubmit}
-          onKeyDown={handleKeyDown}
+          onChange={(value) => {
+            setValue(uuid, value.target.value);
+          }}
           styles={{
             input: {
               minHeight: "1.625rem",

--- a/src/viser/client/src/components/TextInput.tsx
+++ b/src/viser/client/src/components/TextInput.tsx
@@ -7,19 +7,48 @@ import { GuiComponentContext } from "../ControlPanel/GuiComponentContext";
 export default function TextInputComponent({
   uuid,
   value,
-  props: { hint, label, disabled, visible, multiline },
+  props: { hint, label, disabled, visible, multiline, update_on },
 }: GuiTextMessage) {
   const { setValue } = React.useContext(GuiComponentContext)!;
+  const [localValue, setLocalValue] = React.useState(value);
+
+  // Sync local value when server pushes a new value.
+  React.useEffect(() => {
+    setLocalValue(value);
+  }, [value]);
+
+  const submitMode = update_on === "submit";
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const newValue = e.target.value;
+    setLocalValue(newValue);
+    if (!submitMode) {
+      setValue(uuid, newValue);
+    }
+  };
+
+  const handleSubmit = () => {
+    if (submitMode) {
+      setValue(uuid, localValue);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (submitMode && e.key === "Enter" && !multiline) {
+      setValue(uuid, localValue);
+    }
+  };
+
   if (!visible) return null;
   return (
     <ViserInputComponent {...{ uuid, hint, label }}>
       {multiline ? (
         <Textarea
-          value={value}
+          value={localValue}
           size="xs"
-          onChange={(value) => {
-            setValue(uuid, value.target.value);
-          }}
+          onChange={handleChange}
+          onBlur={handleSubmit}
+          onKeyDown={handleKeyDown}
           styles={{
             input: {
               padding: "0 0.5em",
@@ -33,11 +62,11 @@ export default function TextInputComponent({
         />
       ) : (
         <TextInput
-          value={value}
+          value={localValue}
           size="xs"
-          onChange={(value) => {
-            setValue(uuid, value.target.value);
-          }}
+          onChange={handleChange}
+          onBlur={handleSubmit}
+          onKeyDown={handleKeyDown}
           styles={{
             input: {
               minHeight: "1.625rem",

--- a/tests/e2e/test_multi_client.py
+++ b/tests/e2e/test_multi_client.py
@@ -148,6 +148,161 @@ def test_scene_update_visible_to_both(multi_client_setup: dict) -> None:
         wait_for_scene_node_removed(page, "/multi_box")
 
 
+def test_form_dirty_shows_on_sender(multi_client_setup: dict) -> None:
+    """The client that types should see the dirty indicator itself."""
+    server: viser.ViserServer = multi_client_setup["server"]
+    page1: Page = multi_client_setup["page1"]
+
+    with server.gui.add_form("Profile") as form:
+        server.gui.add_text("Name", initial_value="")
+
+    dirty_indicator = page1.locator("span[style*='opacity']", has_text="*")
+    expect(dirty_indicator).to_be_hidden(timeout=5_000)
+
+    input1 = find_gui_input(page1, "Name")
+    expect(input1).to_be_visible(timeout=5_000)
+    input1.fill("alice")
+    expect(dirty_indicator).to_be_visible(timeout=5_000)
+
+    form.submit()
+    expect(dirty_indicator).to_be_hidden(timeout=5_000)
+
+    # Must reappear after a second round of edits.
+    input1.fill("bob")
+    expect(dirty_indicator).to_be_visible(timeout=5_000)
+
+
+def test_form_dirty_syncs_to_peer(multi_client_setup: dict) -> None:
+    """Typing in a form on page1 should show the dirty indicator on page2."""
+    server: viser.ViserServer = multi_client_setup["server"]
+    page1: Page = multi_client_setup["page1"]
+    page2: Page = multi_client_setup["page2"]
+
+    with server.gui.add_form("Profile"):
+        server.gui.add_text("Name", initial_value="")
+
+    dirty_indicator = page2.locator("span[style*='opacity']", has_text="*")
+    expect(dirty_indicator).to_be_hidden(timeout=5_000)
+
+    input1 = find_gui_input(page1, "Name")
+    expect(input1).to_be_visible(timeout=5_000)
+    input1.fill("alice")
+
+    expect(dirty_indicator).to_be_visible(timeout=5_000)
+
+
+def test_form_dirty_clears_on_submit_to_peer(multi_client_setup: dict) -> None:
+    """Submitting a form on page1 should clear the dirty indicator on page2."""
+    server: viser.ViserServer = multi_client_setup["server"]
+    page1: Page = multi_client_setup["page1"]
+    page2: Page = multi_client_setup["page2"]
+
+    with server.gui.add_form("Profile") as form:
+        server.gui.add_text("Name", initial_value="")
+
+    input1 = find_gui_input(page1, "Name")
+    expect(input1).to_be_visible(timeout=5_000)
+    input1.fill("alice")
+
+    dirty_indicator = page2.locator("span[style*='opacity']", has_text="*")
+    expect(dirty_indicator).to_be_visible(timeout=5_000)
+
+    form.submit()
+
+    expect(dirty_indicator).to_be_hidden(timeout=5_000)
+
+
+def test_late_joining_client_sees_dirty_form(browser: Browser) -> None:
+    """A client joining after a form is made dirty should see the dirty indicator."""
+    viser._client_autobuild.ensure_client_is_built = lambda: None
+
+    port = find_free_port()
+    max_retries = 3
+    server: viser.ViserServer | None = None
+    for attempt in range(max_retries):
+        port = find_free_port()
+        try:
+            server = viser.ViserServer(port=port, verbose=False)
+            break
+        except OSError:
+            if attempt == max_retries - 1:
+                raise
+    assert server is not None
+    wait_for_server_ready(port)
+
+    with server.gui.add_form("Settings"):
+        server.gui.add_text("Username", initial_value="")
+
+    context1 = browser.new_context()
+    page1 = context1.new_page()
+    wait_for_connection(page1, port)
+
+    input1 = find_gui_input(page1, "Username")
+    expect(input1).to_be_visible(timeout=5_000)
+    input1.fill("bob")
+
+    # Late-joining client connects after the form is already dirty.
+    context2 = browser.new_context()
+    page2 = context2.new_page()
+    wait_for_connection(page2, port)
+
+    dirty_indicator = page2.locator("span[style*='opacity']", has_text="*")
+    expect(dirty_indicator).to_be_visible(timeout=5_000)
+
+    context1.close()
+    context2.close()
+    server.stop()
+
+
+def test_per_client_form_dirty_is_isolated(browser: Browser) -> None:
+    """Dirty state on a per-client form should not bleed to other clients."""
+    viser._client_autobuild.ensure_client_is_built = lambda: None
+
+    port = find_free_port()
+    max_retries = 3
+    server: viser.ViserServer | None = None
+    for attempt in range(max_retries):
+        port = find_free_port()
+        try:
+            server = viser.ViserServer(port=port, verbose=False)
+            break
+        except OSError:
+            if attempt == max_retries - 1:
+                raise
+    assert server is not None
+
+    @server.on_client_connect
+    def _(client: viser.ClientHandle) -> None:
+        with client.gui.add_form("Per-client Form"):
+            client.gui.add_text("Note", initial_value="")
+
+    wait_for_server_ready(port)
+
+    context1 = browser.new_context()
+    context2 = browser.new_context()
+    page1 = context1.new_page()
+    page2 = context2.new_page()
+    wait_for_connection(page1, port)
+    wait_for_connection(page2, port)
+
+    # Both clients have their own independent form.
+    input1 = find_gui_input(page1, "Note")
+    input2 = find_gui_input(page2, "Note")
+    expect(input1).to_be_visible(timeout=5_000)
+    expect(input2).to_be_visible(timeout=5_000)
+
+    # Client 1 edits -- only its own dirty indicator should appear.
+    input1.fill("hello")
+    dirty1 = page1.locator("span[style*='opacity']", has_text="*")
+    dirty2 = page2.locator("span[style*='opacity']", has_text="*")
+    expect(dirty1).to_be_visible(timeout=5_000)
+    expect(dirty2).to_be_hidden(timeout=2_000)
+
+    context1.close()
+    context2.close()
+    server.stop()
+
+
 def test_late_joining_client_sees_state(browser: Browser) -> None:
     """A client joining after GUI/scene elements are added should see them."""
     viser._client_autobuild.ensure_client_is_built = lambda: None

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -1,0 +1,105 @@
+from unittest.mock import patch
+
+import viser
+import viser._client_autobuild
+
+
+@patch.object(viser._client_autobuild, "ensure_client_is_built", lambda: None)
+def test_form_submit_fires_callback() -> None:
+    """Calling form.submit() should fire all registered on_submit callbacks."""
+    server = viser.ViserServer()
+
+    with server.gui.add_form("Profile") as form:
+        name = server.gui.add_text("Name", initial_value="")
+        age = server.gui.add_number("Age", initial_value=0)
+
+    calls: list[tuple[str, int]] = []
+
+    @form.on_submit
+    def _(_) -> None:
+        calls.append((name.value, age.value))
+
+    # Simulate some edits (as if the client sent GuiUpdateMessages).
+    name.value = "alice"
+    age.value = 30
+
+    form.submit()
+    assert calls == [("alice", 30)]
+
+    # Submitting again should fire again with the current state.
+    name.value = "bob"
+    form.submit()
+    assert calls == [("alice", 30), ("bob", 30)]
+
+
+@patch.object(viser._client_autobuild, "ensure_client_is_built", lambda: None)
+def test_form_child_on_update_not_suppressed() -> None:
+    """on_update callbacks on form children fire as normal (forms are additive)."""
+    server = viser.ViserServer()
+
+    with server.gui.add_form("Quiz") as form:
+        text = server.gui.add_text("Answer", initial_value="")
+
+    keystrokes: list[str] = []
+
+    @text.on_update
+    def _(_) -> None:
+        keystrokes.append(text.value)
+
+    text.value = "hello"
+    assert keystrokes == ["hello"]
+
+    form.submit()
+    # form.submit() does not re-fire on_update for children.
+    assert keystrokes == ["hello"]
+
+
+@patch.object(viser._client_autobuild, "ensure_client_is_built", lambda: None)
+def test_nested_forms_raise() -> None:
+    """Nested forms would produce invalid HTML on the client."""
+    import pytest
+
+    server = viser.ViserServer()
+    with server.gui.add_form("Outer"):
+        with pytest.raises(ValueError, match="Nested forms"):
+            with server.gui.add_form("Inner"):
+                pass
+
+    # A form inside a folder inside a form should also raise.
+    with server.gui.add_form("Outer2"):
+        with server.gui.add_folder("Middle"):
+            with pytest.raises(ValueError, match="Nested forms"):
+                with server.gui.add_form("Inner2"):
+                    pass
+
+
+@patch.object(viser._client_autobuild, "ensure_client_is_built", lambda: None)
+def test_remove_submit_callback() -> None:
+    """remove_submit_callback should support 'all' and specific callbacks."""
+    server = viser.ViserServer()
+
+    with server.gui.add_form("F") as form:
+        pass
+
+    calls: list[int] = []
+
+    def cb1(_):
+        calls.append(1)
+
+    def cb2(_):
+        calls.append(2)
+
+    form.on_submit(cb1)
+    form.on_submit(cb2)
+    form.submit()
+    assert calls == [1, 2]
+
+    form.remove_submit_callback(cb1)
+    calls.clear()
+    form.submit()
+    assert calls == [2]
+
+    form.remove_submit_callback("all")
+    calls.clear()
+    form.submit()
+    assert calls == []


### PR DESCRIPTION
Introduces `add_form()` for grouping GUI controls with explicit submit semantics.

A form is like a folder whose contents can be committed together. The form tracks a "dirty" state in the UI and highlights when any descendant input has been edited since the last submit. Submission is triggered by pressing Enter in a single-line text input inside the form, or programmatically via `form.submit()`.

```python
with server.gui.add_form("User Info") as form:
	name = server.gui.add_text("Name", initial_value="")
	age = server.gui.add_number("Age", 0)
	save = server.gui.add_button("Save")

save.on_click(lambda _: form.submit())

# on_update fires on every keystroke (as normal)
@name.on_update
def _(event):
	print(f"Name so far: {event.target.value}")

# on_submit when the save button is pressed, or if the users hits Enter
@form.on_submit
def _(event):
  print(f"Submitted: {name.value}, {age.value}")
```

Nested forms are not supported and raise ValueError.

Closes #681
