### PR TITLE
Add shading to point clouds, faster Record3D example

### DIFF
--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -475,6 +475,10 @@ class PointCloudProps:
     scale: Union[float, Tuple[float, float, float]] = 1.0
     """Scale of the point cloud. A single float for uniform scaling or a
     tuple of (x, y, z) for per-axis scaling."""
+    point_shading: Literal["flat", "gradient"] = "gradient"
+    """Shading mode for points. "flat" renders each point as a solid color.
+    "gradient" adds a center-to-edge shading effect: lighter in the center,
+    original color at the midpoint, darker at the edges."""
 
     def __post_init__(self):
         # Check shapes.

--- a/src/viser/_scene_api.py
+++ b/src/viser/_scene_api.py
@@ -1396,6 +1396,7 @@ class SceneApi:
         ] = "square",
         precision: Literal["float16", "float32"] = "float16",
         scale: float | tuple[float, float, float] = 1.0,
+        point_shading: Literal["flat", "gradient"] = "gradient",
         wxyz: tuple[float, float, float, float] | np.ndarray = (1.0, 0.0, 0.0, 0.0),
         position: tuple[float, float, float] | np.ndarray = (0.0, 0.0, 0.0),
         visible: bool = True,
@@ -1414,6 +1415,8 @@ class SceneApi:
                 will be cast to this precision.
             scale: Scale of the point cloud. A single float for uniform scaling
                 or a tuple of (x, y, z) for per-axis scaling.
+            point_shading: Shading mode for points. "flat" renders solid colors.
+                "gradient" adds center-to-edge shading for a sphere-like look.
             wxyz: Quaternion rotation to parent frame from local frame (R_pl).
             position: Translation to parent frame from local frame (t_pl).
             visible: Whether or not this scene node is initially visible.
@@ -1444,6 +1447,7 @@ class SceneApi:
                 point_shape=point_shape,
                 precision=precision,
                 scale=scale,
+                point_shading=point_shading,
             ),
         )
         return PointCloudHandle._make(self, message, name, wxyz, position, visible)

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -76,10 +76,10 @@ const PointCloudMaterial = /* @__PURE__ */ shaderMaterial(
           // perceptually smoother gradients.
           // t: 0 at center, 1 at edge.
           float t = min(length(gl_PointCoord - vec2(0.5)) / 1.414, 0.5) * 2.0;
-          vec3 lin = col * col;
-          vec3 outer_lin = lin * 0.85;
-          vec3 inner_lin = 1.0 - (1.0 - lin) * 0.95;
-          col = sqrt(t * outer_lin + (1.0 - t) * inner_lin);
+
+          // Shading curve: highlight center, darken edge.
+          float shade = 0.075 * (1.0 - 2.0 * t);
+          col = sqrt(clamp(col * col + shade, 0.0, 1.0));
       }
       gl_FragColor = vec4(col, 1.0);
       #include <fog_fragment>

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -63,25 +63,23 @@ const PointCloudMaterial = /* @__PURE__ */ shaderMaterial(
   #include <fog_pars_fragment>
 
   void main() {
-      float r = 0.0;
       if (point_ball_norm < 1000.0) {
-          r = pow(
+          float r = pow(
               pow(abs(gl_PointCoord.x - 0.5), point_ball_norm)
               + pow(abs(gl_PointCoord.y - 0.5), point_ball_norm),
               1.0 / point_ball_norm);
           if (r > 0.5) discard;
-      } else {
-          r = max(abs(gl_PointCoord.x - 0.5), abs(gl_PointCoord.y - 0.5));
       }
       vec3 col = vColor;
       if (point_shading_enabled > 0.5) {
-          // t: 0 at center, 1 at edge
-          float t = r * 2.0;
-          // Lighter in the center, original at midpoint, darker at edges.
-          // Asymmetric: lighten center more than we darken edges.
-          float s = 1.0 - 2.0 * t;
-          float shift = (0.06 + 0.02 * s) * s;
-          col = clamp(col + shift, 0.0, 1.0);
+          // Interpolation in approximate linear space (gamma 2.0) for
+          // perceptually smoother gradients.
+          // t: 0 at center, 1 at edge.
+          float t = min(length(gl_PointCoord - vec2(0.5)) / 1.414, 0.5) * 2.0;
+          vec3 lin = col * col;
+          vec3 outer_lin = lin * 0.85;
+          vec3 inner_lin = 1.0 - (1.0 - lin) * 0.98;
+          col = sqrt(t * outer_lin + (1.0 - t) * inner_lin);
       }
       gl_FragColor = vec4(col, 1.0);
       #include <fog_fragment>

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -78,7 +78,7 @@ const PointCloudMaterial = /* @__PURE__ */ shaderMaterial(
           float t = min(length(gl_PointCoord - vec2(0.5)) / 1.414, 0.5) * 2.0;
           vec3 lin = col * col;
           vec3 outer_lin = lin * 0.85;
-          vec3 inner_lin = 1.0 - (1.0 - lin) * 0.98;
+          vec3 inner_lin = 1.0 - (1.0 - lin) * 0.95;
           col = sqrt(t * outer_lin + (1.0 - t) * inner_lin);
       }
       gl_FragColor = vec4(col, 1.0);

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -24,6 +24,7 @@ const PointCloudMaterial = /* @__PURE__ */ shaderMaterial(
   {
     scale: 1.0,
     point_ball_norm: 0.0,
+    point_shading_enabled: 0.0,
     uniformColor: new THREE.Color(1, 1, 1),
     fogColor: new THREE.Color(1, 1, 1),
     fogNear: 0.0,
@@ -57,18 +58,32 @@ const PointCloudMaterial = /* @__PURE__ */ shaderMaterial(
   `varying vec3 vPosition;
   varying vec3 vColor;
   uniform float point_ball_norm;
+  uniform float point_shading_enabled;
 
   #include <fog_pars_fragment>
 
   void main() {
+      float r = 0.0;
       if (point_ball_norm < 1000.0) {
-          float r = pow(
+          r = pow(
               pow(abs(gl_PointCoord.x - 0.5), point_ball_norm)
               + pow(abs(gl_PointCoord.y - 0.5), point_ball_norm),
               1.0 / point_ball_norm);
           if (r > 0.5) discard;
+      } else {
+          r = max(abs(gl_PointCoord.x - 0.5), abs(gl_PointCoord.y - 0.5));
       }
-      gl_FragColor = vec4(vColor, 1.0);
+      vec3 col = vColor;
+      if (point_shading_enabled > 0.5) {
+          // t: 0 at center, 1 at edge
+          float t = r * 2.0;
+          // Lighter in the center, original at midpoint, darker at edges.
+          // Asymmetric: lighten center more than we darken edges.
+          float s = 1.0 - 2.0 * t;
+          float shift = (0.06 + 0.02 * s) * s;
+          col = clamp(col + shift, 0.0, 1.0);
+      }
+      gl_FragColor = vec4(col, 1.0);
       #include <fog_fragment>
   }
    `,
@@ -144,7 +159,9 @@ export const PointCloud = React.forwardRef<
       rounded: 3.0,
       sparkle: 0.6,
     }[props.point_shape];
-  }, [props.point_shape, material]);
+    material.uniforms.point_shading_enabled.value =
+      props.point_shading === "gradient" ? 1.0 : 0.0;
+  }, [props.point_shape, props.point_shading, material]);
 
   // Compute a scalar scale factor for point size. For non-uniform scale,
   // use geometric mean since points are rendered as circles.

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -151,6 +151,7 @@ export interface PointCloudMessage {
     point_shape: "square" | "diamond" | "circle" | "rounded" | "sparkle";
     precision: "float16" | "float32";
     scale: number | [number, number, number];
+    point_shading: "flat" | "gradient";
   };
 }
 /** Directional light message.

--- a/src/viser/extras/_record3d.py
+++ b/src/viser/extras/_record3d.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import dataclasses
 import json
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Tuple, cast
+from typing import Generator, Sequence, Tuple, cast
 
 import imageio.v3 as iio
 import numpy as np
@@ -62,6 +63,7 @@ class Record3dLoader:
         )
         T_world_cameras = (T_world_cameras @ np.diag([1, -1, -1, 1])).astype(np.float32)
 
+        self._data_dir = data_dir
         self.K = K
         self.fps = fps
         self.T_world_cameras = T_world_cameras
@@ -75,6 +77,27 @@ class Record3dLoader:
 
     def num_frames(self) -> int:
         return len(self.rgb_paths)
+
+    def get_frames(
+        self,
+        indices: Sequence[int],
+        *,
+        max_workers: int | None = None,
+    ) -> Generator[Record3dFrame, None, None]:
+        """Load multiple frames in parallel.
+
+        Args:
+            indices: Sequence of frame indices to load.
+            max_workers: Maximum number of worker threads. Defaults to
+                None (lets ThreadPoolExecutor choose).
+
+        Returns:
+            Generator of Record3dFrame objects, in the same order as indices.
+        """
+        # Threads are fine here because pyliblzfse should release the GIL, we
+        # can overlap with IO, etc..
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            yield from executor.map(self.get_frame, indices)
 
     def get_frame(self, index: int) -> Record3dFrame:
         # `pyliblzfse` can be hard to install on some Windows systems and is


### PR DESCRIPTION
New default is `point_shading="gradient"`:


<img width="1400" height="358" alt="image" src="https://github.com/user-attachments/assets/34d10185-e263-43fd-994a-d2e3d00f2356" />


---


Previous behavior is now `point_shading="flat"`:

<img width="1400" height="358" alt="image" src="https://github.com/user-attachments/assets/cc1a7ad9-f547-4d43-8ede-754de52c47bd" />
