### PR TITLE
Visual adjustments for tab handles

### DIFF
--- a/src/viser/client/src/ControlPanel/FloatingPanel.tsx
+++ b/src/viser/client/src/ControlPanel/FloatingPanel.tsx
@@ -289,7 +289,7 @@ FloatingPanel.Contents = function FloatingPanelContents({
   const context = React.useContext(FloatingPanelContext)!;
   return (
     <Collapse in={context.expanded}>
-      <Divider mx="xs" />
+      <Divider />
       <ScrollArea.Autosize mah={context.maxHeight}>
         <Box
           /* Prevent internals from getting too wide. Needs to match the

--- a/src/viser/client/src/components/ComponentStyles.css.ts
+++ b/src/viser/client/src/components/ComponentStyles.css.ts
@@ -53,3 +53,47 @@ globalStyle(
     borderColor: "var(--mantine-color-dark-3)",
   },
 );
+
+// Tab group: when tabs wrap onto multiple rows, the default Mantine underline
+// (drawn via ::before on the list) only appears below the last row. Replace
+// it with a per-tab strategy: each tab gets its own bottom border, plus a
+// pseudo-element that projects the gray line to the right so the underline
+// fills the full width of every row (including past the last tab).
+export const tabGroupWrap = style({});
+
+globalStyle(`${tabGroupWrap} .mantine-Tabs-list`, {
+  // Clip the rightward-projecting stripes so they don't escape the panel.
+  overflowX: "clip",
+});
+
+globalStyle(`${tabGroupWrap} .mantine-Tabs-list::before`, {
+  display: "none",
+});
+
+globalStyle(`${tabGroupWrap} .mantine-Tabs-tab:not([data-active])`, {
+  borderBottomColor: "var(--tab-border-color)",
+});
+
+globalStyle(`${tabGroupWrap} .mantine-Tabs-tab`, {
+  backgroundColor: "transparent",
+});
+
+globalStyle(`${tabGroupWrap} .mantine-Tabs-tab:hover`, {
+  backgroundColor: "transparent",
+  // Use the same theme color as the active-tab underline. Icons rendered via
+  // `currentColor` will pick this up automatically.
+  color: "var(--tabs-color)",
+});
+
+globalStyle(`${tabGroupWrap} .mantine-Tabs-tab::after`, {
+  content: "''",
+  position: "absolute",
+  left: "100%",
+  // Match the per-tab border-bottom thickness (2px in the default Mantine
+  // variant) so the projected stripe lines up with the under-tab border.
+  bottom: "calc(-1 * var(--tabs-list-border-width))",
+  width: "200vw",
+  height: "var(--tabs-list-border-width)",
+  backgroundColor: "var(--tab-border-color)",
+  pointerEvents: "none",
+});

--- a/src/viser/client/src/components/TabGroup.tsx
+++ b/src/viser/client/src/components/TabGroup.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { GuiTabGroupMessage } from "../WebsocketMessages";
 import { Tabs } from "@mantine/core";
 import { GuiComponentContext } from "../ControlPanel/GuiComponentContext";
-import { htmlIconWrapper } from "./ComponentStyles.css";
+import { htmlIconWrapper, tabGroupWrap } from "./ComponentStyles.css";
 
 export default function TabGroupComponent({
   props: {
@@ -15,7 +15,12 @@ export default function TabGroupComponent({
   const { GuiContainer } = React.useContext(GuiComponentContext)!;
   if (!visible) return null;
   return (
-    <Tabs radius="xs" defaultValue={"0"} style={{ marginTop: "-0.55em" }}>
+    <Tabs
+      radius="xs"
+      defaultValue={"0"}
+      className={tabGroupWrap}
+      style={{ marginTop: "-0.55em" }}
+    >
       <Tabs.List>
         {tab_labels.map((label, index) => (
           <Tabs.Tab


### PR DESCRIPTION
Before:
<img width="347" height="161" alt="image" src="https://github.com/user-attachments/assets/a99e6697-9a59-4e49-a91a-e353f6e7e497" />

After:
<img width="347" height="161" alt="image" src="https://github.com/user-attachments/assets/5d7438d9-7cdd-4b6d-8742-8464fc7dacfe" />
