### PR TITLE
Make `yourdfpy` dependency optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
     "tqdm>=4.0.0,<5.0.0",
     "rich>=13.3.3,<15.0.0",
     "trimesh>=3.21.7,<5.0.0",
-    "yourdfpy>=0.0.53,<1.0.0",
     "typing_extensions>=4.0.0",
     # TODO: migrate to backports.zstd when we drop Python 3.8 support.
     # https://pypi.org/project/backports.zstd/
@@ -54,13 +53,16 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+urdf = [
+    "yourdfpy>=0.0.53,<1.0.0",
+]
 dev = [
+    "viser[examples]",
     "pyright>=1.1.308",
     "ruff>=0.9.3",
     "pre-commit==3.3.2",
     "pytest",
     "hypothesis[numpy]",
-    "opencv-python>=4.0.0.21,<5.0.0",
     "psutil>=5.9.5,<8.0.0",
     "nodeenv>=1.9.1,<2.0.0",
     "playwright>=1.40.0",
@@ -68,6 +70,7 @@ dev = [
     "pytest-xdist>=3.0.0",
 ]
 examples = [
+    "viser[urdf]",
     "torch>=1.13.1",
     "torch<2.5.0; python_version<'3.9'",  # Last torch with cp38 wheels.
     "matplotlib>=3.7.1",
@@ -78,7 +81,7 @@ examples = [
     "opencv-python",
     "pyliblzfse>=0.4.1; platform_system!='Windows'",
     "pandas",  # https://github.com/viser-project/viser/issues/457
-    "tyro>=0.2.0,<1.0.0",
+    "tyro>=1.0.0",
 ]
 
 [project.urls]

--- a/src/viser/extras/_urdf.py
+++ b/src/viser/extras/_urdf.py
@@ -3,17 +3,19 @@ from __future__ import annotations
 import warnings
 from functools import partial
 from pathlib import Path
-from typing import List, Tuple
+from typing import TYPE_CHECKING, List, Tuple
 
 import numpy as np
 import trimesh
-import yourdfpy
 from trimesh.scene import Scene
 from typing_extensions import assert_never
 
 import viser
 
 from .. import transforms as tf
+
+if TYPE_CHECKING:
+    import yourdfpy
 
 
 class ViserUrdf:
@@ -92,6 +94,14 @@ class ViserUrdf:
     ) -> None:
         assert root_node_name.startswith("/")
         assert len(root_node_name) == 1 or not root_node_name.endswith("/")
+
+        try:
+            import yourdfpy
+        except ImportError as e:
+            raise ImportError(
+                "yourdfpy is required for ViserUrdf but is not installed. "
+                "Install it with `pip install yourdfpy` or `pip install viser[urdf]`."
+            ) from e
 
         if isinstance(urdf_or_path, Path):
             urdf = yourdfpy.URDF.load(
@@ -192,6 +202,8 @@ class ViserUrdf:
 
     def update_cfg(self, configuration: np.ndarray) -> None:
         """Update the joint angles of the visualized URDF."""
+        import yourdfpy
+
         self._urdf.update_cfg(configuration)
         for joint, frame_handle in zip(self._joint_map_values, self._joint_frames):
             assert isinstance(joint, yourdfpy.Joint)
@@ -205,6 +217,8 @@ class ViserUrdf:
         self,
     ) -> dict[str, tuple[float | None, float | None]]:
         """Returns an ordered mapping from actuated joint names to position limits."""
+        import yourdfpy
+
         out: dict[str, tuple[float | None, float | None]] = {}
         for joint_name, joint in zip(
             self._urdf.actuated_joint_names, self._urdf.actuated_joints
@@ -233,6 +247,8 @@ class ViserUrdf:
         """
         Helper function to add joint frames and meshes to the ViserUrdf object.
         """
+        import yourdfpy
+
         prefix = "collision" if collision_geometry else "visual"
         prefixed_root_node_name = (f"{root_node_name}/{prefix}").replace("//", "/")
         root_frame = self._target.scene.add_frame(


### PR DESCRIPTION
`yourdfpy` can be difficult to install because of `trimesh[easy]`.

cc @kevinzakka 