### PR TITLE
add_plotly: expose config dict parameter

### DIFF
--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -790,6 +790,7 @@ class GuiApi:
         self,
         figure: go.Figure,
         *,
+        config: dict[str, Any] | None = None,
         aspect: float = 1.0,
         order: float | None = None,
         visible: bool = True,
@@ -803,6 +804,9 @@ class GuiApi:
 
         Args:
             figure: Plotly figure to display.
+            config: Plotly config dict merged into the figure JSON. Controls
+                display options like ``{"displayModeBar": False}``. See
+                https://plotly.com/javascript/configuration-options/
             aspect: Aspect ratio of the plot in the control panel (width/height).
             order: Optional ordering, smallest values will be displayed first.
             visible: Whether the component is visible.
@@ -862,6 +866,7 @@ class GuiApi:
                 parent_container_id=message.container_uuid,
             ),
             _figure=figure,
+            _config=config,
         )
 
         # Set the plotly handle properties.

--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -8,6 +8,7 @@ import functools
 import threading
 import time
 from asyncio import AbstractEventLoop
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import (
@@ -790,7 +791,7 @@ class GuiApi:
         self,
         figure: go.Figure,
         *,
-        config: dict[str, Any] | None = None,
+        config: Mapping[str, Any] | None = None,
         aspect: float = 1.0,
         order: float | None = None,
         visible: bool = True,
@@ -805,7 +806,8 @@ class GuiApi:
         Args:
             figure: Plotly figure to display.
             config: Plotly config dict merged into the figure JSON. Controls
-                display options like ``{"displayModeBar": False}``. See
+                display options like ``{"displayModeBar": False}``. Values
+                must be JSON-serializable. See
                 https://plotly.com/javascript/configuration-options/
             aspect: Aspect ratio of the plot in the control panel (width/height).
             order: Optional ordering, smallest values will be displayed first.

--- a/src/viser/_gui_handles.py
+++ b/src/viser/_gui_handles.py
@@ -913,13 +913,19 @@ class GuiHtmlHandle(_GuiHandle[None], GuiHtmlProps):
 class GuiPlotlyHandle(_GuiHandle[None], GuiPlotlyProps):
     """Handle for updating and removing Plotly figures."""
 
-    def __init__(self, _impl: _GuiHandleState, _figure: go.Figure):
+    def __init__(
+        self,
+        _impl: _GuiHandleState,
+        _figure: go.Figure,
+        _config: dict | None = None,
+    ):
         super().__init__(impl=_impl)
         self._figure = _figure
+        self._config = _config
 
     @property
     def figure(self) -> go.Figure:
-        """Current content of this markdown element. Synchronized automatically when assigned."""
+        """Current Plotly figure. Synchronized automatically when assigned."""
         assert self._figure is not None
         return self._figure
 
@@ -927,9 +933,12 @@ class GuiPlotlyHandle(_GuiHandle[None], GuiPlotlyProps):
     def figure(self, figure: go.Figure) -> None:
         self._figure = figure
 
-        json_str = figure.to_json()
-        assert isinstance(json_str, str)
-        self._plotly_json_str = json_str
+        import json as json_mod
+
+        plot_dict = json_mod.loads(figure.to_json())
+        if self._config is not None:
+            plot_dict.setdefault("config", {}).update(self._config)
+        self._plotly_json_str = json_mod.dumps(plot_dict)
 
 
 class GuiUplotHandle(_GuiHandle[None], GuiUplotProps):

--- a/src/viser/_gui_handles.py
+++ b/src/viser/_gui_handles.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import base64
 import dataclasses
+import json
 import re
 import time
 import uuid
 import warnings
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Mapping
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -917,7 +918,7 @@ class GuiPlotlyHandle(_GuiHandle[None], GuiPlotlyProps):
         self,
         _impl: _GuiHandleState,
         _figure: go.Figure,
-        _config: dict | None = None,
+        _config: Mapping[str, Any] | None = None,
     ):
         super().__init__(impl=_impl)
         self._figure = _figure
@@ -932,13 +933,13 @@ class GuiPlotlyHandle(_GuiHandle[None], GuiPlotlyProps):
     @figure.setter
     def figure(self, figure: go.Figure) -> None:
         self._figure = figure
-
-        import json as json_mod
-
-        plot_dict = json_mod.loads(figure.to_json())
+        json_str = figure.to_json()
+        assert isinstance(json_str, str)
         if self._config is not None:
-            plot_dict.setdefault("config", {}).update(self._config)
-        self._plotly_json_str = json_mod.dumps(plot_dict)
+            plot_dict = json.loads(json_str)
+            plot_dict["config"] = {**plot_dict.get("config", {}), **self._config}
+            json_str = json.dumps(plot_dict)
+        self._plotly_json_str = json_str
 
 
 class GuiUplotHandle(_GuiHandle[None], GuiUplotProps):


### PR DESCRIPTION
## Summary
Adds optional `config` parameter to `add_plotly()`. The dict is merged into the figure JSON before sending to the client.

```python
handle = gui.add_plotly(fig, config={"displayModeBar": False, "scrollZoom": True})
```

The config is applied on every `handle.figure = ...` update, so it persists across figure changes.

The client already passes `plotJson.config` to `Plotly.react()` — this just makes it easy to set from the server side without modifying the figure object.

Closes #683