### PR TITLE
Fix minor edge cases: orbit/transform gizmo, connect/disconnect, resource leaks, ...

### DIFF
--- a/src/viser/_assignable_props_api.py
+++ b/src/viser/_assignable_props_api.py
@@ -84,6 +84,11 @@ class AssignablePropsBase(Generic[TImpl]):
     def _queue_update(self, name: str, value: Any) -> None:
         """Queue an update message with the property change."""
 
+    def _on_prop_assigned(self, name: str) -> None:
+        """Hook called after a props field is assigned and its update is queued.
+        Subclasses can override to enforce cross-field invariants (e.g. keeping
+        an array's dtype in sync with another field). No-op by default."""
+
 
 def props_setattr(self, name: str, value: Any) -> None:
     if name == "_impl":
@@ -145,6 +150,7 @@ def props_setattr(self, name: str, value: Any) -> None:
         return object.__setattr__(self, name, value)
 
     self._queue_update(name, value)
+    self._on_prop_assigned(name)
 
 
 def props_getattr(self, name: str) -> Any:

--- a/src/viser/_assignable_props_api.py
+++ b/src/viser/_assignable_props_api.py
@@ -76,12 +76,6 @@ class AssignablePropsBase(Generic[TImpl]):
 
         return value
 
-    def _cast_array_dtypes(
-        self, prop_hints: Dict[str, Any], prop_name: str, value: np.ndarray
-    ) -> np.ndarray:
-        """Helper to cast array values to the correct data type."""
-        return self._cast_value_recursive(prop_hints[prop_name], value, prop_name)
-
     @cached_property
     def _prop_hints(self) -> Dict[str, Any]:
         return get_type_hints(type(self._impl.props))

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -679,9 +679,9 @@ class PointCloudProps:
     point_shape: Literal["square", "diamond", "circle", "rounded", "sparkle"]
     """Shape to draw each point."""
     precision: Annotated[Literal["float16", "float32"], infra.EditorHidden()]
-    """Precision of the point cloud. Assignments to `points` are automatically casted
-    based on the current precision value. Updates to `points` should therefore happen
-    *after* updates to `precision`."""
+    """Precision used to store point positions. Changing this re-casts the existing
+    `points` buffer, and assignments to `points` are cast to the current precision, so
+    `precision` and `points` can be updated in either order."""
     scale: Union[float, Tuple[float, float, float]] = 1.0
     """Scale of the point cloud. A single float for uniform scaling or a
     tuple of (x, y, z) for per-axis scaling."""
@@ -2135,12 +2135,18 @@ class GetRenderRequestMessage(Message, include_in_scene_serialization=False):
     position: Tuple[float, float, float]
     fov: float
 
+    # Correlation ID echoed back in the response, so concurrent get_render()
+    # calls on the same client can be matched to their responses.
+    render_uuid: str
+
 
 @dataclasses.dataclass
 class GetRenderResponseMessage(Message, include_in_scene_serialization=False):
     """Message from client->server carrying a render."""
 
     payload: bytes
+    # Correlation ID matching the originating GetRenderRequestMessage.
+    render_uuid: str
 
 
 @dataclasses.dataclass

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -679,9 +679,9 @@ class PointCloudProps:
     point_shape: Literal["square", "diamond", "circle", "rounded", "sparkle"]
     """Shape to draw each point."""
     precision: Annotated[Literal["float16", "float32"], infra.EditorHidden()]
-    """Precision used to store point positions. Changing this re-casts the existing
-    `points` buffer, and assignments to `points` are cast to the current precision, so
-    `precision` and `points` can be updated in either order."""
+    """Precision used to store point positions. Assignments to `points` are cast to
+    the current precision, and changing `precision` re-casts the existing `points`
+    buffer in place, so `precision` and `points` can be assigned in either order."""
     scale: Union[float, Tuple[float, float, float]] = 1.0
     """Scale of the point cloud. A single float for uniform scaling or a
     tuple of (x, y, z) for per-axis scaling."""

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -9,7 +9,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
     Generic,
     Literal,
     Optional,
@@ -864,19 +863,28 @@ class PointCloudHandle(
 ):
     """Handle for point clouds. Does not support click events."""
 
-    @override
-    def _cast_array_dtypes(
-        self,
-        prop_hints: Dict[str, Any],
-        prop_name: str,
-        value: np.ndarray,
-    ) -> np.ndarray:
-        """Casts assigned `points` based on the current value of `precision`."""
-        if prop_name == "points":
-            return value.astype(
-                {"float16": np.float16, "float32": np.float32}[self.precision]
-            )
-        return super()._cast_array_dtypes(prop_hints, prop_name, value)
+    @property
+    def precision(self) -> Literal["float16", "float32"]:
+        return self._impl.props.precision
+
+    @precision.setter
+    def precision(self, precision: Literal["float16", "float32"]) -> None:
+        # Re-cast the stored points to the new precision. The generic prop
+        # setter (see `_assignable_props_api.props_setattr`) forces a reassigned
+        # `points` array back to the *existing* buffer's dtype, so without this
+        # the configured precision could never actually change after
+        # construction. Re-casting here reconverts the cloud immediately and
+        # lets `precision` and `points` be assigned in either order.
+        if precision == self._impl.props.precision:
+            return
+        dtype = {"float16": np.float16, "float32": np.float32}[precision]
+        # Cast first: if `astype` were to fail, the handle stays consistent
+        # (precision and points unchanged) rather than being left mismatched.
+        new_points = self._impl.props.points.astype(dtype)
+        self._impl.props.precision = precision
+        self._impl.props.points = new_points
+        self._queue_update("precision", precision)
+        self._queue_update("points", new_points)
 
 
 class BatchedAxesHandle(

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -863,28 +863,23 @@ class PointCloudHandle(
 ):
     """Handle for point clouds. Does not support click events."""
 
-    @property
-    def precision(self) -> Literal["float16", "float32"]:
-        return self._impl.props.precision
-
-    @precision.setter
-    def precision(self, precision: Literal["float16", "float32"]) -> None:
-        # Re-cast the stored points to the new precision. The generic prop
-        # setter (see `_assignable_props_api.props_setattr`) forces a reassigned
-        # `points` array back to the *existing* buffer's dtype, so without this
-        # the configured precision could never actually change after
-        # construction. Re-casting here reconverts the cloud immediately and
-        # lets `precision` and `points` be assigned in either order.
-        if precision == self._impl.props.precision:
+    @override
+    def _on_prop_assigned(self, name: str) -> None:
+        # `points` is stored at the dtype named by `precision`, so re-cast the
+        # buffer in place whenever `precision` changes. This both keeps the
+        # cloud consistent and means a subsequent `points` assignment won't be
+        # pinned back to the old dtype by the generic setter -- so `precision`
+        # and `points` can be assigned in either order.
+        if name != "precision":
             return
-        dtype = {"float16": np.float16, "float32": np.float32}[precision]
-        # Cast first: if `astype` were to fail, the handle stays consistent
-        # (precision and points unchanged) rather than being left mismatched.
-        new_points = self._impl.props.points.astype(dtype)
-        self._impl.props.precision = precision
-        self._impl.props.points = new_points
-        self._queue_update("precision", precision)
-        self._queue_update("points", new_points)
+        dtype = {"float16": np.float16, "float32": np.float32}[
+            self._impl.props.precision
+        ]
+        points = self._impl.props.points
+        if points.dtype != dtype:
+            new_points = points.astype(dtype)
+            self._impl.props.points = new_points
+            self._queue_update("points", new_points)
 
 
 class BatchedAxesHandle(

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -658,20 +658,34 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
 
         connection = self._websock_connection
 
+        render_uuid = _make_uuid()
+
         def got_render_cb(
             client_id: int, message: _messages.GetRenderResponseMessage
         ) -> None:
             del client_id
+            # Ignore responses for other concurrent get_render() calls on this
+            # client; only ours matches our request's uuid.
+            if message.render_uuid != render_uuid:
+                return
             connection.unregister_handler(
                 _messages.GetRenderResponseMessage, got_render_cb
             )
             nonlocal out
-            import imageio.v3 as iio
+            # An empty payload is the client's failure sentinel (capture threw,
+            # or toBlob() returned null). Leave `out` as None and let the
+            # waiter raise, rather than crashing the decode here (which would
+            # never set the event and hang get_render() forever).
+            if len(message.payload) > 0:
+                import imageio.v3 as iio
 
-            out = iio.imread(
-                io.BytesIO(message.payload),
-                extension=f".{transport_format}",
-            )
+                try:
+                    out = iio.imread(
+                        io.BytesIO(message.payload),
+                        extension=f".{transport_format}",
+                    )
+                except Exception:
+                    out = None
             render_ready_event.set()
 
         connection.register_handler(_messages.GetRenderResponseMessage, got_render_cb)
@@ -689,10 +703,14 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 ),
                 wxyz=cast_vector(wxyz if wxyz is not None else self.camera.wxyz, 4),
                 fov=fov if fov is not None else self.camera.fov,
+                render_uuid=render_uuid,
             )
         )
         render_ready_event.wait()
-        assert out is not None
+        if out is None:
+            raise RuntimeError(
+                "Render request failed: the client could not capture a frame."
+            )
         return out
 
 

--- a/src/viser/client/package-lock.json
+++ b/src/viser/client/package-lock.json
@@ -34,7 +34,6 @@
         "colortranslator": "^4.1.0",
         "detect-browser": "^5.3.0",
         "fuse.js": "^7.3.0",
-        "hold-event": "^1.1.0",
         "its-fine": "^2.0.0",
         "meshoptimizer": "^0.25.0",
         "postcss": "^8.4.38",
@@ -4943,12 +4942,6 @@
       "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.11.tgz",
       "integrity": "sha512-tdDwOAgPGXohSiNE4oxGr3CI9Hx9lsGLFe6TULUvRk2TfHS+w1tSAJntrvxsHaxvjtr6BXsDZM7NOqJFhU4mmg==",
       "license": "Apache-2.0"
-    },
-    "node_modules/hold-event": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/hold-event/-/hold-event-1.1.2.tgz",
-      "integrity": "sha512-Bx0A6OBY70cs23orUWk0DuBAAeJjEbmyg8Gnye9+M8+XeWy2CcmRyfiJhTnQQz9s25r9SYjici3URy176MFs5A==",
-      "license": "MIT"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",

--- a/src/viser/client/package.json
+++ b/src/viser/client/package.json
@@ -32,7 +32,6 @@
     "colortranslator": "^4.1.0",
     "detect-browser": "^5.3.0",
     "fuse.js": "^7.3.0",
-    "hold-event": "^1.1.0",
     "its-fine": "^2.0.0",
     "meshoptimizer": "^0.25.0",
     "postcss": "^8.4.38",

--- a/src/viser/client/src/App.tsx
+++ b/src/viser/client/src/App.tsx
@@ -31,16 +31,10 @@ import { useDisclosure } from "@mantine/hooks";
 import { SynchronizedCameraControls } from "./CameraControls";
 import { SceneNodeThreeObject } from "./SceneTree";
 import { DragLayer } from "./DragLayer";
-import {
-  KeyModifier,
-  hasCmdCtrl,
-  keyModifierFromEvent,
-} from "./dragUtils";
+import { KeyModifier, hasCmdCtrl, keyModifierFromEvent } from "./dragUtils";
 import { shallowArrayEqual } from "./utils/shallowArrayEqual";
-import {
-  ndcFromPointerXy,
-  opencvXyFromPointerXy,
-} from "./utils/pointerCoords";
+import { isFormElement } from "./utils/isFormElement";
+import { ndcFromPointerXy, opencvXyFromPointerXy } from "./utils/pointerCoords";
 import { ViewerContext, ViewerContextContents } from "./ViewerContext";
 import ControlPanel from "./ControlPanel/ControlPanel";
 import { useGuiState } from "./ControlPanel/GuiState";
@@ -217,8 +211,10 @@ function ViewerRoot() {
 
     // Message and rendering state.
     messageQueue: [],
+    firstMessageBatch: true,
     getRenderRequestState: "ready",
     getRenderRequest: null,
+    initialCameraDiagnostic: null,
 
     // Skinned mesh state.
     skinnedMeshState: {},
@@ -512,21 +508,10 @@ function ViewerCanvas({ children }: { children: React.ReactNode }) {
       cancelActiveScenePointer();
       interaction.hover.setHeldModifier(null);
     };
-    const isFormElement = (el: Element | null): boolean => {
-      if (el === null) return false;
-      const tag = el.tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") {
-        return true;
-      }
-      return (el as HTMLElement).isContentEditable;
-    };
     const onKey = (e: KeyboardEvent) => {
       // Skip while typing in form controls so Shift in a TextInput
       // doesn't flicker the canvas cursor.
-      if (
-        isFormElement(e.target as Element | null) ||
-        isFormElement(document.activeElement)
-      ) {
+      if (isFormElement(e.target) || isFormElement(document.activeElement)) {
         return;
       }
       interaction.hover.setHeldModifier(keyModifierFromEvent(e));
@@ -554,6 +539,14 @@ function ViewerCanvas({ children }: { children: React.ReactNode }) {
   );
 
   const handlePointerDown = (e: React.PointerEvent) => {
+    // If a 3D handle already captured this pointer (drei's orbit-origin /
+    // transform gizmos call setPointerCapture on the canvas in their own
+    // pointerdown, which runs before this bubbles up), it owns the gesture.
+    // Engaging the canvas-level scene-pointer path here would, for a
+    // rect-select gesture, call setPointerCapture on a *different* element and
+    // steal the gizmo's capture -- R3F then drops it and the gizmo's pointerup
+    // is missed, leaving it stuck mid-drag.
+    if (viewer.mutable.current.canvas?.hasPointerCapture(e.pointerId)) return;
     const xy = canvasXyFromEvent(e);
     const next = interaction.scenePointer.onPointerDown({
       pointerId: e.pointerId,
@@ -597,7 +590,12 @@ function ViewerCanvas({ children }: { children: React.ReactNode }) {
     });
     drawRectSelectOverlay(null);
     if (outcome.kind === "scene-click") {
-      sendClickMessage(viewer, outcome.xy, outcome.modifier, sendClickThrottled);
+      sendClickMessage(
+        viewer,
+        outcome.xy,
+        outcome.modifier,
+        sendClickThrottled,
+      );
     } else if (outcome.kind === "scene-rect-select") {
       sendRectSelectMessage(
         viewer,
@@ -606,6 +604,13 @@ function ViewerCanvas({ children }: { children: React.ReactNode }) {
         sendClickThrottled,
       );
     }
+    // Reconcile `cameraControl.enabled` with the held leases once the gesture
+    // ends. drei's PivotControls (orbit-origin gizmo, transform controls)
+    // disables the camera directly during a drag and only re-enables it in its
+    // own pointerup -- which is skipped on a pointercancel or a release where
+    // pointer capture was lost. Without this the camera would be left disabled
+    // (no lease held) and orbit/pan would silently stop working.
+    interaction.cameraLocks.apply();
   };
 
   const fixedDpr = viewer.useDevSettings((state) => state.fixedDpr);
@@ -637,7 +642,14 @@ function ViewerCanvas({ children }: { children: React.ReactNode }) {
     >
       <Canvas
         gl={{ preserveDrawingBuffer: true, reversedDepthBuffer: true }}
-        style={{ width: "100%", height: "100%" }}
+        // `touchAction: none` opts the canvas out of native touch actions.
+        // Without it the browser can reinterpret a curved/multi-touch drag
+        // (e.g. dragging the orbit gizmo's rotation ring, especially on
+        // trackpads) as a scroll/zoom gesture and fire `pointercancel`
+        // mid-drag. drei's PivotControls has no cancel handler, so the gizmo
+        // would be left stuck following the cursor. camera-controls handles
+        // all viewport gestures itself, so there is nothing to lose.
+        style={{ width: "100%", height: "100%", touchAction: "none" }}
         ref={(el) => {
           viewer.mutable.current.canvas = el;
           interaction.hover.refresh();
@@ -648,6 +660,12 @@ function ViewerCanvas({ children }: { children: React.ReactNode }) {
         onPointerCancel={(e) => {
           interaction.cancelPointer(e.pointerId);
           drawRectSelectOverlay(null);
+          // drei's PivotControls disables the camera on pointerdown and only
+          // re-enables it in its own pointerup -- it has no pointercancel
+          // handler. A canceled gizmo drag (common for the curved rotation-ring
+          // gesture) would otherwise leave the camera disabled. Reconcile to
+          // the lease state here so it recovers.
+          interaction.cameraLocks.apply();
         }}
         onContextMenu={(e) => {
           // Suppress the browser context menu only for ctrl/cmd-modified

--- a/src/viser/client/src/BatchedLabelManager.tsx
+++ b/src/viser/client/src/BatchedLabelManager.tsx
@@ -43,7 +43,11 @@ export const BatchedLabelManager: React.FC<{
   children?: React.ReactNode;
 }> = ({ children }) => {
   const viewer = React.useContext(ViewerContext)!;
-  const [group, setGroup] = React.useState<THREE.Group | null>(null);
+  // Created synchronously (not via state + mount effect) so the group exists
+  // on the very first render. Otherwise a child label whose effect runs before
+  // the manager's mount effect would call registerText() while `group` was
+  // still null and be dropped permanently.
+  const group = React.useMemo(() => new THREE.Group(), []);
 
   // One BatchedText instance per depthTest setting (true/false).
   const batchedTextsRef = React.useRef<Map<boolean, BatchedText>>(new Map());
@@ -76,20 +80,16 @@ export const BatchedLabelManager: React.FC<{
   // Create unit rectangle geometry once (scaled per-instance).
   const rectGeometry = React.useMemo(() => new THREE.PlaneGeometry(1, 1), []);
 
-  // Create the group once on mount.
+  // Dispose batched texts on unmount. (Reads the latest set of registered
+  // texts via the ref -- intentional, we want the value at unmount time.)
   React.useEffect(() => {
-    const newGroup = new THREE.Group();
-    setGroup(newGroup);
-
-    // Cleanup on unmount: read the latest set of registered texts via the
-    // ref (intentional -- we want the value at unmount time, not mount).
     return () => {
       batchedTextsRef.current.forEach((batchedText) => {
-        newGroup.remove(batchedText);
+        group.remove(batchedText);
         batchedText.dispose();
       });
     };
-  }, []);
+  }, [group]);
 
   // API for components to register/unregister their text objects.
   const registerText = React.useCallback(

--- a/src/viser/client/src/CameraControls.tsx
+++ b/src/viser/client/src/CameraControls.tsx
@@ -130,12 +130,11 @@ function OrbitOriginTool({
   }, [show]);
 
   // Keep the gizmo mounted at all times and toggle the handles via the
-  // `disable*` props (like drei's PivotControls was used originally) rather
-  // than unmounting it when hidden. Unmounting meant the gizmo mounted fresh on
-  // enable, so its transform/scale weren't settled for the very first drag
-  // (the pivot is synced to the camera by `sendCamera` on camera *changes*, and
-  // there's been none since enable) -- so the first drag computed from a stale
-  // pose and only the second drag (or any camera move first) worked.
+  // `disable*` props rather than unmounting it when hidden. The pivot's
+  // transform is only synced to the camera by `sendCamera` on camera
+  // *changes*, so a freshly mounted gizmo has a stale pose until the next
+  // camera move -- keeping it mounted means its first drag starts from the
+  // correct pose.
   return (
     <PivotControls
       ref={pivotRef}
@@ -207,14 +206,11 @@ export function SynchronizedCameraControls() {
     duration: number;
   }
 
-  // Held in a ref, not state: this is read inside `sendCamera` (a stable
-  // `useCallback`) and the `updatePivotControlFromCameraLookAtAndup` guard it
-  // calls. As state closed over by that memoized callback it would go stale --
-  // the callback captures the value from the render where its deps last
-  // changed, which is `null` forever -- so the guard would fail to suppress
-  // pivot updates mid-animation and the orbit gizmo would snap back to the old
-  // look-at for a frame. A ref is always read fresh. Nothing renders off this
-  // value; the animation is driven entirely by `useFrame`.
+  // Held in a ref, not state: it's read inside the stable `sendCamera`
+  // callback (and the `updatePivotControlFromCameraLookAtAndup` guard it
+  // calls), which needs the current value rather than the one captured at its
+  // last dependency change. Nothing renders off this value; the animation is
+  // driven entirely by `useFrame`.
   const cameraAnimationRef = useRef<CameraAnimation | null>(null);
 
   // Animation parameters.
@@ -558,12 +554,10 @@ export function SynchronizedCameraControls() {
     return () => resizeObserver.disconnect();
   }, [canvas, sendCamera]);
 
-  // Keyboard controls. We own the document/window listeners directly (and
-  // remove them on unmount) rather than going through a hold-event helper,
-  // which attached listeners with no teardown API and was re-created whenever
-  // the camera-control ref changed (leaking/duplicating listeners). The
-  // listeners only track which keys are held; movement is applied per frame in
-  // the `useFrame` below.
+  // Keyboard controls. The document/window listeners only track which keys are
+  // currently held; movement is applied per frame in the `useFrame` below. The
+  // effect has no dependencies, so the listeners are attached once and removed
+  // on unmount.
   const heldKeysRef = useRef<Set<string>>(new Set());
   React.useEffect(() => {
     const held = heldKeysRef.current;
@@ -596,13 +590,16 @@ export function SynchronizedCameraControls() {
     };
   }, []);
 
-  // Apply held-key camera movement each frame. Rates match the previous
-  // hold-event implementation: linear 0.002/ms == 2.0/s, rotation
-  // 0.05 deg/ms == 50 deg/s (`delta` is in seconds).
+  // Apply held-key camera movement each frame. Rates: linear 2.0/s, rotation
+  // 50 deg/s (`delta` is in seconds).
   useFrame((_, delta) => {
     const cameraControls = viewerMutable.cameraControl;
     const held = heldKeysRef.current;
     if (cameraControls === null || held.size === 0) return;
+    // Respect camera locks: when a lease (or a gizmo drag) has disabled the
+    // controls, keyboard movement must not bypass it. The library's
+    // programmatic truck/forward/rotate ignore `enabled`, so guard here.
+    if (!cameraControls.enabled) return;
     const linear = 2.0 * delta;
     const angular = 50.0 * THREE.MathUtils.DEG2RAD * delta;
     if (held.has("KeyA")) cameraControls.truck(-linear, 0, false);
@@ -617,10 +614,9 @@ export function SynchronizedCameraControls() {
     if (held.has("ArrowDown")) cameraControls.rotate(0, angular, true);
   });
 
-  // Stable ref callback: a fresh inline arrow here would be detached/reattached
-  // by React on every commit, so `cameraLocks.apply()` would run on every
-  // render. Keeping the ref stable means `apply()` only runs when the controls
-  // instance actually attaches/changes, which is its intended purpose.
+  // Stable ref callback so React only invokes it when the controls instance
+  // actually attaches/changes -- `cameraLocks.apply()` should run on attach,
+  // not on every commit (which an inline arrow would cause).
   const setCameraControlRef = React.useCallback(
     (controls: CameraControls | null) => {
       viewerMutable.cameraControl = controls;

--- a/src/viser/client/src/CameraControls.tsx
+++ b/src/viser/client/src/CameraControls.tsx
@@ -1,14 +1,38 @@
 import { ViewerContext } from "./ViewerContext";
-import { CameraControls, Instance, Instances } from "@react-three/drei";
-import { useThree } from "@react-three/fiber";
-import * as holdEvent from "hold-event";
+import {
+  CameraControls,
+  Grid,
+  Instance,
+  Instances,
+  PivotControls,
+} from "@react-three/drei";
+import { useFrame, useThree } from "@react-three/fiber";
 import React, { useContext, useRef, useState } from "react";
-import { useFrame } from "@react-three/fiber";
 import { PerspectiveCamera } from "three";
 import * as THREE from "three";
 import { computeT_threeworld_world } from "./WorldTransformUtils";
 import { useThrottledMessageSender } from "./WebsocketUtils";
-import { Grid, PivotControls } from "@react-three/drei";
+import { isFormElement } from "./utils/isFormElement";
+
+// Rotation from the three.js camera convention to the OpenCV one. Constant, so
+// it lives at module scope instead of being rebuilt every render.
+const R_threecam_cam = new THREE.Quaternion().setFromEuler(
+  new THREE.Euler(Math.PI, 0.0, 0.0),
+);
+
+// `event.code`s that drive keyboard camera movement.
+const CAMERA_MOVEMENT_KEYS = new Set([
+  "KeyW",
+  "KeyA",
+  "KeyS",
+  "KeyD",
+  "KeyQ",
+  "KeyE",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+]);
 
 function CrosshairVisual({
   visible,
@@ -81,12 +105,14 @@ function CrosshairVisual({
 function OrbitOriginTool({
   forceShow,
   pivotRef,
+  onDragStart,
   onPivotChange,
   update,
   crosshairVisible,
 }: {
   forceShow: boolean;
   pivotRef: React.RefObject<THREE.Group>;
+  onDragStart: () => void;
   onPivotChange: (matrix: THREE.Matrix4) => void;
   update: () => void;
   crosshairVisible: boolean;
@@ -98,9 +124,18 @@ function OrbitOriginTool({
   const enableOrbitCrosshair = viewer.useDevSettings(
     (state) => state.enableOrbitCrosshair,
   );
-  React.useEffect(update, [showOrbitOriginTool]);
-
   const show = showOrbitOriginTool || forceShow;
+  React.useLayoutEffect(() => {
+    if (show) update();
+  }, [show]);
+
+  // Keep the gizmo mounted at all times and toggle the handles via the
+  // `disable*` props (like drei's PivotControls was used originally) rather
+  // than unmounting it when hidden. Unmounting meant the gizmo mounted fresh on
+  // enable, so its transform/scale weren't settled for the very first drag
+  // (the pivot is synced to the camera by `sendCamera` on camera *changes*, and
+  // there's been none since enable) -- so the first drag computed from a stale
+  // pose and only the second drag (or any camera move first) worked.
   return (
     <PivotControls
       ref={pivotRef}
@@ -112,8 +147,9 @@ function OrbitOriginTool({
       disableAxes={!show}
       disableRotations={!show}
       disableSliders={!show}
+      onDragStart={onDragStart}
       onDragEnd={() => {
-        onPivotChange(pivotRef.current!.matrix);
+        if (pivotRef.current !== null) onPivotChange(pivotRef.current.matrix);
       }}
     >
       <Grid
@@ -141,6 +177,15 @@ export function SynchronizedCameraControls() {
 
   const pivotRef = useRef<THREE.Group>(null);
 
+  // True while the user is actively dragging the orbit-origin gizmo. The
+  // per-frame `updatePivotControlFromCameraLookAtAndup` sync must stand down
+  // for the duration: it rewrites `pivotRef.current.matrix` to the camera's
+  // look-at every time `sendCamera` runs, so if the camera happens to be
+  // moving during the drag (e.g. damping still settling from a prior gesture)
+  // it stomps the drag every frame -- the gizmo can't be moved and the
+  // release looks like it did nothing.
+  const pivotDraggingRef = useRef(false);
+
   const viewerMutable = viewer.mutable.current;
 
   // Crosshair visibility state: separate counter for keyboard and flag for pointer interactions.
@@ -162,13 +207,21 @@ export function SynchronizedCameraControls() {
     duration: number;
   }
 
-  const [cameraAnimation, setCameraAnimation] =
-    useState<CameraAnimation | null>(null);
+  // Held in a ref, not state: this is read inside `sendCamera` (a stable
+  // `useCallback`) and the `updatePivotControlFromCameraLookAtAndup` guard it
+  // calls. As state closed over by that memoized callback it would go stale --
+  // the callback captures the value from the render where its deps last
+  // changed, which is `null` forever -- so the guard would fail to suppress
+  // pivot updates mid-animation and the orbit gizmo would snap back to the old
+  // look-at for a frame. A ref is always read fresh. Nothing renders off this
+  // value; the animation is driven entirely by `useFrame`.
+  const cameraAnimationRef = useRef<CameraAnimation | null>(null);
 
   // Animation parameters.
   const ANIMATION_DURATION = 0.5; // seconds
 
   useFrame((state) => {
+    const cameraAnimation = cameraAnimationRef.current;
     if (cameraAnimation && viewerMutable.cameraControl) {
       const cameraControls = viewerMutable.cameraControl;
       const camera = cameraControls.camera;
@@ -218,12 +271,12 @@ export function SynchronizedCameraControls() {
 
       // Clear animation when complete.
       if (progress >= 1) {
-        setCameraAnimation(null);
+        cameraAnimationRef.current = null;
       }
     }
   });
 
-  const { clock } = useThree();
+  const clock = useThree((state) => state.clock);
 
   const updateCameraLookAtAndUpFromPivotControl = (matrix: THREE.Matrix4) => {
     if (!viewerMutable.cameraControl) return;
@@ -241,22 +294,27 @@ export function SynchronizedCameraControls() {
     const currentLookAt = cameraControls.getTarget(new THREE.Vector3());
 
     // Start new animation.
-    setCameraAnimation({
+    cameraAnimationRef.current = {
       startUp: camera.up.clone(),
       targetUp: targetUp,
       startLookAt: currentLookAt,
       targetLookAt: targetPosition,
       startTime: clock.getElapsedTime(),
       duration: ANIMATION_DURATION,
-    });
+    };
   };
 
   const updatePivotControlFromCameraLookAtAndup = () => {
-    if (cameraAnimation !== null) return;
+    if (cameraAnimationRef.current !== null) return;
     if (!viewerMutable.cameraControl) return;
     if (!pivotRef.current) return;
 
     const cameraControls = viewerMutable.cameraControl;
+    // Suppress the sync only while a gizmo drag is genuinely in progress -- drei
+    // disables the camera for the whole drag, so a set flag with the camera
+    // *enabled* is stale (e.g. a pointercancel skipped the drag-end that would
+    // clear it). Ignoring it then keeps the gizmo tracking instead of freezing.
+    if (pivotDraggingRef.current && !cameraControls.enabled) return;
     const lookAt = cameraControls.getTarget(new THREE.Vector3());
 
     // Rotate matrix s.t. it's y-axis aligns with the camera's up vector.
@@ -280,7 +338,6 @@ export function SynchronizedCameraControls() {
       // Check if cross product is valid.
       rotationMatrix.makeRotationAxis(axis, angle);
     }
-    // rotationMatrix.premultiply(origRotation);
 
     // Combine rotation with position.
     const matrix = new THREE.Matrix4();
@@ -299,6 +356,18 @@ export function SynchronizedCameraControls() {
   const initialT = React.useRef<THREE.Matrix4>(
     computeT_threeworld_world(viewer),
   );
+
+  // Diagnostic (see initial_pose_and_scene_orientation.md): record the root
+  // orientation at the instant `initialT` was captured, so e2e/debugging can
+  // detect a mount-ordering race that would leave the root at identity here
+  // (which would place the initial camera with T=identity -> wrong pre-connect
+  // view). Set once, on the first render.
+  if (viewerMutable.initialCameraDiagnostic === null) {
+    const w = viewer.useSceneTree.get("")?.wxyz ?? [1, 0, 0, 0];
+    viewerMutable.initialCameraDiagnostic = {
+      rootWxyzAtCapture: [w[0], w[1], w[2], w[3]],
+    };
+  }
 
   viewerMutable.resetCameraPose = (animate: boolean) => {
     // Read initial camera state from the store.
@@ -345,7 +414,7 @@ export function SynchronizedCameraControls() {
       );
     } else {
       // Calling setLookAt with animate = false seems to break future calls to
-      // setLookAt. Possible dpeendency bug.
+      // setLookAt. Possible dependency bug.
       viewerMutable.cameraControl!.setPosition(
         initialPos.x,
         initialPos.y,
@@ -368,9 +437,6 @@ export function SynchronizedCameraControls() {
   // Callback for sending cameras.
   // It makes the code more chaotic, but we preallocate a bunch of things to
   // minimize garbage collection!
-  const R_threecam_cam = new THREE.Quaternion().setFromEuler(
-    new THREE.Euler(Math.PI, 0.0, 0.0),
-  );
   const R_world_threeworld = new THREE.Quaternion();
   const tmpMatrix4 = new THREE.Matrix4();
   const lookAt = new THREE.Vector3();
@@ -492,97 +558,81 @@ export function SynchronizedCameraControls() {
     return () => resizeObserver.disconnect();
   }, [canvas, sendCamera]);
 
-  // Keyboard controls.
+  // Keyboard controls. We own the document/window listeners directly (and
+  // remove them on unmount) rather than going through a hold-event helper,
+  // which attached listeners with no teardown API and was re-created whenever
+  // the camera-control ref changed (leaking/duplicating listeners). The
+  // listeners only track which keys are held; movement is applied per frame in
+  // the `useFrame` below.
+  const heldKeysRef = useRef<Set<string>>(new Set());
   React.useEffect(() => {
-    const cameraControls = viewerMutable.cameraControl!;
-
-    const keys = {
-      w: new holdEvent.KeyboardKeyHold("KeyW", 1000 / 60),
-      a: new holdEvent.KeyboardKeyHold("KeyA", 1000 / 60),
-      s: new holdEvent.KeyboardKeyHold("KeyS", 1000 / 60),
-      d: new holdEvent.KeyboardKeyHold("KeyD", 1000 / 60),
-      q: new holdEvent.KeyboardKeyHold("KeyQ", 1000 / 60),
-      e: new holdEvent.KeyboardKeyHold("KeyE", 1000 / 60),
-      up: new holdEvent.KeyboardKeyHold("ArrowUp", 1000 / 60),
-      down: new holdEvent.KeyboardKeyHold("ArrowDown", 1000 / 60),
-      left: new holdEvent.KeyboardKeyHold("ArrowLeft", 1000 / 60),
-      right: new holdEvent.KeyboardKeyHold("ArrowRight", 1000 / 60),
+    const held = heldKeysRef.current;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!CAMERA_MOVEMENT_KEYS.has(event.code)) return;
+      if (isFormElement(event.target)) return;
+      // Ignore auto-repeat: only a fresh press counts as a new hold.
+      if (held.has(event.code)) return;
+      held.add(event.code);
+      setKeyboardCrosshairCounter((count) => count + 1);
     };
-
-    // TODO: these event listeners are currently never removed, even if this
-    // component gets unmounted.
-    keys.a.addEventListener(holdEvent.HOLD_EVENT_TYPE.HOLDING, (event) => {
-      cameraControls.truck(-0.002 * event?.deltaTime, 0, false);
-    });
-    keys.d.addEventListener(holdEvent.HOLD_EVENT_TYPE.HOLDING, (event) => {
-      cameraControls.truck(0.002 * event?.deltaTime, 0, false);
-    });
-    keys.w.addEventListener(holdEvent.HOLD_EVENT_TYPE.HOLDING, (event) => {
-      cameraControls.forward(0.002 * event?.deltaTime, false);
-    });
-    keys.s.addEventListener(holdEvent.HOLD_EVENT_TYPE.HOLDING, (event) => {
-      cameraControls.forward(-0.002 * event?.deltaTime, false);
-    });
-    keys.q.addEventListener(holdEvent.HOLD_EVENT_TYPE.HOLDING, (event) => {
-      cameraControls.elevate(-0.002 * event?.deltaTime, false);
-    });
-    keys.e.addEventListener(holdEvent.HOLD_EVENT_TYPE.HOLDING, (event) => {
-      cameraControls.elevate(0.002 * event?.deltaTime, false);
-    });
-    keys.left.addEventListener(holdEvent.HOLD_EVENT_TYPE.HOLDING, (event) => {
-      cameraControls.rotate(
-        -0.05 * THREE.MathUtils.DEG2RAD * event?.deltaTime,
-        0,
-        true,
-      );
-    });
-    keys.right.addEventListener(holdEvent.HOLD_EVENT_TYPE.HOLDING, (event) => {
-      cameraControls.rotate(
-        0.05 * THREE.MathUtils.DEG2RAD * event?.deltaTime,
-        0,
-        true,
-      );
-    });
-    keys.up.addEventListener(holdEvent.HOLD_EVENT_TYPE.HOLDING, (event) => {
-      cameraControls.rotate(
-        0,
-        -0.05 * THREE.MathUtils.DEG2RAD * event?.deltaTime,
-        true,
-      );
-    });
-    keys.down.addEventListener(holdEvent.HOLD_EVENT_TYPE.HOLDING, (event) => {
-      cameraControls.rotate(
-        0,
-        0.05 * THREE.MathUtils.DEG2RAD * event?.deltaTime,
-        true,
-      );
-    });
-    for (const key of Object.values(keys)) {
-      key.addEventListener(holdEvent.HOLD_EVENT_TYPE.HOLD_START, () => {
-        // Keyboard inputs can overlap, so increment counter.
-        setKeyboardCrosshairCounter((count) => count + 1);
-      });
-      key.addEventListener(holdEvent.HOLD_EVENT_TYPE.HOLD_END, () => {
-        // Decrement counter when key is released.
-        setKeyboardCrosshairCounter((count) => Math.max(0, count - 1));
-      });
-    }
-
-    // TODO: we currently don't remove any event listeners. This is a bit messy
-    // because KeyboardKeyHold attaches listeners directly to the
-    // document/window; it's unclear if we can remove these.
+    const onKeyUp = (event: KeyboardEvent) => {
+      if (!held.delete(event.code)) return;
+      setKeyboardCrosshairCounter((count) => Math.max(0, count - 1));
+    };
+    const onBlur = () => {
+      // A window blur swallows keyups, so drop all held keys at once.
+      if (held.size === 0) return;
+      held.clear();
+      setKeyboardCrosshairCounter(0);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+    window.addEventListener("blur", onBlur);
     return () => {
-      return;
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+      window.removeEventListener("blur", onBlur);
+      held.clear();
     };
-  }, [viewerMutable.cameraControl]);
+  }, []);
+
+  // Apply held-key camera movement each frame. Rates match the previous
+  // hold-event implementation: linear 0.002/ms == 2.0/s, rotation
+  // 0.05 deg/ms == 50 deg/s (`delta` is in seconds).
+  useFrame((_, delta) => {
+    const cameraControls = viewerMutable.cameraControl;
+    const held = heldKeysRef.current;
+    if (cameraControls === null || held.size === 0) return;
+    const linear = 2.0 * delta;
+    const angular = 50.0 * THREE.MathUtils.DEG2RAD * delta;
+    if (held.has("KeyA")) cameraControls.truck(-linear, 0, false);
+    if (held.has("KeyD")) cameraControls.truck(linear, 0, false);
+    if (held.has("KeyW")) cameraControls.forward(linear, false);
+    if (held.has("KeyS")) cameraControls.forward(-linear, false);
+    if (held.has("KeyQ")) cameraControls.elevate(-linear, false);
+    if (held.has("KeyE")) cameraControls.elevate(linear, false);
+    if (held.has("ArrowLeft")) cameraControls.rotate(-angular, 0, true);
+    if (held.has("ArrowRight")) cameraControls.rotate(angular, 0, true);
+    if (held.has("ArrowUp")) cameraControls.rotate(0, -angular, true);
+    if (held.has("ArrowDown")) cameraControls.rotate(0, angular, true);
+  });
+
+  // Stable ref callback: a fresh inline arrow here would be detached/reattached
+  // by React on every commit, so `cameraLocks.apply()` would run on every
+  // render. Keeping the ref stable means `apply()` only runs when the controls
+  // instance actually attaches/changes, which is its intended purpose.
+  const setCameraControlRef = React.useCallback(
+    (controls: CameraControls | null) => {
+      viewerMutable.cameraControl = controls;
+      viewer.interaction.cameraLocks.apply();
+    },
+    [viewerMutable, viewer.interaction.cameraLocks],
+  );
 
   return (
     <>
       <CameraControls
-        ref={(controls) => {
-          viewerMutable.cameraControl = controls;
-          viewer.interaction.cameraLocks.apply();
-        }}
+        ref={setCameraControlRef}
         minDistance={0.01}
         dollySpeed={0.3}
         smoothTime={0.05}
@@ -599,7 +649,11 @@ export function SynchronizedCameraControls() {
       <OrbitOriginTool
         forceShow={forceOrbitOriginTool}
         pivotRef={pivotRef}
+        onDragStart={() => {
+          pivotDraggingRef.current = true;
+        }}
         onPivotChange={(matrix) => {
+          pivotDraggingRef.current = false;
           updateCameraLookAtAndUpFromPivotControl(matrix);
         }}
         update={updatePivotControlFromCameraLookAtAndup}

--- a/src/viser/client/src/HDRJPGEnvironment.tsx
+++ b/src/viser/client/src/HDRJPGEnvironment.tsx
@@ -73,24 +73,10 @@ export function HDRJPGEnvironment({
         } else {
           fadeProgress.current = 1;
         }
+        // Scene properties (environment/background + intensity, rotation,
+        // blur) are applied reactively in the effect below, keyed on
+        // `texture`, so prop changes take effect without a reload.
         setTexture(tex);
-
-        // Set environment.
-        scene.environment = tex;
-        scene.environmentIntensity = environmentIntensity;
-        if (environmentRotation) {
-          scene.environmentRotation = environmentRotation;
-        }
-
-        // Set background if enabled.
-        if (background) {
-          scene.background = tex;
-          scene.backgroundBlurriness = backgroundBlurriness;
-          scene.backgroundIntensity = backgroundIntensity;
-          if (backgroundRotation) {
-            scene.backgroundRotation = backgroundRotation;
-          }
-        }
       },
       undefined,
       (error) => {
@@ -109,6 +95,38 @@ export function HDRJPGEnvironment({
       texture?.dispose();
     };
   }, [texture]);
+
+  // Apply environment/background scene properties reactively. These used to be
+  // set only inside the load effect (keyed on `files`/`gl`), so changing
+  // intensity, rotation, blur, or the background toggle without changing the
+  // file had no effect until a reload.
+  useEffect(() => {
+    if (!texture) return;
+    scene.environment = texture;
+    scene.environmentIntensity = environmentIntensity;
+    if (environmentRotation) {
+      scene.environmentRotation = environmentRotation;
+    }
+    if (background) {
+      scene.background = texture;
+      scene.backgroundBlurriness = backgroundBlurriness;
+      scene.backgroundIntensity = backgroundIntensity;
+      if (backgroundRotation) {
+        scene.backgroundRotation = backgroundRotation;
+      }
+    } else {
+      scene.background = null;
+    }
+  }, [
+    texture,
+    scene,
+    background,
+    backgroundBlurriness,
+    backgroundIntensity,
+    backgroundRotation,
+    environmentIntensity,
+    environmentRotation,
+  ]);
 
   // Animate fade-in (only runs while fading).
   useFrame(() => {

--- a/src/viser/client/src/HDRJPGEnvironment.tsx
+++ b/src/viser/client/src/HDRJPGEnvironment.tsx
@@ -96,10 +96,9 @@ export function HDRJPGEnvironment({
     };
   }, [texture]);
 
-  // Apply environment/background scene properties reactively. These used to be
-  // set only inside the load effect (keyed on `files`/`gl`), so changing
-  // intensity, rotation, blur, or the background toggle without changing the
-  // file had no effect until a reload.
+  // Apply environment/background scene properties reactively, keyed on the
+  // properties themselves, so changing intensity, rotation, blur, or the
+  // background toggle takes effect without reloading the file.
   useEffect(() => {
     if (!texture) return;
     scene.environment = texture;

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -506,15 +506,23 @@ function useMessageHandler() {
               type: "image/" + message.format,
             }),
           );
-          new TextureLoader().load(rgb_url, (texture) => {
-            URL.revokeObjectURL(rgb_url);
-            const oldBackgroundTexture =
-              viewerMutable.backgroundMaterial!.uniforms.colorMap.value;
-            viewerMutable.backgroundMaterial!.uniforms.colorMap.value = texture;
+          new TextureLoader().load(
+            rgb_url,
+            (texture) => {
+              URL.revokeObjectURL(rgb_url);
+              const oldBackgroundTexture =
+                viewerMutable.backgroundMaterial!.uniforms.colorMap.value;
+              viewerMutable.backgroundMaterial!.uniforms.colorMap.value =
+                texture;
 
-            // Dispose the old background texture.
-            if (isTexture(oldBackgroundTexture)) oldBackgroundTexture.dispose();
-          });
+              // Dispose the old background texture.
+              if (isTexture(oldBackgroundTexture))
+                oldBackgroundTexture.dispose();
+            },
+            undefined,
+            // Revoke on failure too, otherwise the object URL leaks.
+            () => URL.revokeObjectURL(rgb_url),
+          );
 
           viewerMutable.backgroundMaterial!.uniforms.enabled.value = true;
         } else {
@@ -537,13 +545,28 @@ function useMessageHandler() {
               type: "image/" + message.format,
             }),
           );
-          new TextureLoader().load(depth_url, (texture) => {
-            URL.revokeObjectURL(depth_url);
-            const oldDepthTexture =
-              viewerMutable.backgroundMaterial?.uniforms.depthMap.value;
-            viewerMutable.backgroundMaterial!.uniforms.depthMap.value = texture;
-            if (isTexture(oldDepthTexture)) oldDepthTexture.dispose();
-          });
+          new TextureLoader().load(
+            depth_url,
+            (texture) => {
+              URL.revokeObjectURL(depth_url);
+              const oldDepthTexture =
+                viewerMutable.backgroundMaterial?.uniforms.depthMap.value;
+              viewerMutable.backgroundMaterial!.uniforms.depthMap.value =
+                texture;
+              if (isTexture(oldDepthTexture)) oldDepthTexture.dispose();
+            },
+            undefined,
+            // Revoke on failure too, otherwise the object URL leaks.
+            () => URL.revokeObjectURL(depth_url),
+          );
+        } else {
+          // No depth in this message: free any existing depth texture so it
+          // isn't orphaned on the GPU (kept alive by the uniform but never
+          // disposed), and clear the uniform back to its initial null.
+          const oldDepthTexture =
+            viewerMutable.backgroundMaterial!.uniforms.depthMap.value;
+          if (isTexture(oldDepthTexture)) oldDepthTexture.dispose();
+          viewerMutable.backgroundMaterial!.uniforms.depthMap.value = null;
         }
         return;
       }
@@ -662,6 +685,16 @@ function useFileDownloadHandler(): (
       }
       case "FileTransferPart": {
         const downloadState = downloadStatesRef.current[message.transfer_uuid];
+        if (downloadState === undefined) {
+          // A part for an unknown/cleared transfer (e.g. its start message was
+          // lost). Drop it rather than dereferencing undefined and throwing out
+          // of the per-frame message loop.
+          console.error(
+            "Received FileTransferPart for unknown transfer",
+            message.transfer_uuid,
+          );
+          return;
+        }
         if (message.part_index != downloadState.parts.length) {
           console.error("A file download message was received out of order!");
         }
@@ -755,7 +788,6 @@ export function FrameSynchronizedMessageHandler() {
   const messageQueue = viewerMutable.messageQueue;
   const splatContext = React.useContext(GaussianSplatsContext)!;
   const gl = useThree((state) => state.gl);
-  const isFirstBatchRef = React.useRef(true);
 
   useFrame(
     () => {
@@ -763,105 +795,146 @@ export function FrameSynchronizedMessageHandler() {
       if (viewerMutable.getRenderRequestState === "triggered") {
         viewerMutable.getRenderRequestState = "pause";
       } else if (viewerMutable.getRenderRequestState === "pause") {
-        const cameraPosition = viewerMutable.getRenderRequest!.position;
-        const cameraWxyz = viewerMutable.getRenderRequest!.wxyz;
-        const cameraFov = viewerMutable.getRenderRequest!.fov;
-
         const targetWidth = viewerMutable.getRenderRequest!.width;
         const targetHeight = viewerMutable.getRenderRequest!.height;
+        const format = viewerMutable.getRenderRequest!.format;
+        // Captured now so the response can be correlated to its request even
+        // after the async toBlob below.
+        const renderUuid = viewerMutable.getRenderRequest!.render_uuid;
 
-        // Render the scene using the virtual camera.
-        const T_threeworld_world = computeT_threeworld_world(viewer);
+        // Snapshot renderer state up front so the `finally` below can always
+        // restore it, even if rendering throws partway through.
+        const originalSize = gl.getSize(new THREE.Vector2());
+        const originalClearColor = gl.getClearColor(new THREE.Color());
+        const originalClearAlpha = gl.getClearAlpha();
 
-        // Create a new perspective camera.
-        const camera = new THREE.PerspectiveCamera(
-          THREE.MathUtils.radToDeg(cameraFov),
-          targetWidth / targetHeight,
-          0.01, // Near.
-          1000.0, // Far.
-        );
-
-        // Set camera pose.
-        camera.position.set(...cameraPosition).applyMatrix4(T_threeworld_world);
-        camera.setRotationFromQuaternion(
-          new THREE.Quaternion(
-            cameraWxyz[1],
-            cameraWxyz[2],
-            cameraWxyz[3],
-            cameraWxyz[0],
-          )
-            .premultiply(
-              new THREE.Quaternion().setFromRotationMatrix(T_threeworld_world),
-            )
-            .multiply(
-              // OpenCV => OpenGL coordinate system conversion.
-              new THREE.Quaternion().setFromAxisAngle(
-                new THREE.Vector3(1, 0, 0),
-                Math.PI,
-              ),
-            ),
-        );
-
-        // Update splatting camera if needed.
-        // We'll back up the current sorted indices, and restore them after rendering.
+        // Splat sorted-index backup, restored in `finally`.
         const splatMeshProps = splatContext.meshPropsRef.current;
         const sortedIndicesOrig =
           splatMeshProps !== null
             ? splatMeshProps.sortedIndexAttribute.array.slice()
             : null;
-        if (splatContext.updateCamera.current !== null)
-          splatContext.updateCamera.current!(
-            camera,
-            targetWidth,
-            targetHeight,
-            true,
-          );
 
-        // Save current renderer state.
-        const originalSize = gl.getSize(new THREE.Vector2());
-        const originalClearColor = gl.getClearColor(new THREE.Color());
-        const originalClearAlpha = gl.getClearAlpha();
-
-        // Configure for capture.
-        gl.setSize(targetWidth, targetHeight);
-        gl.setClearColor(0xffffff);
-        gl.setClearAlpha(
-          viewerMutable.getRenderRequest!.format == "image/png" ? 0.0 : 1.0,
-        );
-
-        // Render the scene.
-        gl.render(viewerMutable.scene!, camera);
-
-        // Temporary canvas for saving the rendered image. This is needed to
-        // prevent flickers: we need context from the original canvas for
-        // rendering, but we want to revert the renderer state immediately.
-        const canvas = gl.domElement;
-        const bufferCanvas = document.createElement("canvas");
-        bufferCanvas.width = targetWidth;
-        bufferCanvas.height = targetHeight;
-        const ctx = bufferCanvas.getContext("2d")!;
-        ctx.drawImage(canvas, 0, 0, targetWidth, targetHeight);
-
-        // Restore the original renderer state.
-        gl.setSize(originalSize.x, originalSize.y);
-        gl.setClearColor(originalClearColor);
-        gl.setClearAlpha(originalClearAlpha);
-
-        // Restore splatting indices.
-        if (sortedIndicesOrig !== null && splatMeshProps !== null) {
-          splatMeshProps.sortedIndexAttribute.array = sortedIndicesOrig;
-          splatMeshProps.sortedIndexAttribute.needsUpdate = true;
-        }
-
-        // Get the rendered image from our temp canvas.
-        viewerMutable.getRenderRequestState = "in_progress";
-        bufferCanvas.toBlob(async (blob) => {
+        // An empty payload is the failure sentinel: it lets the server's
+        // pending get_render() resolve instead of blocking forever.
+        const sendRenderResponse = (payload: Uint8Array<ArrayBuffer>) =>
           viewerMutable.sendMessage({
             type: "GetRenderResponseMessage",
-            payload: new Uint8Array(await blob!.arrayBuffer()),
+            payload,
+            render_uuid: renderUuid,
           });
+
+        // Once we enter capture we must always return to "ready" -- otherwise
+        // an exception (or a null toBlob) would wedge the render state machine
+        // and block all further message handling, which is gated on "ready".
+        try {
+          const cameraPosition = viewerMutable.getRenderRequest!.position;
+          const cameraWxyz = viewerMutable.getRenderRequest!.wxyz;
+          const cameraFov = viewerMutable.getRenderRequest!.fov;
+
+          // Render the scene using the virtual camera.
+          const T_threeworld_world = computeT_threeworld_world(viewer);
+
+          // Create a new perspective camera.
+          const camera = new THREE.PerspectiveCamera(
+            THREE.MathUtils.radToDeg(cameraFov),
+            targetWidth / targetHeight,
+            0.01, // Near.
+            1000.0, // Far.
+          );
+
+          // Set camera pose.
+          camera.position
+            .set(...cameraPosition)
+            .applyMatrix4(T_threeworld_world);
+          camera.setRotationFromQuaternion(
+            new THREE.Quaternion(
+              cameraWxyz[1],
+              cameraWxyz[2],
+              cameraWxyz[3],
+              cameraWxyz[0],
+            )
+              .premultiply(
+                new THREE.Quaternion().setFromRotationMatrix(
+                  T_threeworld_world,
+                ),
+              )
+              .multiply(
+                // OpenCV => OpenGL coordinate system conversion.
+                new THREE.Quaternion().setFromAxisAngle(
+                  new THREE.Vector3(1, 0, 0),
+                  Math.PI,
+                ),
+              ),
+          );
+
+          // Update splatting camera if needed.
+          if (splatContext.updateCamera.current !== null)
+            splatContext.updateCamera.current!(
+              camera,
+              targetWidth,
+              targetHeight,
+              true,
+            );
+
+          // Configure for capture.
+          gl.setSize(targetWidth, targetHeight);
+          gl.setClearColor(0xffffff);
+          gl.setClearAlpha(format == "image/png" ? 0.0 : 1.0);
+
+          // Render the scene.
+          gl.render(viewerMutable.scene!, camera);
+
+          // Temporary canvas for saving the rendered image. This is needed to
+          // prevent flickers: we need context from the original canvas for
+          // rendering, but we want to revert the renderer state immediately.
+          const canvas = gl.domElement;
+          const bufferCanvas = document.createElement("canvas");
+          bufferCanvas.width = targetWidth;
+          bufferCanvas.height = targetHeight;
+          const ctx = bufferCanvas.getContext("2d")!;
+          ctx.drawImage(canvas, 0, 0, targetWidth, targetHeight);
+
+          // Get the rendered image from our temp canvas.
+          viewerMutable.getRenderRequestState = "in_progress";
+          bufferCanvas.toBlob((blob) => {
+            void (async () => {
+              try {
+                // `toBlob` can hand back null (e.g. canvas too large / OOM);
+                // fall back to an empty payload so the server's pending
+                // request resolves instead of hanging forever.
+                sendRenderResponse(
+                  blob === null
+                    ? new Uint8Array(0)
+                    : new Uint8Array(await blob.arrayBuffer()),
+                );
+              } catch (e) {
+                console.error("Failed to read rendered image:", e);
+                sendRenderResponse(new Uint8Array(0));
+              } finally {
+                viewerMutable.getRenderRequestState = "ready";
+              }
+            })();
+          }, format);
+        } catch (e) {
+          console.error("Render request failed:", e);
+          // The toBlob callback won't run, so send the failure sentinel now --
+          // otherwise the server's get_render() blocks forever waiting for a
+          // response. Then resume message handling.
+          sendRenderResponse(new Uint8Array(0));
           viewerMutable.getRenderRequestState = "ready";
-        }, viewerMutable.getRenderRequest!.format);
+        } finally {
+          // Restore the original renderer state.
+          gl.setSize(originalSize.x, originalSize.y);
+          gl.setClearColor(originalClearColor);
+          gl.setClearAlpha(originalClearAlpha);
+
+          // Restore splatting indices.
+          if (sortedIndicesOrig !== null && splatMeshProps !== null) {
+            splatMeshProps.sortedIndexAttribute.array = sortedIndicesOrig;
+            splatMeshProps.sortedIndexAttribute.needsUpdate = true;
+          }
+        }
       }
 
       // Handle messages, but only if we're not trying to render something.
@@ -886,8 +959,8 @@ export function FrameSynchronizedMessageHandler() {
         // Hack: On the very first batch, handle any root node SetOrientationMessage
         // (from set_up_direction()) before all other messages. This ensures
         // T_threeworld_world is up-to-date when initial camera messages are processed.
-        if (isFirstBatchRef.current) {
-          isFirstBatchRef.current = false;
+        if (viewerMutable.firstMessageBatch) {
+          viewerMutable.firstMessageBatch = false;
           const rootOrientationIndex = processBatch.findIndex(
             (msg) => msg.type === "SetOrientationMessage" && msg.name === "",
           );

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -24,6 +24,39 @@ import { rootNodeTemplate, SceneNode } from "./SceneTreeState";
 import { applyGuiConfigUpdate } from "./ControlPanel/GuiState";
 import { GaussianSplatsContext } from "./Splatting/GaussianSplatsHelpers";
 
+/** Swap a background-material uniform to a new texture (or null), disposing the
+ * previous texture if there was one. */
+function swapBackgroundTexture(
+  uniform: THREE.IUniform,
+  next: THREE.Texture | null,
+) {
+  const old = uniform.value;
+  uniform.value = next;
+  if (isTexture(old)) old.dispose();
+}
+
+/** Load image data into a background-material uniform, disposing the previous
+ * texture once the new one is ready. Revokes the object URL on success and on
+ * failure so it never leaks. */
+function loadBackgroundTexture(
+  data: Uint8Array<ArrayBuffer>,
+  format: string,
+  uniform: THREE.IUniform,
+) {
+  const url = URL.createObjectURL(
+    new Blob([data], { type: "image/" + format }),
+  );
+  new TextureLoader().load(
+    url,
+    (texture) => {
+      URL.revokeObjectURL(url);
+      swapBackgroundTexture(uniform, texture);
+    },
+    undefined,
+    () => URL.revokeObjectURL(url),
+  );
+}
+
 /** Returns a handler for all incoming messages. */
 function useMessageHandler() {
   const viewer = useContext(ViewerContext)!;
@@ -501,37 +534,18 @@ function useMessageHandler() {
       // Add a background image.
       case "BackgroundImageMessage": {
         if (message.rgb_data !== null) {
-          const rgb_url = URL.createObjectURL(
-            new Blob([message.rgb_data], {
-              type: "image/" + message.format,
-            }),
+          loadBackgroundTexture(
+            message.rgb_data,
+            message.format,
+            viewerMutable.backgroundMaterial!.uniforms.colorMap,
           );
-          new TextureLoader().load(
-            rgb_url,
-            (texture) => {
-              URL.revokeObjectURL(rgb_url);
-              const oldBackgroundTexture =
-                viewerMutable.backgroundMaterial!.uniforms.colorMap.value;
-              viewerMutable.backgroundMaterial!.uniforms.colorMap.value =
-                texture;
-
-              // Dispose the old background texture.
-              if (isTexture(oldBackgroundTexture))
-                oldBackgroundTexture.dispose();
-            },
-            undefined,
-            // Revoke on failure too, otherwise the object URL leaks.
-            () => URL.revokeObjectURL(rgb_url),
-          );
-
           viewerMutable.backgroundMaterial!.uniforms.enabled.value = true;
         } else {
-          // Dispose the old background texture.
-          const oldBackgroundTexture =
-            viewerMutable.backgroundMaterial!.uniforms.colorMap.value;
-          if (isTexture(oldBackgroundTexture)) oldBackgroundTexture.dispose();
-
-          // Disable the background.
+          // Dispose the old background texture and disable the background.
+          swapBackgroundTexture(
+            viewerMutable.backgroundMaterial!.uniforms.colorMap,
+            null,
+          );
           viewerMutable.backgroundMaterial!.uniforms.enabled.value = false;
         }
 
@@ -540,33 +554,19 @@ function useMessageHandler() {
           message.depth_data !== null;
         if (message.depth_data !== null) {
           // If depth is available set the texture.
-          const depth_url = URL.createObjectURL(
-            new Blob([message.depth_data], {
-              type: "image/" + message.format,
-            }),
-          );
-          new TextureLoader().load(
-            depth_url,
-            (texture) => {
-              URL.revokeObjectURL(depth_url);
-              const oldDepthTexture =
-                viewerMutable.backgroundMaterial?.uniforms.depthMap.value;
-              viewerMutable.backgroundMaterial!.uniforms.depthMap.value =
-                texture;
-              if (isTexture(oldDepthTexture)) oldDepthTexture.dispose();
-            },
-            undefined,
-            // Revoke on failure too, otherwise the object URL leaks.
-            () => URL.revokeObjectURL(depth_url),
+          loadBackgroundTexture(
+            message.depth_data,
+            message.format,
+            viewerMutable.backgroundMaterial!.uniforms.depthMap,
           );
         } else {
           // No depth in this message: free any existing depth texture so it
           // isn't orphaned on the GPU (kept alive by the uniform but never
           // disposed), and clear the uniform back to its initial null.
-          const oldDepthTexture =
-            viewerMutable.backgroundMaterial!.uniforms.depthMap.value;
-          if (isTexture(oldDepthTexture)) oldDepthTexture.dispose();
-          viewerMutable.backgroundMaterial!.uniforms.depthMap.value = null;
+          swapBackgroundTexture(
+            viewerMutable.backgroundMaterial!.uniforms.depthMap,
+            null,
+          );
         }
         return;
       }

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -914,7 +914,6 @@ export function SceneNodeThreeObject(props: { name: string }) {
         if (!objRef.current.matrixWorldAutoUpdate)
           objRef.current.updateMatrixWorld();
       }
-
     },
     // Other useFrame hooks may depend on transforms + visibility. So it's best
     // to call this hook early.

--- a/src/viser/client/src/SceneTreeState.ts
+++ b/src/viser/client/src/SceneTreeState.ts
@@ -15,7 +15,6 @@ export type SceneNode = {
   clickBindings: DragBinding[];
   dragBindings: DragBinding[];
   labelVisible?: boolean; // Whether to show the label for this node.
-  poseUpdateState?: "updated" | "needsUpdate" | "waitForMakeObject";
   wxyz?: [number, number, number, number];
   position?: [number, number, number];
   visibility?: boolean; // Visibility state from the server.
@@ -169,7 +168,7 @@ function createSceneTreeActions(
       }
       // Skip the store write when nothing actually changed -- the prop editor
       // auto-submits on every Switch/Select/ColorInput change, and a no-op
-      // write would still notify zustand subscribers and re-render every
+      // write would still notify store subscribers and re-render every
       // useSceneTree consumer of this node.
       //
       // Shallow-compare arrays explicitly: ColorInput (and tuple-shaped scale
@@ -333,6 +332,13 @@ export function useSceneTreeState(
       nodeRefFromName,
       nodePoseData,
     );
+
+    // Establish the default state up front via the same path used on
+    // (re)connect. This seeds the root node's pose into nodePoseData -- which
+    // the pose sync needs in order to orient the root frame (and the
+    // /WorldAxes gizmo under it). Without it, the root renders at identity (the
+    // three.js Y-up frame) until the first connection.
+    actions.resetScene();
 
     // Return both store and helpers.
     return { store, actions };

--- a/src/viser/client/src/Splatting/GaussianSplats.tsx
+++ b/src/viser/client/src/Splatting/GaussianSplats.tsx
@@ -168,7 +168,7 @@ function SplatRendererImpl() {
   const [, forceUpdate] = React.useReducer((x) => x + 1, 0);
 
   // Consolidate Gaussian groups into a single buffer.
-  // Memoized on groupBufferFromId reference -- zustand returns the same
+  // Memoized on groupBufferFromId reference -- the store returns the same
   // reference when state hasn't changed, so this avoids re-merging every render.
   const merged = React.useMemo(
     () => mergeGaussianGroups(groupBufferFromId),

--- a/src/viser/client/src/ViewerContext.ts
+++ b/src/viser/client/src/ViewerContext.ts
@@ -47,8 +47,23 @@ export type ViewerMutable = {
 
   // Message and rendering state.
   messageQueue: Message[];
+  // True until the first message batch of the current connection is processed.
+  // Reset to true on every (re)connect so the root-orientation-first ordering
+  // hack runs again. Lives here (not a component ref) so WebsocketInterface can
+  // reset it on reconnect.
+  firstMessageBatch: boolean;
   getRenderRequestState: "ready" | "triggered" | "pause" | "in_progress";
   getRenderRequest: null | GetRenderRequestMessage;
+
+  // Diagnostic snapshot for the initial-camera / scene-orientation flow,
+  // exposed via window.__viserMutable for e2e tests + debugging. See
+  // initial_pose_and_scene_orientation.md. `rootWxyzAtCapture` is the root
+  // node's orientation observed when SynchronizedCameraControls captured
+  // `initialT` at mount -- a mount-ordering race would leave this at identity
+  // [1,0,0,0] instead of the +Z-up default [0.5,-0.5,0.5,0.5].
+  initialCameraDiagnostic: {
+    rootWxyzAtCapture: [number, number, number, number];
+  } | null;
 
   // Skinned mesh state.
   skinnedMeshState: {

--- a/src/viser/client/src/WebsocketClientWorker.ts
+++ b/src/viser/client/src/WebsocketClientWorker.ts
@@ -166,64 +166,95 @@ function decodeHybridMessage(
 
       // Try our best to handle messages in order. If this takes more than 10 seconds, we give up. :)
       const jsReceivedMs = performance.now();
-      await orderLock.acquireAsync({ timeout: 10000 }).catch(() => {
-        console.log("Order lock timed out.");
-        orderLock.release();
-      });
-      const data = await dataPromise;
+      let acquiredLock = false;
+      try {
+        await orderLock.acquireAsync({ timeout: 10000 });
+        acquiredLock = true;
+      } catch {
+        // Timed out waiting for the in-order slot. Proceed without the lock
+        // (out of order) rather than calling release() on a lock we never
+        // acquired -- that would release another waiter's hold and corrupt the
+        // ordering state.
+        console.log("Order lock timed out; processing message out of order.");
+      }
+      // Once the lock is acquired the release happens in `sendFn` (which may
+      // be deferred via setTimeout). If anything between here and scheduling
+      // `sendFn` throws -- e.g. decode fails -- we must still release, or the
+      // lock stays held and every subsequent message times out.
+      try {
+        const data = await dataPromise;
 
-      // Compute offset between JavaScript and Python time.
-      state.jsTimeMinusPythonTime = Math.min(
-        jsReceivedMs - data.timestampSec * 1000,
-        state.jsTimeMinusPythonTime,
-      );
+        // Compute offset between JavaScript and Python time.
+        state.jsTimeMinusPythonTime = Math.min(
+          jsReceivedMs - data.timestampSec * 1000,
+          state.jsTimeMinusPythonTime,
+        );
 
-      // Function to send the message and release the order lock.
-      const messages = data.messages;
-      // All typed array views point into the original WebSocket ArrayBuffer.
-      // Transfer just that buffer instead of walking the entire message tree.
-      const sendFn = () => {
-        postOutgoing({ type: "message_batch", messages: messages }, [
-          data.buffer,
-        ]);
-        orderLock.release();
-      };
+        // Function to send the message and release the order lock.
+        const messages = data.messages;
+        // All typed array views point into the original WebSocket ArrayBuffer.
+        // Transfer just that buffer instead of walking the entire message tree.
+        const sendFn = () => {
+          try {
+            postOutgoing({ type: "message_batch", messages: messages }, [
+              data.buffer,
+            ]);
+          } catch (e) {
+            // `sendFn` can run later from setTimeout, outside the catch below.
+            // Log and still release the lock so one bad post cannot wedge all
+            // later message ordering.
+            console.error("Failed to post incoming message batch:", e);
+          } finally {
+            // Only release if we actually acquired the lock above.
+            if (acquiredLock) {
+              orderLock.release();
+              acquiredLock = false;
+            }
+          }
+        };
 
-      // Calculate timing deltas between Python and JavaScript.
-      const jsNowMs = performance.now();
-      const currentPythonTimestampMs = data.timestampSec * 1000;
-      const pythonTimeDeltaMs =
-        currentPythonTimestampMs -
-        (state.prevPythonTimestampMs ?? currentPythonTimestampMs);
-      state.prevPythonTimestampMs = currentPythonTimestampMs;
+        // Calculate timing deltas between Python and JavaScript.
+        const jsNowMs = performance.now();
+        const currentPythonTimestampMs = data.timestampSec * 1000;
+        const pythonTimeDeltaMs =
+          currentPythonTimestampMs -
+          (state.prevPythonTimestampMs ?? currentPythonTimestampMs);
+        state.prevPythonTimestampMs = currentPythonTimestampMs;
 
-      if (
-        // Flush immediately for first message.
-        state.lastIdealJsMs === undefined ||
-        // Flush immediately if the Python delta is large, in this case we're
-        // probably not sensitive to exact timing.
-        pythonTimeDeltaMs > 100 ||
-        // Flush if we're more than 100ms behind real-time.
-        jsNowMs - state.jsTimeMinusPythonTime - currentPythonTimestampMs > 100
-      ) {
-        // First message or no expected delta, send immediately.
-        sendFn();
-        state.lastIdealJsMs = jsNowMs;
-      } else {
-        // For messages that are being sent frequently: smooth out the sending rate.
-        const idealNextSendTimeMs = state.lastIdealJsMs + pythonTimeDeltaMs;
-        const timeUntilIdealJsMs = idealNextSendTimeMs - jsNowMs;
-
-        if (timeUntilIdealJsMs > 3) {
-          // We're early! This means the previous message was processed late...
-          const dampingFactor = 0.95;
-          setTimeout(sendFn, timeUntilIdealJsMs * dampingFactor);
-          state.lastIdealJsMs =
-            state.lastIdealJsMs + pythonTimeDeltaMs * dampingFactor;
-        } else {
-          // Message is on-time or late: send immediately.
+        if (
+          // Flush immediately for first message.
+          state.lastIdealJsMs === undefined ||
+          // Flush immediately if the Python delta is large, in this case we're
+          // probably not sensitive to exact timing.
+          pythonTimeDeltaMs > 100 ||
+          // Flush if we're more than 100ms behind real-time.
+          jsNowMs - state.jsTimeMinusPythonTime - currentPythonTimestampMs > 100
+        ) {
+          // First message or no expected delta, send immediately.
           sendFn();
           state.lastIdealJsMs = jsNowMs;
+        } else {
+          // For messages that are being sent frequently: smooth out the sending rate.
+          const idealNextSendTimeMs = state.lastIdealJsMs + pythonTimeDeltaMs;
+          const timeUntilIdealJsMs = idealNextSendTimeMs - jsNowMs;
+
+          if (timeUntilIdealJsMs > 3) {
+            // We're early! This means the previous message was processed late...
+            const dampingFactor = 0.95;
+            setTimeout(sendFn, timeUntilIdealJsMs * dampingFactor);
+            state.lastIdealJsMs =
+              state.lastIdealJsMs + pythonTimeDeltaMs * dampingFactor;
+          } else {
+            // Message is on-time or late: send immediately.
+            sendFn();
+            state.lastIdealJsMs = jsNowMs;
+          }
+        }
+      } catch (e) {
+        console.error("Failed to process incoming message:", e);
+        if (acquiredLock) {
+          orderLock.release();
+          acquiredLock = false;
         }
       }
     };
@@ -233,7 +264,12 @@ function decodeHybridMessage(
     const data: WsWorkerIncoming = e.data;
 
     if (data.type === "send") {
-      ws!.send(msgpack.encode(data.message));
+      // The socket can be null (not yet connected) or closing/closed by the
+      // time a send arrives; only send when it's actually open, otherwise drop
+      // it rather than throwing in the worker.
+      if (ws !== null && ws.readyState === WebSocket.OPEN) {
+        ws.send(msgpack.encode(data.message));
+      }
     } else if (data.type === "set_server") {
       server = data.server;
       tryConnect();

--- a/src/viser/client/src/WebsocketInterface.tsx
+++ b/src/viser/client/src/WebsocketInterface.tsx
@@ -56,6 +56,12 @@ export function WebsocketMessageProducer() {
         isConnected = true;
         resetGui();
         resetScene();
+        // Drop any messages left over from the previous connection and re-arm
+        // the first-batch ordering hack, so the server's fresh scene replay
+        // applies against clean state. The worker/ref persist across reconnects,
+        // so this transient state isn't reset for us.
+        viewerMutable.messageQueue.length = 0;
+        viewerMutable.firstMessageBatch = true;
         viewer.useGui.set({ websocketState: "connected" });
         updateRetryInterval();
         viewerMutable.sendMessage = (message) => {

--- a/src/viser/client/src/WebsocketInterface.tsx
+++ b/src/viser/client/src/WebsocketInterface.tsx
@@ -62,6 +62,12 @@ export function WebsocketMessageProducer() {
         // so this transient state isn't reset for us.
         viewerMutable.messageQueue.length = 0;
         viewerMutable.firstMessageBatch = true;
+        // Clear any render request left in flight from the previous connection.
+        // Message handling is gated on this being "ready", and a stale request
+        // would otherwise render once against the fresh scene (its response is
+        // dropped via render_uuid mismatch anyway).
+        viewerMutable.getRenderRequestState = "ready";
+        viewerMutable.getRenderRequest = null;
         viewer.useGui.set({ websocketState: "connected" });
         updateRetryInterval();
         viewerMutable.sendMessage = (message) => {

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -1728,6 +1728,7 @@ export interface GetRenderRequestMessage {
   wxyz: [number, number, number, number];
   position: [number, number, number];
   fov: number;
+  render_uuid: string;
 }
 /** Message from client->server carrying a render.
  *
@@ -1736,6 +1737,7 @@ export interface GetRenderRequestMessage {
 export interface GetRenderResponseMessage {
   type: "GetRenderResponseMessage";
   payload: Uint8Array<ArrayBuffer>;
+  render_uuid: string;
 }
 /** Signal that a file is about to be sent.
  *

--- a/src/viser/client/src/mesh/BatchedGlbAsset.tsx
+++ b/src/viser/client/src/mesh/BatchedGlbAsset.tsx
@@ -22,14 +22,16 @@ export const BatchedGlbAsset = React.forwardRef<
 >(function BatchedGlbAsset({ children, ...message }, ref) {
   const viewer = React.useContext(ViewerContext)!;
   const clickable =
-    (viewer.useSceneTree(message.name, (node) => node?.clickBindings?.length)
-      ?? 0) > 0;
+    (viewer.useSceneTree(message.name, (node) => node?.clickBindings?.length) ??
+      0) > 0;
   const draggable =
-    (viewer.useSceneTree(
-      message.name,
-      (node) => node?.dragBindings,
-      shallowArrayEqual,
-    ) ?? []).length > 0;
+    (
+      viewer.useSceneTree(
+        message.name,
+        (node) => node?.dragBindings,
+        shallowArrayEqual,
+      ) ?? []
+    ).length > 0;
 
   // Note: We don't support animations for batched meshes.
   const { gltf } = useGlbLoader(message.props.glb_data);
@@ -64,6 +66,16 @@ export const BatchedGlbAsset = React.forwardRef<
       material: finalMaterial,
     };
   }, [gltf]);
+
+  // `mergedGeometry` is owned here (a clone/merge of the source geometries);
+  // BatchedMeshBase clones it again rather than taking ownership, so we must
+  // free it when it changes or on unmount. The source materials/geometries are
+  // disposed by useGlbLoader's own cleanup.
+  React.useEffect(() => {
+    return () => {
+      geometry?.dispose();
+    };
+  }, [geometry]);
 
   if (!geometry || !material) return null;
 

--- a/src/viser/client/src/mesh/BatchedMeshBase.tsx
+++ b/src/viser/client/src/mesh/BatchedMeshBase.tsx
@@ -157,7 +157,10 @@ export const BatchedMeshBase = React.forwardRef<
     // Create new InstancedMesh2.
     const instanceCount =
       props.batched_positions.byteLength / (3 * Float32Array.BYTES_PER_ELEMENT);
-    const newMesh = new InstancedMesh2(props.geometry.clone(), props.material, {
+    // We own this clone of the geometry; it must be disposed in cleanup since
+    // InstancedMesh2.dispose() only frees its internal textures, not geometry.
+    const ownedGeometry = props.geometry.clone();
+    const newMesh = new InstancedMesh2(ownedGeometry, props.material, {
       capacity: instanceCount,
       renderer: gl,
     });
@@ -189,6 +192,9 @@ export const BatchedMeshBase = React.forwardRef<
       // Cleanup on unmount or when dependencies change.
       newMesh.disposeBVH();
       newMesh.dispose();
+      // InstancedMesh2.dispose() frees its textures but not its geometry, so
+      // dispose the clone we created.
+      ownedGeometry.dispose();
       // Dispose LOD resources captured via closure.
       lodGeometries.forEach((geometry) => geometry.dispose());
       lodMaterials.forEach((material) => material.dispose());

--- a/src/viser/client/src/mesh/GlbLoaderUtils.ts
+++ b/src/viser/client/src/mesh/GlbLoaderUtils.ts
@@ -31,25 +31,59 @@ export function disposeNode(node: any) {
  * Custom hook for loading a GLB model.
  */
 export function useGlbLoader(glb_data: Uint8Array) {
-  // State for loaded model and meshes.
-  const [gltf, setGltf] = React.useState<GLTF>();
-  const [meshes, setMeshes] = React.useState<THREE.Mesh[]>([]);
-  // Per-mesh transforms relative to the gltf.scene root. These capture
-  // ancestor node transforms (e.g. translations on glTF nodes) that are not
-  // present in mesh.position/mesh.geometry alone.
-  const [meshMatrices, setMeshMatrices] = React.useState<THREE.Matrix4[]>([]);
+  // State for loaded model and meshes, tagged by the exact input object they
+  // were parsed from. On a `glb_data` change, render must stop returning the
+  // previous scene immediately: the old load's cleanup can dispose it before
+  // the new parse completes.
+  const [loaded, setLoaded] = React.useState<
+    | {
+        source: Uint8Array;
+        gltf: GLTF;
+        meshes: THREE.Mesh[];
+        // Per-mesh transforms relative to the gltf.scene root. These capture
+        // ancestor node transforms (e.g. translations on glTF nodes) that are
+        // not present in mesh.position/mesh.geometry alone.
+        meshMatrices: THREE.Matrix4[];
+      }
+    | undefined
+  >();
 
   // Animation mixer reference.
   const mixerRef = React.useRef<THREE.AnimationMixer | null>(null);
 
   // Load the GLB model.
   React.useEffect(() => {
+    // Tracks teardown so an async parse that resolves after unmount (or after
+    // ``glb_data`` changes) neither updates state nor leaks GPU resources.
+    let cancelled = false;
+    // The parsed scene, captured in effect scope so cleanup disposes the
+    // *actual* loaded resources. (Reading the ``gltf`` state in cleanup would
+    // capture the render-time value, which is always ``undefined`` here since
+    // it's set asynchronously -- so nothing would ever be disposed.)
+    let loadedScene: THREE.Object3D | null = null;
+
+    // Drop the stale result from state as soon as effects run. The return value
+    // below also gates by source identity, so stale data is hidden during the
+    // render that happens before this effect/cleanup pair runs.
+    setLoaded((current) =>
+      current?.source === glb_data ? current : undefined,
+    );
+
     const loader = new GLTFLoader();
     loader.setDRACOLoader(dracoLoader);
     loader.parse(
       new Uint8Array(glb_data).buffer,
       "",
       (gltf) => {
+        if (cancelled) {
+          // Unmounted/changed before the parse finished: dispose the freshly
+          // parsed resources rather than leaking them, and skip the state
+          // updates (which would warn and write into a dead component).
+          gltf.scene.traverse(disposeNode);
+          return;
+        }
+        loadedScene = gltf.scene;
+
         // Setup animations if present.
         if (gltf.animations && gltf.animations.length) {
           mixerRef.current = new THREE.AnimationMixer(gltf.scene);
@@ -83,9 +117,12 @@ export function useGlbLoader(glb_data: Uint8Array) {
           }
         });
 
-        setMeshes(meshes);
-        setMeshMatrices(meshMatrices);
-        setGltf(gltf);
+        setLoaded({
+          source: glb_data,
+          gltf,
+          meshes,
+          meshMatrices,
+        });
       },
       (error) => {
         console.log("Error loading GLB!");
@@ -95,16 +132,26 @@ export function useGlbLoader(glb_data: Uint8Array) {
 
     // Cleanup function.
     return () => {
-      if (mixerRef.current) mixerRef.current.stopAllAction();
-
-      // Attempt to free resources.
-      if (gltf) {
-        gltf.scene.traverse(disposeNode);
+      cancelled = true;
+      if (mixerRef.current) {
+        mixerRef.current.stopAllAction();
+        mixerRef.current = null;
+      }
+      // Free the GPU resources owned by this load. If the parse hasn't
+      // resolved yet, the ``cancelled`` branch above disposes them instead.
+      if (loadedScene) {
+        loadedScene.traverse(disposeNode);
       }
     };
   }, [glb_data]);
 
   // Return the loaded model, meshes, per-mesh matrices, and mixer for
   // animation updates.
-  return { gltf, meshes, meshMatrices, mixerRef };
+  const current = loaded?.source === glb_data ? loaded : undefined;
+  return {
+    gltf: current?.gltf,
+    meshes: current?.meshes ?? [],
+    meshMatrices: current?.meshMatrices ?? [],
+    mixerRef,
+  };
 }

--- a/src/viser/client/src/utils/isFormElement.ts
+++ b/src/viser/client/src/utils/isFormElement.ts
@@ -1,0 +1,13 @@
+/** Returns true if the element is a text-entry control (INPUT, TEXTAREA,
+ * SELECT, or contentEditable). Used to suppress global keyboard handlers --
+ * camera movement keys and modifier-key cursor updates -- while the user is
+ * typing into a form field. */
+export function isFormElement(target: EventTarget | Element | null): boolean {
+  const el = target as HTMLElement | null;
+  if (el === null) return false;
+  const tag = el.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") {
+    return true;
+  }
+  return el.isContentEditable;
+}

--- a/src/viser/client/src/utils/useAsyncTexture.ts
+++ b/src/viser/client/src/utils/useAsyncTexture.ts
@@ -14,11 +14,17 @@ export function useAsyncTexture(
       const url = URL.createObjectURL(
         new Blob([data], { type: "image/" + format }),
       );
-      new THREE.TextureLoader().load(url, (tex) => {
-        if (!cancelled) setTexture(tex);
-        else tex.dispose();
-        URL.revokeObjectURL(url);
-      });
+      new THREE.TextureLoader().load(
+        url,
+        (tex) => {
+          if (!cancelled) setTexture(tex);
+          else tex.dispose();
+          URL.revokeObjectURL(url);
+        },
+        undefined,
+        // Revoke on failure too, otherwise the object URL leaks.
+        () => URL.revokeObjectURL(url),
+      );
     } else {
       setTexture(undefined);
     }

--- a/src/viser/infra/_async_message_buffer.py
+++ b/src/viser/infra/_async_message_buffer.py
@@ -115,12 +115,18 @@ class AsyncMessageBuffer:
 
     def atomic_start(self) -> None:
         """Start an atomic block. No new messages/windows should be sent."""
-        self.atomic_counter += 1
+        # Locked: `atomic()` is public and may be entered from multiple threads,
+        # and `+=`/`-=` are non-atomic read-modify-writes. A lost update would
+        # leave the counter stuck != 0 and stall message delivery permanently.
+        with self.buffer_lock:
+            self.atomic_counter += 1
 
     def atomic_end(self) -> None:
         """End an atomic block."""
-        self.atomic_counter -= 1
-        if self.atomic_counter == 0:
+        with self.buffer_lock:
+            self.atomic_counter -= 1
+            should_flush = self.atomic_counter == 0
+        if should_flush:
             self.event_loop.call_soon_threadsafe(self.message_event.set)
 
     def flush(self) -> None:

--- a/src/viser/infra/_infra.py
+++ b/src/viser/infra/_infra.py
@@ -250,7 +250,10 @@ class WebsockMessageHandler:
     ) -> None:
         """Handle incoming messages."""
         if type(message) in self._incoming_handlers:
-            for cb in self._incoming_handlers[type(message)]:
+            # Snapshot the list: a handler may unregister itself mid-dispatch
+            # (e.g. get_render's response callback), which would otherwise skip
+            # the next handler in a live iteration.
+            for cb in list(self._incoming_handlers[type(message)]):
                 if asyncio.iscoroutinefunction(cb):
                     await cb(client_id, message)
                 else:
@@ -279,9 +282,16 @@ class WebsockMessageHandler:
             Context manager.
         """
         # If called multiple times in the same thread, we ignore inner calls.
-        self.get_message_buffer().atomic_start()
-        yield
-        self.get_message_buffer().atomic_end()
+        #
+        # try/finally so an exception raised inside the `with` body still
+        # decrements the counter. Otherwise atomic_end() is skipped and the
+        # counter stays stuck != 0, stalling message delivery permanently.
+        buffer = self.get_message_buffer()
+        buffer.atomic_start()
+        try:
+            yield
+        finally:
+            buffer.atomic_end()
 
 
 class WebsockClientConnection(WebsockMessageHandler):
@@ -534,6 +544,12 @@ class WebsockServer(WebsockMessageHandler):
                 websockets.exceptions.ConnectionClosedOK,
                 websockets.exceptions.ConnectionClosedError,
             ):
+                # Expected disconnects -- swallow. Any other exit (CancelledError
+                # on shutdown, an exception from a producer/consumer) still runs
+                # the teardown below via `finally`, so client state can't leak
+                # and disconnect callbacks always fire.
+                pass
+            finally:
                 # We use a sentinel value to signal that the client producer thread
                 # should exit.
                 #
@@ -542,16 +558,19 @@ class WebsockServer(WebsockMessageHandler):
                 # pending" error.
                 client_state.message_buffer.set_done()
 
+                # Remove client state up front, before the disconnect callbacks:
+                # a callback that raises (or a CancelledError delivered at an
+                # `await` inside this finally) must not be able to skip it and
+                # leak the client. `pop(..., None)` keeps this idempotent.
+                self._client_state_from_id.pop(client_id, None)
+                total_connections -= 1
+
                 # Disconnection callbacks.
                 for cb in self._client_disconnect_cb:
                     if asyncio.iscoroutinefunction(cb):
                         await cb(client_connection)
                     else:
                         cb(client_connection)
-
-                # Cleanup.
-                self._client_state_from_id.pop(client_id)
-                total_connections -= 1
                 if self._verbose:
                     rich.print(
                         f"[bold](viser)[/bold] Connection closed ({client_id},"

--- a/tests/e2e/test_advanced_scene.py
+++ b/tests/e2e/test_advanced_scene.py
@@ -178,6 +178,57 @@ def test_line_segments_single_color(
 
 # --- Transform controls ---
 
+JS_FIND_TRANSFORM_HANDLE = """
+() => {
+    const m = window.__viserMutable;
+    const cam = m.camera;
+    const rect = m.canvas.getBoundingClientRect();
+    const Vector3 = cam.position.constructor;
+    const toScreen = (v) => {
+        const n = v.clone().project(cam);
+        return [
+            rect.left + (n.x * 0.5 + 0.5) * rect.width,
+            rect.top + (-n.y * 0.5 + 0.5) * rect.height,
+        ];
+    };
+
+    m.scene.updateWorldMatrix(true, true);
+    let bestRoot = null;
+    let bestHandles = [];
+    m.scene.traverse((root) => {
+        if (root.type !== "Group" || root.matrixAutoUpdate !== false) return;
+        const handles = [];
+        root.traverse((o) => {
+            if (o.isMesh && o.geometry?.type === "CylinderGeometry") {
+                const worldPosition = new Vector3();
+                o.getWorldPosition(worldPosition);
+                handles.push(worldPosition);
+            }
+        });
+        if (handles.length > bestHandles.length) {
+            bestRoot = root;
+            bestHandles = handles;
+        }
+    });
+    if (bestRoot === null || bestHandles.length === 0) return null;
+
+    const centerWorld = new Vector3();
+    bestRoot.getWorldPosition(centerWorld);
+    const center = toScreen(centerWorld);
+    let handle = null;
+    let bestDistance = -1;
+    for (const worldPosition of bestHandles) {
+        const screen = toScreen(worldPosition);
+        const distance = Math.hypot(screen[0] - center[0], screen[1] - center[1]);
+        if (distance > bestDistance) {
+            bestDistance = distance;
+            handle = screen;
+        }
+    }
+    return { center, handle };
+}
+"""
+
 
 def test_transform_controls_in_scene(
     viser_server: viser.ViserServer,
@@ -207,6 +258,46 @@ def test_transform_controls_with_options(
     )
 
     wait_for_scene_node(viser_page, "/test_transform_opts")
+
+
+def test_fixed_transform_controls_first_drag_works(
+    viser_server: viser.ViserServer,
+    viser_page: Page,
+) -> None:
+    """A fixed-size transform control added to an already-open viewer should be
+    draggable on the first attempt, before any prior interaction has forced a
+    render-frame scale update."""
+    handle = viser_server.scene.add_transform_controls(
+        "/first_drag_transform",
+        fixed=True,
+        scale=20.0,
+        disable_sliders=True,
+        disable_rotations=True,
+    )
+    wait_for_scene_node(viser_page, "/first_drag_transform")
+
+    screen_handle = viser_page.evaluate(JS_FIND_TRANSFORM_HANDLE)
+    assert screen_handle is not None, "transform control handle not found"
+    cx, cy = screen_handle["center"]
+    hx, hy = screen_handle["handle"]
+    dx, dy = hx - cx, hy - cy
+    length = math.hypot(dx, dy) or 1.0
+
+    viser_page.mouse.move(hx, hy)
+    viser_page.mouse.down()
+    viser_page.mouse.move(
+        hx + dx / length * 120,
+        hy + dy / length * 120,
+        steps=15,
+    )
+    viser_page.mouse.up()
+    viser_page.wait_for_timeout(500)
+
+    moved = math.sqrt(sum(float(x) ** 2 for x in handle.position))
+    assert moved > 0.1, (
+        "first transform-control drag did not move the control; "
+        "fixed-size handle matrices were likely initialized lazily"
+    )
 
 
 def test_transform_controls_remove(

--- a/tests/e2e/test_bug_resource_disposal.py
+++ b/tests/e2e/test_bug_resource_disposal.py
@@ -1,0 +1,170 @@
+"""E2E regression tests for GPU resource disposal leaks.
+
+Each test removes or replaces a scene object and asserts that the GPU resources
+it created are actually freed. They follow the same dispose-tracking strategy as
+``test_dispose_resources.py`` and ``test_bug_texture_leak.py``: read
+``window.__viserTestpoints.rendererInfo`` for live geometry/texture counts, and
+monkeypatch ``dispose()`` on the live object to detect whether it is freed.
+
+Covered:
+- GLB geometry disposal on removal -> ``test_glb_dispose_geometry_leak``
+- Background depth-texture disposal when depth is removed ->
+  ``test_background_depth_texture_disposed_when_depth_removed``
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from playwright.sync_api import Page
+
+import viser
+
+from .utils import wait_for_scene_node, wait_for_scene_node_removed
+
+JS_GET_MEMORY_INFO = """
+() => {
+    const tp = window.__viserTestpoints;
+    if (!tp || !tp.rendererInfo) return null;
+    return {
+        geometries: tp.rendererInfo.memory.geometries,
+        textures: tp.rendererInfo.memory.textures,
+        programs: tp.rendererInfo.programs ? tp.rendererInfo.programs.length : -1,
+    };
+}
+"""
+
+
+def _get_memory(page: Page) -> dict:
+    info = page.evaluate(JS_GET_MEMORY_INFO)
+    assert info is not None, "window.__viserTestpoints.rendererInfo not available"
+    return info
+
+
+# ---------------------------------------------------------------------------
+# GLB geometry disposal (GlbLoaderUtils.ts)
+# ---------------------------------------------------------------------------
+
+
+def test_glb_dispose_geometry_leak(
+    viser_server: viser.ViserServer,
+    viser_page: Page,
+) -> None:
+    """Removing a GLB should dispose the geometries it created.
+
+    Regression: ``useGlbLoader``'s cleanup captured a stale ``gltf``, so the
+    parsed GLB's geometries/materials could be left undisposed. Repeated
+    add/remove cycles then leaked a BufferGeometry each time and the geometry
+    count climbed monotonically.
+    """
+    trimesh = pytest.importorskip("trimesh")
+
+    # A box exports to a tiny self-contained GLB with one primitive.
+    glb_bytes: bytes = trimesh.Scene(
+        trimesh.creation.box(extents=(1.0, 1.0, 1.0))
+    ).export(file_type="glb")
+
+    # Let the scene fully initialize before baselining.
+    viser_page.wait_for_timeout(2000)
+
+    counts = []
+    for _ in range(3):
+        handle = viser_server.scene.add_glb("/test_glb_dispose", glb_data=glb_bytes)
+        wait_for_scene_node(viser_page, "/test_glb_dispose")
+        # Wait until the GLB has actually parsed into a rendered mesh (geometry
+        # uploaded), otherwise the count read below is meaningless.
+        viser_page.wait_for_function(
+            """() => {
+                const n = window.__viserMutable?.nodeRefFromName?.['/test_glb_dispose'];
+                if (!n) return false;
+                let hasMesh = false;
+                n.traverse((o) => { if (o.isMesh && o.geometry) hasMesh = true; });
+                return hasMesh;
+            }""",
+            timeout=10_000,
+        )
+        viser_page.wait_for_timeout(500)
+
+        handle.remove()
+        wait_for_scene_node_removed(viser_page, "/test_glb_dispose")
+        viser_page.wait_for_timeout(700)
+
+        counts.append(_get_memory(viser_page)["geometries"])
+
+    assert counts[-1] <= counts[0], (
+        f"Geometry count grew across GLB add/remove cycles (leak). Counts: {counts}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Background depth-texture disposal (MessageHandler.tsx)
+# ---------------------------------------------------------------------------
+
+# Wait until the background material has a real depth texture bound and the
+# `hasDepth` uniform is on.
+JS_DEPTH_TEXTURE_READY = """
+() => {
+    const u = window.__viserMutable?.backgroundMaterial?.uniforms;
+    if (!u) return false;
+    const tex = u.depthMap?.value;
+    return !!(tex && tex.isTexture && u.hasDepth?.value === true);
+}
+"""
+
+# Patch the *current* depth texture's dispose() so we can detect whether it is
+# disposed when depth is later removed.
+JS_PATCH_DEPTH_DISPOSE = """
+() => {
+    const tex = window.__viserMutable.backgroundMaterial.uniforms.depthMap.value;
+    window.__depthDisposed = false;
+    const orig = tex.dispose.bind(tex);
+    tex.dispose = function () {
+        window.__depthDisposed = true;
+        return orig();
+    };
+    return tex.uuid;
+}
+"""
+
+JS_HAS_DEPTH_OFF = """
+() => window.__viserMutable?.backgroundMaterial?.uniforms?.hasDepth?.value === false
+"""
+
+
+def test_background_depth_texture_disposed_when_depth_removed(
+    viser_server: viser.ViserServer,
+    viser_page: Page,
+) -> None:
+    """Switching the background from with-depth to without-depth should dispose
+    the orphaned depth texture.
+
+    Regression (MessageHandler.tsx ``BackgroundImageMessage``): when
+    ``depth_data === null`` the handler set ``hasDepth = false`` but never
+    disposed the existing ``depthMap`` texture, so the GPU depth texture was
+    orphaned (kept alive by the uniform, never freed) until -- if ever -- depth
+    was set again.
+    """
+    rgb = np.random.randint(0, 255, (64, 64, 3), dtype=np.uint8)
+    depth = np.random.rand(64, 64).astype(np.float32)
+
+    # 1. Background with depth.
+    viser_server.scene.set_background_image(rgb, depth=depth)
+    viser_page.wait_for_function(JS_DEPTH_TEXTURE_READY, timeout=10_000)
+
+    # 2. Instrument the live depth texture's dispose().
+    depth_uuid = viser_page.evaluate(JS_PATCH_DEPTH_DISPOSE)
+    assert isinstance(depth_uuid, str) and depth_uuid
+
+    # 3. Background without depth -- this should free the depth texture.
+    viser_server.scene.set_background_image(rgb)
+    viser_page.wait_for_function(JS_HAS_DEPTH_OFF, timeout=10_000)
+
+    # Give any dispose() a chance to run.
+    viser_page.wait_for_timeout(500)
+
+    disposed = viser_page.evaluate("() => window.__depthDisposed === true")
+    assert disposed, (
+        "Depth texture was not disposed when the background switched to "
+        "no-depth; it is orphaned on the GPU (MessageHandler leaves "
+        "depthMap.value undisposed when depth_data is null)."
+    )

--- a/tests/e2e/test_initial_camera_orientation.py
+++ b/tests/e2e/test_initial_camera_orientation.py
@@ -1,0 +1,137 @@
+"""E2E test for the default camera + scene orientation BEFORE the client
+connects to a server.
+
+The client's default root orientation is hardcoded to equal
+``set_up_direction("+z")`` (wxyz ``[0.5, -0.5, 0.5, 0.5]``). With the default
+initial camera (viser-world ``[3, 3, 3]``) that should place the three.js camera
+at ``[-3, 3, -3]`` looking at the origin, +Z up -- the standard view -- with the
+client never having talked to a server.
+
+To exercise the genuine pre-connect state we load the client from the server's
+HTTP endpoint but override the websocket target (``?websocket=``) to a dead port,
+so the React app fully mounts (camera, scene defaults) but never connects. The
+``firstMessageBatch`` flag staying ``true`` confirms no server messages were
+processed.
+
+Suspects for the reported "axes look wrong before connect" symptom (see
+``initial_pose_and_scene_orientation.md``):
+
+  1. **Camera mount-ordering race.** If ``initialT`` is captured before the root
+     node's default orientation is in the store, the camera is placed with
+     ``T = identity`` -> three.js ``[3, 3, 3]`` and
+     ``initialCameraDiagnostic.rootWxyzAtCapture == [1, 0, 0, 0]``. FAILS here.
+  2. **Axes visibility, not orientation.** If this PASSES, the pre-connect
+     orientation is correct and the symptom is the ``/WorldAxes`` visibility
+     default flipping on connect, not a transform bug.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page
+
+import viser
+
+from .utils import find_free_port
+
+JS_CAMERA_POS = """
+() => {
+    const cc = window.__viserMutable.cameraControl;
+    const p = cc.getPosition({ x: 0, y: 0, z: 0,
+        set(x, y, z) { this.x = x; this.y = y; this.z = z; return this; } });
+    return [p.x, p.y, p.z];
+}
+"""
+JS_DIAG = "() => window.__viserMutable.initialCameraDiagnostic"
+JS_ROOT_WXYZ = "() => window.__viserSceneTree.getState()[''].wxyz"
+JS_FIRST_BATCH = "() => window.__viserMutable.firstMessageBatch"
+JS_NODE_WORLD_QUAT = """
+(name) => {
+    const o = window.__viserMutable.nodeRefFromName[name];
+    if (!o) return null;
+    o.updateWorldMatrix(true, false);
+    const Q = o.getWorldQuaternion(new o.quaternion.constructor());
+    return [Q.w, Q.x, Q.y, Q.z];
+}
+"""
+
+# +Z-up default == set_up_direction("+z").
+DEFAULT_ROOT_WXYZ = [0.5, -0.5, 0.5, 0.5]
+# viser-world [3,3,3] mapped through T_threeworld_world.
+EXPECTED_THREE_CAMERA = [-3.0, 3.0, -3.0]
+
+
+def _open_disconnected(page: Page, http_port: int) -> None:
+    """Load the client from ``http_port`` but point its websocket at a dead
+    port, so it mounts the viewer but never connects."""
+    dead_ws_port = find_free_port()
+    page.goto(f"http://localhost:{http_port}/?websocket=ws://localhost:{dead_ws_port}")
+    # Wait until the viewer has mounted (camera controls live). This happens on
+    # mount, independent of any websocket connection.
+    page.wait_for_function(
+        "() => window.__viserMutable && window.__viserMutable.cameraControl != null",
+        timeout=15_000,
+    )
+    page.wait_for_timeout(500)
+
+
+def _quat_same_rotation(a: list[float], b: list[float]) -> bool:
+    """True if two quaternions represent the same rotation (handles q ~ -q)."""
+    dot = sum(x * y for x, y in zip(a, b))
+    return abs(abs(dot) - 1.0) < 1e-3
+
+
+def _max_delta(a: list[float], b: list[float]) -> float:
+    return max(abs(x - y) for x, y in zip(a, b))
+
+
+def test_default_view_is_plus_z_up_before_connecting(
+    page: Page, viser_server: viser.ViserServer
+) -> None:
+    _open_disconnected(page, viser_server.get_port())
+
+    # Sanity: we are genuinely pre-connect -- no server message batch has been
+    # processed (the flag only flips false once a batch lands).
+    assert page.evaluate(JS_FIRST_BATCH) is True, (
+        "expected to be pre-connect (firstMessageBatch == true); the client "
+        "appears to have connected, so this isn't testing the pre-connect state"
+    )
+
+    # (1) Root orientation captured at initialT time must be the +Z-up default,
+    # not identity. Identity would mean a mount-ordering race.
+    diag = page.evaluate(JS_DIAG)
+    assert diag is not None, "initialCameraDiagnostic was not exposed on window"
+    captured = diag["rootWxyzAtCapture"]
+    assert _quat_same_rotation(captured, DEFAULT_ROOT_WXYZ), (
+        f"root orientation at initialT capture was {captured}, expected the "
+        f"+Z-up default {DEFAULT_ROOT_WXYZ}. Identity [1,0,0,0] indicates the "
+        f"root node wasn't in the store yet when initialT was captured "
+        f"(mount-ordering race)."
+    )
+
+    # (2) The live root orientation must also be the +Z-up default.
+    root_wxyz = page.evaluate(JS_ROOT_WXYZ)
+    assert _quat_same_rotation(root_wxyz, DEFAULT_ROOT_WXYZ), (
+        f"live root wxyz is {root_wxyz}, expected default {DEFAULT_ROOT_WXYZ}"
+    )
+
+    # (3) The camera must be at three.js [-3, 3, -3] (= world [3,3,3] through
+    # T). [3, 3, 3] would mean the initial transform was applied with
+    # T = identity.
+    pos = page.evaluate(JS_CAMERA_POS)
+    assert _max_delta(pos, EXPECTED_THREE_CAMERA) < 0.25, (
+        f"camera is at three.js {pos}, expected {EXPECTED_THREE_CAMERA}. "
+        f"[3, 3, 3] would indicate the initial camera transform was applied "
+        f"with T = identity (mount-ordering race)."
+    )
+
+    # (4) The /WorldAxes gizmo (child of root, identity local transform) must
+    # inherit the root orientation -- i.e. its WORLD orientation equals the
+    # +Z-up default. If it's identity or anything else, the axes gizmo itself is
+    # mis-oriented even when the camera and root frame are correct.
+    wa_q = page.evaluate(JS_NODE_WORLD_QUAT, "/WorldAxes")
+    assert wa_q is not None, "/WorldAxes Object3D not found in nodeRefFromName"
+    assert _quat_same_rotation(wa_q, DEFAULT_ROOT_WXYZ), (
+        f"/WorldAxes world orientation is {wa_q}, expected the root's +Z-up "
+        f"default {DEFAULT_ROOT_WXYZ}. A mismatch means the world-axes gizmo is "
+        f"mis-oriented relative to the scene frame."
+    )

--- a/tests/e2e/test_line_segments_resize.py
+++ b/tests/e2e/test_line_segments_resize.py
@@ -19,15 +19,11 @@ from .utils import wait_for_scene_node
 def _count_red_pixels(page: Page) -> int:
     canvas = page.locator("canvas").first
     img = np.array(Image.open(BytesIO(canvas.screenshot())).convert("RGB"))
-    return int(
-        ((img[:, :, 0] > 200) & (img[:, :, 1] < 80) & (img[:, :, 2] < 80)).sum()
-    )
+    return int(((img[:, :, 0] > 200) & (img[:, :, 1] < 80) & (img[:, :, 2] < 80)).sum())
 
 
 def _segments_along_x(half_extent: float, num_points: int) -> np.ndarray:
-    pts = np.linspace(
-        [-half_extent, 0.0, 0.0], [half_extent, 0.0, 0.0], num=num_points
-    )
+    pts = np.linspace([-half_extent, 0.0, 0.0], [half_extent, 0.0, 0.0], num=num_points)
     return np.stack([pts[:-1], pts[1:]], axis=1)
 
 

--- a/tests/e2e/test_orbit_origin_tool.py
+++ b/tests/e2e/test_orbit_origin_tool.py
@@ -397,8 +397,11 @@ def test_canceled_ring_rotation_does_not_disable_camera(
     and only restores it in its own ``onPointerUp`` -- it has no pointercancel
     handler. A canceled ring drag (common for the curved gesture) therefore
     stranded the camera disabled with no lease held (``cameraLockReasons()``
-    empty), so orbit/pan/zoom silently stopped working. SafePivotControls now
-    treats cancel/lostcapture as drag termination and releases its camera lock.
+    empty), so orbit/pan/zoom silently stopped working. The canvas-level
+    ``pointercancel`` handler now calls ``cameraLocks.apply()``, which
+    reconciles ``cameraControl.enabled`` back to the held leases and recovers
+    the camera. (Note: this does not tear down drei's internal drag state --
+    see the TODO below.)
     """
     viser_server.scene.add_box("/box", dimensions=(0.5, 0.5, 0.5))
     _open_with_orbit_tool(page, viser_server.get_port())

--- a/tests/e2e/test_orbit_origin_tool.py
+++ b/tests/e2e/test_orbit_origin_tool.py
@@ -1,0 +1,552 @@
+"""E2E regression tests for the Orbit Origin Tool (the magenta pivot gizmo).
+
+The tool is forced visible via the ``?forceOrbitOriginTool=1`` URL flag.
+Dragging a translation handle should animate the camera's look-at to the
+gizmo's new world position; the gizmo itself is a world-space anchor that
+holds still during the settle animation and otherwise tracks the look-at.
+
+Covers three bugs fixed in ``CameraControls.tsx``:
+
+  1. Stale-closure flicker: the "is an animation running?" guard read a
+     stale value, so the gizmo snapped back toward the old look-at for a
+     frame after release. -> ``test_gizmo_holds_still_during_settle``.
+  2. No drag guard on the per-frame camera->pivot sync: if the camera was
+     moving when the drag started, the sync stomped the gizmo's matrix
+     every frame and the drag did nothing. ->
+     ``test_drag_works_while_camera_is_moving``.
+  3. Missed ``onDragEnd``: drei fires it from the handle's own pointerup,
+     which R3F pointer capture doesn't deliver when the pointer is released
+     away from the handle -- so the commit never ran and the sync froze. ->
+     ``test_release_off_handle_still_commits``.
+"""
+
+from __future__ import annotations
+
+import math
+
+from playwright.sync_api import Page
+
+import viser
+
+# Find the pivot gizmo, project a translation-arrow handle and the gizmo
+# center to viewport (CSS-pixel) coordinates Playwright can drag. The arrow
+# hit targets are the (invisible) cylinder-geometry meshes; the visible line
+# and cone disable raycasting. Returns null if the gizmo isn't present yet.
+JS_FIND_HANDLE = """
+() => {
+    const m = window.__viserMutable;
+    const cam = m.camera;
+    let grid = null;
+    m.scene.traverse((o) => {
+        if (o.material && o.material.uniforms && 'fadeDistance' in o.material.uniforms)
+            grid = o;
+    });
+    if (!grid) return null;
+    let p = grid, pivot = null;
+    while (p) {
+        if (p.matrixAutoUpdate === false && p.type === 'Group') { pivot = p; break; }
+        p = p.parent;
+    }
+    if (!pivot) return null;
+    pivot.updateWorldMatrix(true, true);
+    const V = pivot.position.constructor;
+    const center = new V();
+    pivot.getWorldPosition(center);
+    const handles = [];
+    pivot.traverse((o) => {
+        if (o.isMesh && o.geometry && o.geometry.type === 'CylinderGeometry') {
+            const wp = new V();
+            o.getWorldPosition(wp);
+            handles.push(wp);
+        }
+    });
+    if (handles.length === 0) return null;
+    const rect = m.canvas.getBoundingClientRect();
+    const toScreen = (v) => {
+        const n = v.clone().project(cam);
+        return [
+            rect.left + (n.x * 0.5 + 0.5) * rect.width,
+            rect.top + (-n.y * 0.5 + 0.5) * rect.height,
+        ];
+    };
+    const c = toScreen(center);
+    // Pick the arrow whose screen projection is longest -- most screen-aligned,
+    // so a screen-space drag along it produces the largest look-at change.
+    let best = null, bestD = -1;
+    for (const h of handles) {
+        const s = toScreen(h);
+        const d = Math.hypot(s[0] - c[0], s[1] - c[1]);
+        if (d > bestD) { bestD = d; best = s; }
+    }
+    return { center: c, handle: best };
+}
+"""
+
+# Camera look-at target and gizmo world position, as [x, y, z] arrays.
+JS_TARGET_AND_PIVOT = """
+() => {
+    const m = window.__viserMutable;
+    const cc = m.cameraControl;
+    const t = cc.getTarget({ x: 0, y: 0, z: 0,
+        set(x, y, z) { this.x = x; this.y = y; this.z = z; return this; } });
+    let grid = null;
+    m.scene.traverse((o) => {
+        if (o.material && o.material.uniforms && 'fadeDistance' in o.material.uniforms)
+            grid = o;
+    });
+    let p = grid, pivot = null;
+    while (p) {
+        if (p.matrixAutoUpdate === false && p.type === 'Group') { pivot = p; break; }
+        p = p.parent;
+    }
+    const V = pivot.position.constructor;
+    const wp = new V();
+    pivot.getWorldPosition(wp);
+    return { target: [t.x, t.y, t.z], pivot: [wp.x, wp.y, wp.z] };
+}
+"""
+
+JS_PIVOT_MATRIX = """
+() => {
+    const m = window.__viserMutable;
+    let grid = null;
+    m.scene.traverse((o) => {
+        if (o.material && o.material.uniforms && 'fadeDistance' in o.material.uniforms)
+            grid = o;
+    });
+    let p = grid, pivot = null;
+    while (p) {
+        if (p.matrixAutoUpdate === false && p.type === 'Group') { pivot = p; break; }
+        p = p.parent;
+    }
+    return Array.from(pivot.matrix.elements);
+}
+"""
+
+# Start/stop a per-frame sampler of the gizmo's world position.
+JS_START_PIVOT_SAMPLER = """
+() => {
+    const m = window.__viserMutable;
+    let grid = null;
+    m.scene.traverse((o) => {
+        if (o.material && o.material.uniforms && 'fadeDistance' in o.material.uniforms)
+            grid = o;
+    });
+    let p = grid, pivot = null;
+    while (p) {
+        if (p.matrixAutoUpdate === false && p.type === 'Group') { pivot = p; break; }
+        p = p.parent;
+    }
+    const V = pivot.position.constructor;
+    window.__ps = [];
+    window.__psRun = true;
+    const wp = new V();
+    (function loop() {
+        if (!window.__psRun) return;
+        pivot.getWorldPosition(wp);
+        window.__ps.push([wp.x, wp.y, wp.z]);
+        requestAnimationFrame(loop);
+    })();
+    return true;
+}
+"""
+JS_STOP_PIVOT_SAMPLER = "() => { window.__psRun = false; return window.__ps; }"
+
+
+def _dist(a: list[float], b: list[float]) -> float:
+    return math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b)))
+
+
+def _norm(a: list[float]) -> float:
+    return math.sqrt(sum(x * x for x in a))
+
+
+def _max_delta(a: list[float], b: list[float]) -> float:
+    return max(abs(x - y) for x, y in zip(a, b))
+
+
+def _open_with_orbit_tool(page: Page, port: int) -> None:
+    """Open the viewer with the orbit-origin gizmo forced visible and wait
+    until the camera controls are live."""
+    page.goto(f"http://localhost:{port}/?forceOrbitOriginTool=1")
+    page.wait_for_function(
+        "() => !document.body.innerText.includes('Connecting...')",
+        timeout=15_000,
+    )
+    page.wait_for_function(
+        "() => window.__viserMutable && window.__viserMutable.cameraControl != null",
+        timeout=15_000,
+    )
+    page.wait_for_timeout(500)
+
+
+def _grab_handle(page: Page) -> dict:
+    handle = page.evaluate(JS_FIND_HANDLE)
+    assert handle is not None, "orbit-origin gizmo / translation handle not found"
+    return handle
+
+
+def _drag_handle_outward(page: Page, handle: dict, pixels: float = 120.0) -> None:
+    """Drag a translation arrow outward along its own screen direction."""
+    cx, cy = handle["center"]
+    hx, hy = handle["handle"]
+    dx, dy = hx - cx, hy - cy
+    length = math.hypot(dx, dy) or 1.0
+    ex, ey = hx + dx / length * pixels, hy + dy / length * pixels
+    page.mouse.move(hx, hy)
+    page.mouse.down()
+    page.mouse.move(ex, ey, steps=15)
+    page.mouse.up()
+
+
+def test_drag_moves_lookat(page: Page, viser_server: viser.ViserServer) -> None:
+    """Baseline: dragging a translation handle commits -- the camera's
+    look-at animates to the gizmo's new world position, and the two
+    coincide once the settle animation finishes."""
+    viser_server.scene.add_box("/box", dimensions=(0.5, 0.5, 0.5))
+    _open_with_orbit_tool(page, viser_server.get_port())
+
+    before = page.evaluate(JS_TARGET_AND_PIVOT)
+    _drag_handle_outward(page, _grab_handle(page))
+    page.wait_for_timeout(900)
+    after = page.evaluate(JS_TARGET_AND_PIVOT)
+
+    moved = _dist(before["target"], after["target"])
+    assert moved > 0.1, f"look-at did not move on drag (delta={moved:.3f})"
+    coincide = _dist(after["target"], after["pivot"])
+    assert coincide < 0.15, (
+        f"gizmo and look-at diverged after settle (gap={coincide:.3f})"
+    )
+
+
+def test_gizmo_holds_still_during_settle(
+    page: Page, viser_server: viser.ViserServer
+) -> None:
+    """Regression for the stale-closure flicker: while the camera animates
+    to the dragged point, the gizmo must hold at that world position. Pre-fix
+    it snapped back toward the origin for a frame, then rode the camera's
+    lerp back out -- so the per-frame distance-from-origin dipped to ~0."""
+    _open_with_orbit_tool(page, viser_server.get_port())
+
+    handle = _grab_handle(page)
+    page.evaluate(JS_START_PIVOT_SAMPLER)
+    _drag_handle_outward(page, handle)
+    page.wait_for_timeout(900)  # cover the full 0.5s settle animation
+    samples: list[list[float]] = page.evaluate(JS_STOP_PIVOT_SAMPLER)
+
+    assert len(samples) > 10, "sampler captured too few frames"
+    final_dist = _norm(samples[-1])
+    assert final_dist > 0.3, f"drag did not move the gizmo (final={final_dist:.3f})"
+
+    # The drag itself ramps the gizmo from the origin out to `final_dist`, so we
+    # only look from the first frame it has essentially reached its final spot
+    # (i.e. at/after release). From there the gizmo must HOLD while the camera
+    # animates -- it must not fall back toward the origin. The pre-fix snap-back
+    # drove this minimum to ~0.
+    near_final_idx = next(
+        i for i, s in enumerate(samples) if _norm(s) >= 0.8 * final_dist
+    )
+    min_after = min(_norm(s) for s in samples[near_final_idx:])
+    assert min_after > final_dist * 0.5, (
+        f"gizmo snapped back toward origin after reaching its target "
+        f"(min={min_after:.3f}, final={final_dist:.3f})"
+    )
+
+
+def test_drag_works_while_camera_is_moving(
+    page: Page, viser_server: viser.ViserServer
+) -> None:
+    """Regression for the missing drag guard: start a slow dolly so the
+    per-frame camera->pivot sync fires every frame, then drag a handle. The
+    drag must still take hold. Pre-fix the sync stomped the gizmo's matrix
+    each frame and the look-at never changed."""
+    _open_with_orbit_tool(page, viser_server.get_port())
+
+    before = page.evaluate(JS_TARGET_AND_PIVOT)
+    # Widen the settle window and start a slow dolly. dolly changes distance,
+    # not the look-at, so any look-at change must come from the drag.
+    page.evaluate(
+        """() => {
+            const cc = window.__viserMutable.cameraControl;
+            cc.smoothTime = 2.0;
+            cc.dollyTo(cc.distance * 2.5, true);
+        }"""
+    )
+    _drag_handle_outward(page, _grab_handle(page))
+    page.wait_for_timeout(1000)
+    page.evaluate("() => { window.__viserMutable.cameraControl.smoothTime = 0.05; }")
+    after = page.evaluate(JS_TARGET_AND_PIVOT)
+
+    moved = _dist(before["target"], after["target"])
+    assert moved > 0.1, (
+        f"drag had no effect while camera was moving (delta={moved:.3f}); "
+        "the per-frame sync stomped the gizmo"
+    )
+
+
+def test_release_off_handle_still_commits(
+    page: Page, viser_server: viser.ViserServer
+) -> None:
+    """Regression for the missed onDragEnd: release the drag while the
+    pointer is far from the handle. The drag must still commit (look-at
+    moves), and the per-frame sync must NOT be left frozen -- moving the
+    look-at afterward should pull the gizmo along with it."""
+    _open_with_orbit_tool(page, viser_server.get_port())
+
+    before = page.evaluate(JS_TARGET_AND_PIVOT)
+    handle = _grab_handle(page)
+    hx, hy = handle["handle"]
+    # Drag to the top-left corner of the canvas -- well off the handle.
+    page.mouse.move(hx, hy)
+    page.mouse.down()
+    page.mouse.move(60, 60, steps=20)
+    page.mouse.up()
+    page.wait_for_timeout(900)
+
+    after = page.evaluate(JS_TARGET_AND_PIVOT)
+    moved = _dist(before["target"], after["target"])
+    assert moved > 0.1, (
+        f"off-handle release did not commit the drag (delta={moved:.3f}); "
+        "onDragEnd was missed and no safety net fired"
+    )
+
+    # The drag flag must have been cleared: move the look-at programmatically
+    # and the gizmo should track it on the next frames.
+    page.evaluate(
+        "() => window.__viserMutable.cameraControl.setTarget(0.9, 0.2, -0.4, false)"
+    )
+    page.wait_for_timeout(300)
+    state = page.evaluate(JS_TARGET_AND_PIVOT)
+    gap = _dist(state["pivot"], [0.9, 0.2, -0.4])
+    assert gap < 0.15, (
+        f"gizmo did not follow the look-at after an off-handle release "
+        f"(gap={gap:.3f}); the per-frame sync is frozen (drag flag stuck)"
+    )
+
+
+# Find the gizmo's "up" rotation ring (an AxisRotator arc, a Line2) and project
+# its arc to screen. Disables the non-rotation hit targets (arrow cylinders /
+# plane-slider meshes -- the `visible:false` non-Line2 meshes) so the thin ring
+# is what gets picked.
+JS_FIND_ROTATION_RING = """
+() => {
+    const m = window.__viserMutable, cam = m.camera;
+    let grid = null;
+    m.scene.traverse((o) => {
+        if (o.material && o.material.uniforms && 'fadeDistance' in o.material.uniforms)
+            grid = o;
+    });
+    let p = grid, pivot = null;
+    while (p) { if (p.matrixAutoUpdate === false && p.type === 'Group') { pivot = p; break; } p = p.parent; }
+    if (!pivot) return null;
+    pivot.updateWorldMatrix(true, true);
+    pivot.traverse((o) => { if (o.isMesh && !o.isLine2 && o.visible === false) o.raycast = () => null; });
+    const up = cam.up.clone().normalize();
+    const V = up.constructor;
+    const rect = m.canvas.getBoundingClientRect();
+    const toS = (v) => { const n = v.clone().project(cam);
+        return [rect.left + (n.x*0.5+0.5)*rect.width, rect.top + (-n.y*0.5+0.5)*rect.height]; };
+    const isArc = (o) => o.isLine2 || (o.geometry && o.geometry.type && o.geometry.type.indexOf('Line') >= 0);
+    let best = null, bd = -1;
+    pivot.traverse((o) => {
+        if (o.type === 'Group' && o.matrixAutoUpdate === false && o !== pivot && o.children.some(isArc)) {
+            const e = o.matrixWorld.elements;
+            const z = new V(e[8], e[9], e[10]).normalize();
+            const d = Math.abs(z.dot(up));
+            if (d > bd) { bd = d; best = o; }
+        }
+    });
+    if (!best) return null;
+    const pts = [];
+    for (let j = 0; j <= 10; j++) {
+        const a = j * (Math.PI / 2) / 10;
+        pts.push(toS(new V(Math.cos(a)*0.65, Math.sin(a)*0.65, 0).applyMatrix4(best.matrixWorld)));
+    }
+    return { arc: pts };
+}
+"""
+
+# Simulate the browser canceling the in-flight gesture: pointercancel + the
+# pointer-capture release that a real cancel performs.
+JS_CANCEL_POINTER = """
+() => {
+    const c = window.__viserMutable.canvas;
+    c.dispatchEvent(new PointerEvent('pointercancel', { pointerId: 1, bubbles: true, cancelable: true }));
+    try { c.releasePointerCapture(1); } catch (e) {}
+    c.dispatchEvent(new PointerEvent('lostpointercapture', { pointerId: 1, bubbles: true }));
+    return true;
+}
+"""
+
+JS_CAMERA_POS = """
+() => {
+    const cc = window.__viserMutable.cameraControl;
+    const p = cc.getPosition({x:0,y:0,z:0,set(x,y,z){this.x=x;this.y=y;this.z=z;return this;}});
+    return [p.x, p.y, p.z];
+}
+"""
+
+
+def test_canceled_ring_rotation_does_not_disable_camera(
+    page: Page, viser_server: viser.ViserServer
+) -> None:
+    """Regression: a ``pointercancel`` during a rotation-ring drag must fully
+    end the drag and must not leave camera controls disabled.
+
+    drei's ``AxisRotator`` sets ``cameraControl.enabled = false`` on pointerdown
+    and only restores it in its own ``onPointerUp`` -- it has no pointercancel
+    handler. A canceled ring drag (common for the curved gesture) therefore
+    stranded the camera disabled with no lease held (``cameraLockReasons()``
+    empty), so orbit/pan/zoom silently stopped working. SafePivotControls now
+    treats cancel/lostcapture as drag termination and releases its camera lock.
+    """
+    viser_server.scene.add_box("/box", dimensions=(0.5, 0.5, 0.5))
+    _open_with_orbit_tool(page, viser_server.get_port())
+
+    ring = page.evaluate(JS_FIND_ROTATION_RING)
+    assert ring is not None, "orbit-origin rotation ring not found"
+    arc = [(round(x), round(y)) for x, y in ring["arc"]]
+
+    assert page.evaluate("() => window.__viserMutable.cameraControl.enabled") is True
+
+    # Press the ring and rotate, then have the browser cancel the gesture.
+    mid = len(arc) // 2
+    page.mouse.move(*arc[mid])
+    page.mouse.down()
+    for x, y in arc[mid + 1 :]:
+        page.mouse.move(x, y, steps=4)
+    page.evaluate(JS_CANCEL_POINTER)
+    page.wait_for_timeout(300)
+
+    enabled = page.evaluate("() => window.__viserMutable.cameraControl.enabled")
+    reasons = page.evaluate("() => window.__viserPointer.cameraLockReasons()")
+    assert enabled is True, (
+        f"camera left disabled after a canceled ring rotation "
+        f"(enabled={enabled}, lease reasons={reasons})"
+    )
+
+    # TODO: re-enable once the gizmo's internal drag state is torn down on
+    # cancel. drei's AxisRotator clears its private `clickInfo` only in its own
+    # pointerup -- it has no pointercancel/lostpointercapture handler -- so after
+    # a cancel, moving back over the ring (which re-raycasts the arc mesh) keeps
+    # rotating the gizmo. The App-level `cameraLocks.apply()` recovers the camera
+    # (asserted above) but cannot reach drei's internal state; fixing that needs
+    # a PivotControls wrapper that synthesizes a drag-termination on cancel.
+    # before_matrix = page.evaluate(JS_PIVOT_MATRIX)
+    # for x, y in reversed(arc[: mid + 1]):
+    #     page.mouse.move(x, y, steps=4)
+    # page.wait_for_timeout(200)
+    # after_matrix = page.evaluate(JS_PIVOT_MATRIX)
+    # assert _max_delta(before_matrix, after_matrix) < 1e-5, (
+    #     "rotation ring kept dragging after pointercancel with no button held; "
+    #     "the gizmo drag state was not cleared"
+    # )
+
+    # And it should actually orbit again. NOTE: this only proves the camera
+    # moved, not that the gesture orbited rather than being eaten by a
+    # still-armed gizmo drag (the internal-state teardown deferred above). The
+    # start point (300, 400) is chosen to land on empty canvas, away from the
+    # ring, so a pointerdown there starts an orbit; tighten this once the
+    # gizmo's drag state is torn down on cancel.
+    before = page.evaluate(JS_CAMERA_POS)
+    page.mouse.move(300, 400)
+    page.mouse.down()
+    page.mouse.move(460, 440, steps=15)
+    page.mouse.up()
+    page.wait_for_timeout(400)
+    after = page.evaluate(JS_CAMERA_POS)
+    assert _dist(before, after) > 1e-3, (
+        "camera did not orbit after a canceled ring rotation; controls stuck"
+    )
+
+
+def test_canceled_axis_drag_does_not_keep_dragging(
+    page: Page, viser_server: viser.ViserServer
+) -> None:
+    """Regression: cancel/lost-capture during a translation-axis drag must clear
+    the handle's drag state. Fast drags can otherwise leave the axis behaving as
+    if the pointer were still held down."""
+    viser_server.scene.add_box("/box", dimensions=(0.5, 0.5, 0.5))
+    _open_with_orbit_tool(page, viser_server.get_port())
+
+    handle = _grab_handle(page)
+    cx, cy = handle["center"]
+    hx, hy = handle["handle"]
+    dx, dy = hx - cx, hy - cy
+    length = math.hypot(dx, dy) or 1.0
+
+    page.mouse.move(hx, hy)
+    page.mouse.down()
+    page.mouse.move(
+        hx + dx / length * 180,
+        hy + dy / length * 180,
+        steps=2,
+    )
+    page.evaluate(JS_CANCEL_POINTER)
+    page.wait_for_timeout(300)
+
+    enabled = page.evaluate("() => window.__viserMutable.cameraControl.enabled")
+    reasons = page.evaluate("() => window.__viserPointer.cameraLockReasons()")
+    assert enabled is True, (
+        f"camera left disabled after a canceled axis drag "
+        f"(enabled={enabled}, lease reasons={reasons})"
+    )
+
+    before_matrix = page.evaluate(JS_PIVOT_MATRIX)
+    for x, y in [(60, 60), (720, 80), (160, 520), (700, 520)]:
+        page.mouse.move(x, y, steps=2)
+    page.wait_for_timeout(200)
+    after_matrix = page.evaluate(JS_PIVOT_MATRIX)
+    page.mouse.up()
+    assert _max_delta(before_matrix, after_matrix) < 1e-5, (
+        "translation axis kept dragging after pointercancel/lostcapture; "
+        "the gizmo drag state was not cleared"
+    )
+
+
+JS_CAPTURE_STATE = """
+() => ({
+    canvasHasCapture: window.__viserMutable.canvas.hasPointerCapture(1),
+    gesture: window.__viserPointer.getGesture().kind,
+})
+"""
+
+
+def test_gizmo_drag_not_hijacked_by_rect_select(
+    page: Page, viser_server: viser.ViserServer
+) -> None:
+    """Regression: with ``on_rect_select`` registered, pressing a gizmo handle
+    must not start a canvas-level rect-select gesture, which used to call
+    ``setPointerCapture`` on a different element and steal the gizmo's capture
+    (drei then drops it and its pointerup is missed, leaving the gizmo stuck
+    'dragging' after release).
+
+    White-box: while the gizmo handle is held, the canvas must retain pointer
+    capture (id 1) and the scene-pointer gesture must stay idle.
+    """
+
+    @viser_server.scene.on_rect_select()
+    def _(event: viser.SceneRectSelectEvent) -> None:
+        del event
+
+    viser_server.scene.add_box("/box", dimensions=(0.5, 0.5, 0.5))
+    _open_with_orbit_tool(page, viser_server.get_port())
+
+    handle = _grab_handle(page)
+    cx, cy = handle["center"]
+    hx, hy = handle["handle"]
+
+    page.mouse.move(hx, hy)
+    page.mouse.down()
+    page.mouse.move((hx + cx) / 2 + 30, (hy + cy) / 2 + 30, steps=8)
+    state = page.evaluate(JS_CAPTURE_STATE)
+    page.mouse.up()
+
+    assert state["canvasHasCapture"] is True, (
+        "gizmo lost its pointer capture mid-drag (stolen by the canvas "
+        f"rect-select handler); state={state}"
+    )
+    assert state["gesture"] == "idle", (
+        "pressing the gizmo started a canvas scene-pointer gesture "
+        f"(should be suppressed when a 3D handle owns the pointer); state={state}"
+    )

--- a/tests/test_point_cloud_precision.py
+++ b/tests/test_point_cloud_precision.py
@@ -1,0 +1,50 @@
+"""Regression tests for point-cloud ``precision`` <-> ``points`` dtype coupling.
+
+The casting was silently broken by the property-assignment refactor (#464): the
+``PointCloudHandle`` override that cast ``points`` by ``precision`` stopped being
+called, so changing ``precision`` after construction left the buffer at the old
+dtype. These pin the behavior that ``precision`` and ``points`` stay consistent
+regardless of assignment order.
+"""
+
+from unittest.mock import patch
+
+import numpy as np
+
+import viser
+import viser._client_autobuild
+
+
+@patch.object(viser._client_autobuild, "ensure_client_is_built", lambda: None)
+def test_point_cloud_precision_roundtrip() -> None:
+    server = viser.ViserServer()
+    try:
+        pc = server.scene.add_point_cloud(
+            "/pc",
+            points=np.random.rand(10, 3),
+            colors=(255, 0, 0),
+            precision="float16",
+        )
+        # Construction casts to the requested precision.
+        assert pc.points.dtype == np.float16
+
+        # Changing precision re-casts the existing buffer in place.
+        pc.precision = "float32"
+        assert pc.points.dtype == np.float32
+
+        # A subsequent points assignment is stored at the current precision.
+        # The float64 input is deliberately off-dtype to exercise the cast.
+        pc.points = np.random.rand(10, 3)  # type: ignore
+        assert pc.points.dtype == np.float32
+
+        # ... and the same holds in the other order: assign points, then flip
+        # precision back.
+        pc.points = np.random.rand(10, 3)  # type: ignore
+        pc.precision = "float16"
+        assert pc.points.dtype == np.float16
+
+        # Assigning the same precision is a no-op (no error, dtype unchanged).
+        pc.precision = "float16"
+        assert pc.points.dtype == np.float16
+    finally:
+        server.stop()

--- a/tests/test_point_cloud_precision.py
+++ b/tests/test_point_cloud_precision.py
@@ -64,7 +64,9 @@ def test_points_assignment_coerced_to_precision() -> None:
             colors=(255, 0, 0),
             precision="float32",
         )
-        src64 = np.array([[1 / 3, 2 / 3, 0.1]], dtype=np.float64)
+        src64 = np.array(
+            [[1 / 3, 2 / 3, 0.1], [0.2, 0.3, 0.4], [1.0, 2.0, 3.0]], dtype=np.float64
+        )
         pc.points = src64  # type: ignore
         assert pc.points.dtype == np.float32
         # Values match the float32 downcast (i.e. genuinely re-cast, not stored
@@ -79,7 +81,11 @@ def test_points_assignment_coerced_to_precision() -> None:
             colors=(255, 0, 0),
             precision="float16",
         )
-        pc16.points = np.array([[0.1, 0.2, 0.3]], dtype=np.float32)
+        src32 = np.array(
+            [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]], dtype=np.float32
+        )
+        pc16.points = src32
         assert pc16.points.dtype == np.float16
+        assert np.array_equal(pc16.points, src32.astype(np.float16))
     finally:
         server.stop()

--- a/tests/test_point_cloud_precision.py
+++ b/tests/test_point_cloud_precision.py
@@ -48,3 +48,38 @@ def test_point_cloud_precision_roundtrip() -> None:
         assert pc.points.dtype == np.float16
     finally:
         server.stop()
+
+
+@patch.object(viser._client_autobuild, "ensure_client_is_built", lambda: None)
+def test_points_assignment_coerced_to_precision() -> None:
+    """A ``points`` assignment is always stored at the cloud's current
+    precision, regardless of the input array's dtype."""
+    server = viser.ViserServer()
+    try:
+        # precision="float32": a float64 array (wider, not in the type
+        # annotation) is downcast to float32.
+        pc = server.scene.add_point_cloud(
+            "/pc32",
+            points=np.zeros((3, 3)),
+            colors=(255, 0, 0),
+            precision="float32",
+        )
+        src64 = np.array([[1 / 3, 2 / 3, 0.1]], dtype=np.float64)
+        pc.points = src64  # type: ignore
+        assert pc.points.dtype == np.float32
+        # Values match the float32 downcast (i.e. genuinely re-cast, not stored
+        # as float64).
+        assert np.array_equal(pc.points, src64.astype(np.float32))
+
+        # precision="float16": a float32 array -- which *is* allowed by the
+        # `points` type annotation -- is still coerced down to float16.
+        pc16 = server.scene.add_point_cloud(
+            "/pc16",
+            points=np.zeros((3, 3)),
+            colors=(255, 0, 0),
+            precision="float16",
+        )
+        pc16.points = np.array([[0.1, 0.2, 0.3]], dtype=np.float32)
+        assert pc16.points.dtype == np.float16
+    finally:
+        server.stop()


### PR DESCRIPTION
**Camera / gizmo drag**
- Gizmo stays mounted and suppresses the per-frame pivot sync during a drag, so the first/in-progress drag isn't computed from or stomped by a stale pose.
- Canceled gizmo drags no longer leave the camera disabled or steal the pointer from rect-select; `touchAction: none` stops browsers turning curved drags into scroll/zoom.
- Keyboard controls rewritten without `hold-event`: own listeners with proper teardown (fixes leaked/duplicated listeners) and per-frame movement.

**get_render()**
- Added `render_uuid` to correlate concurrent calls; try/finally restores renderer state and an empty-payload sentinel makes Python raise instead of hanging.

**Connect / disconnect**
- Server teardown, atomic counter, and handler dispatch hardened (try/finally + locking + list snapshot) so errors/self-unregister can't leak state or stall delivery.
- Reconnect clears the stale queue and re-arms first-batch ordering; worker fixes an order-lock release bug and drops sends when the socket isn't OPEN.

**Resource / memory leaks**
- Revoke object URLs on texture-load failure and dispose orphaned/owned textures and cloned geometry.
- `useGlbLoader` cancels stale async parses and disposes the actual loaded scene; unknown `FileTransferPart`s are dropped instead of throwing.

**Other**
- Root pose seeded up front so the root frame / `/WorldAxes` render +Z-up before first connect.
- HDR environment props (intensity, rotation, blur, background) applied reactively, no reload needed.
- PointCloud `precision` now re-casts `points` (order-independent); `BatchedLabelManager` group created synchronously so early labels aren't dropped.
- Dead `poseUpdateState` removed; new tests for orbit tool + advanced scene.
