### PR TITLE
Fix prop update regression for line segments

### DIFF
--- a/src/viser/client/src/CameraFrustumVariants.tsx
+++ b/src/viser/client/src/CameraFrustumVariants.tsx
@@ -77,33 +77,26 @@ export const CameraFrustumComponent = React.forwardRef<
     imageTexture === undefined ? [0.0, -0.9, 1.0] : [0.0, -1.0, 1.0],
   ].map((xyz) => [xyz[0] * x, xyz[1] * y, xyz[2] * z]);
 
-  // Populate filled-variant geometry via ref. R3F auto-disposes.
-  const filledGeomRef = React.useRef<THREE.BufferGeometry>(null);
-  React.useLayoutEffect(() => {
-    const geom = filledGeomRef.current;
-    if (!geom || message.props.variant !== "filled") return;
-
+  // Fresh BufferGeometry per dimension change: in-place setAttribute swaps
+  // hit the same truncation bug as LineSegments2. See:
+  //   https://github.com/nerfstudio-project/viser/issues/719
+  const filledGeometry = React.useMemo(() => {
+    if (message.props.variant !== "filled") return null;
+    const geom = new THREE.BufferGeometry();
     const vertices = new Float32Array([
-      0,
-      0,
-      0,
-      -x,
-      -y,
-      z,
-      x,
-      -y,
-      z,
-      x,
-      y,
-      z,
-      -x,
-      y,
-      z,
+      0, 0, 0, -x, -y, z, x, -y, z, x, y, z, -x, y, z,
     ]);
     geom.setAttribute("position", new THREE.BufferAttribute(vertices, 3));
     geom.setIndex(new THREE.BufferAttribute(FRUSTUM_INDICES, 1));
     geom.computeVertexNormals();
+    return geom;
   }, [x, y, z, message.props.variant]);
+
+  React.useEffect(() => {
+    return () => {
+      filledGeometry?.dispose();
+    };
+  }, [filledGeometry]);
 
   const color = new THREE.Color().setRGB(
     message.props.color[0] / 255,
@@ -124,9 +117,9 @@ export const CameraFrustumComponent = React.forwardRef<
       />
 
       {/* Filled faces - only for "filled" variant */}
-      {message.props.variant === "filled" && (
+      {message.props.variant === "filled" && filledGeometry && (
         <mesh>
-          <bufferGeometry ref={filledGeomRef} />
+          <primitive object={filledGeometry} attach="geometry" />
           <meshBasicMaterial
             color={isHovered ? 0xfbff00 : color}
             transparent

--- a/src/viser/client/src/Line.tsx
+++ b/src/viser/client/src/Line.tsx
@@ -48,13 +48,14 @@ export const Line: ForwardRefComponent<LineProps, Line2 | LineSegments2> =
     ) {
       const size = useThree((state) => state.size);
       const lineRef = React.useRef<Line2 | LineSegments2>(null);
-      const geomRef = React.useRef<LineGeometry | LineSegmentsGeometry>(null);
       const matRef = React.useRef<LineMaterial>(null);
 
-      // Populate geometry data via ref.
-      React.useLayoutEffect(() => {
-        const geom = geomRef.current;
-        if (!geom) return;
+      // Build a fresh geometry per change: reusing one instance and calling
+      // setPositions() in a layout effect intermittently truncates the draw
+      // on LineSegments2. See:
+      //   https://github.com/nerfstudio-project/viser/issues/719
+      const lineGeom = React.useMemo(() => {
+        const geom = segments ? new LineSegmentsGeometry() : new LineGeometry();
         geom.setPositions(points);
         if (vertexColors) {
           const normalizedColors = new Float32Array(vertexColors).map(
@@ -62,11 +63,18 @@ export const Line: ForwardRefComponent<LineProps, Line2 | LineSegments2> =
           );
           geom.setColors(normalizedColors, 3);
         }
-      }, [points, vertexColors]);
+        return geom;
+      }, [points, vertexColors, segments]);
+
+      React.useEffect(() => {
+        return () => {
+          lineGeom.dispose();
+        };
+      }, [lineGeom]);
 
       React.useLayoutEffect(() => {
         lineRef.current?.computeLineDistances();
-      }, [points]);
+      }, [lineGeom]);
 
       // Handle dashed defines via ref (can't be expressed as a prop).
       React.useLayoutEffect(() => {
@@ -97,10 +105,31 @@ export const Line: ForwardRefComponent<LineProps, Line2 | LineSegments2> =
         [ref],
       );
 
+      // LineMaterial's trimSegment near-plane estimate assumes standard
+      // depth; under reversed depth (App.tsx) it explodes and lines smear
+      // when the camera is close. Switch the formula on sign(a). Three.js
+      // has an equivalent fix queued for r185
+      // (https://github.com/mrdoob/three.js/pull/33572); drop this patch
+      // once we upgrade to three@>=0.185.
+      const patchLineMaterialShader = React.useCallback(
+        (mat: LineMaterial | null) => {
+          (matRef as React.MutableRefObject<LineMaterial | null>).current = mat;
+          if (!mat) return;
+          mat.onBeforeCompile = (shader) => {
+            shader.vertexShader = shader.vertexShader.replace(
+              "float nearEstimate = - 0.5 * b / a;",
+              "float nearEstimate = ( a > 0.0 ) ? ( - b / ( 1.0 + a ) ) : ( - 0.5 * b / a );",
+            );
+          };
+          mat.needsUpdate = true;
+        },
+        [],
+      );
+
       // R3F manages lifecycle for all declarative children -- no manual disposal.
       const materialJsx = (
         <lineMaterial
-          ref={matRef}
+          ref={patchLineMaterialShader}
           color={effectiveColor}
           vertexColors={Boolean(vertexColors)}
           resolution={[size.width, size.height]}
@@ -114,14 +143,14 @@ export const Line: ForwardRefComponent<LineProps, Line2 | LineSegments2> =
       if (segments) {
         return (
           <lineSegments2 ref={setLineRef} {...rest}>
-            <lineSegmentsGeometry ref={geomRef} />
+            <primitive object={lineGeom} attach="geometry" />
             {materialJsx}
           </lineSegments2>
         );
       } else {
         return (
           <line2 ref={setLineRef} {...rest}>
-            <lineGeometry ref={geomRef} />
+            <primitive object={lineGeom} attach="geometry" />
             {materialJsx}
           </line2>
         );

--- a/tests/e2e/test_line_segments_resize.py
+++ b/tests/e2e/test_line_segments_resize.py
@@ -1,0 +1,78 @@
+"""Regression test for resizing add_line_segments truncating the draw.
+
+See https://github.com/nerfstudio-project/viser/issues/719.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import numpy as np
+from PIL import Image
+from playwright.sync_api import Page
+
+import viser
+
+from .utils import wait_for_scene_node
+
+
+def _count_red_pixels(page: Page) -> int:
+    canvas = page.locator("canvas").first
+    img = np.array(Image.open(BytesIO(canvas.screenshot())).convert("RGB"))
+    return int(
+        ((img[:, :, 0] > 200) & (img[:, :, 1] < 80) & (img[:, :, 2] < 80)).sum()
+    )
+
+
+def _segments_along_x(half_extent: float, num_points: int) -> np.ndarray:
+    pts = np.linspace(
+        [-half_extent, 0.0, 0.0], [half_extent, 0.0, 0.0], num=num_points
+    )
+    return np.stack([pts[:-1], pts[1:]], axis=1)
+
+
+def test_line_segments_resize_rerender(
+    viser_server: viser.ViserServer,
+    viser_page: Page,
+) -> None:
+    viser_server.initial_camera.position = (0.0, -6.0, 0.0)
+    viser_server.initial_camera.look_at = (0.0, 0.0, 0.0)
+
+    short_half_extent = 0.4
+    long_half_extent = 2.5
+    short_num_pts = 3
+    long_num_pts = 60
+
+    def push(half_extent: float, num_pts: int) -> None:
+        viser_server.scene.add_line_segments(
+            "/regression_line",
+            points=_segments_along_x(half_extent, num_pts),
+            colors=(255, 0, 0),
+            line_width=8.0,
+        )
+
+    push(short_half_extent, short_num_pts)
+    wait_for_scene_node(viser_page, "/regression_line")
+    viser_page.wait_for_timeout(200)
+    short_baseline = _count_red_pixels(viser_page)
+
+    push(long_half_extent, long_num_pts)
+    viser_page.wait_for_timeout(100)
+    long_baseline = _count_red_pixels(viser_page)
+    assert long_baseline > short_baseline * 3, (
+        f"short={short_baseline}, long={long_baseline}"
+    )
+
+    # Bounce back to short, then long again with a different buffer size.
+    # Pre-fix this short->long transition under-rendered.
+    long_threshold = long_baseline // 2
+    for i in range(2):
+        push(short_half_extent, short_num_pts + (i % 2))
+        viser_page.wait_for_timeout(100)
+        push(long_half_extent, long_num_pts + (i + 1) * 4)
+        viser_page.wait_for_timeout(100)
+        long_count = _count_red_pixels(viser_page)
+        assert long_count >= long_threshold, (
+            f"iter {i}: red_pixels={long_count}, threshold={long_threshold}, "
+            f"long_baseline={long_baseline}, short_baseline={short_baseline}"
+        )


### PR DESCRIPTION
Fixes regression introduced by #668, which was preventing line segments from updating properly. Closes #719, thanks @sea-bass!