### PR TITLE
Fix subtle dock geometry bugs, tests

### DIFF
--- a/src/viser/client/src/dock/DockManager.tsx
+++ b/src/viser/client/src/dock/DockManager.tsx
@@ -52,9 +52,9 @@ import {
   MAX_PANEL_WIDTH_PX,
   MIN_PANEL_WIDTH_PX,
   NodeId,
-  SPLIT_DIVIDER_PX,
   PanelId,
   PanelRegistry,
+  regionWidthsOf,
   WindowId,
 } from "./types";
 
@@ -112,14 +112,11 @@ export function DockManager({
     onLayoutChangeRef.current?.(layout);
   }, [layout]);
 
-  const [regionWidth, setRegionWidth] = React.useState({
-    left: DEFAULT_REGION_PX,
-    right: DEFAULT_REGION_PX,
-  });
-  // Mirror of regionWidth for synchronous reads inside gesture closures (which
-  // run right after a setRegionWidth and would otherwise see a stale value).
-  const regionWidthRef = React.useRef(regionWidth);
-  regionWidthRef.current = regionWidth;
+  // Region widths are part of the layout MODEL (DockLayout.regionWidth, the
+  // single source of truth -- see widthReconciliation.ts); this is just the
+  // defaults-filled view of it. Gesture closures read the synchronous truth
+  // via regionWidthsOf(layoutRef.current).
+  const regionWidth = React.useMemo(() => regionWidthsOf(layout), [layout]);
   // Rendered region widths per edge (assigned after the region plans below).
   const reservedWidthRef = React.useRef({ left: 0, right: 0 });
   const [draggingGroupId, setDraggingGroupId] = React.useState<GroupId | null>(
@@ -156,6 +153,11 @@ export function DockManager({
   };
 
   const containerRef = React.useRef<HTMLDivElement>(null);
+  // The window currently being dragged, if any. The container ResizeObserver
+  // skips it: during a drag the CURSOR is the source of truth for that
+  // window's position, and an anchor/pull write mid-drag would detach the
+  // window from the cursor (the drop commits the final position anyway).
+  const draggingWindowIdRef = React.useRef<WindowId | null>(null);
   // Cleanup for an in-flight gesture, run if the manager unmounts mid-drag.
   const activeCleanup = React.useRef<(() => void) | null>(null);
   // Pending tab-reorder "settle" timer, so it can be cancelled on unmount.
@@ -185,42 +187,27 @@ export function DockManager({
     [layout],
   );
 
-  // Auto-grow a docked region when its contents need more width than the
-  // current region width (e.g. after docking a second column side by side), so
-  // the per-panel minimum is honored rather than splitting one region's worth.
-  // Only EXPANDED columns count (per the region plan): minimized strips render
-  // at a fixed width on top of regionWidth and impose no minimum.
-  React.useEffect(() => {
-    setRegionWidth((prev) => {
-      let changed = false;
-      const next = { ...prev };
-      (["left", "right"] as DockEdge[]).forEach((edge) => {
-        const expanded = plans[edge]?.expandedColumns ?? [];
-        if (expanded.length === 0) return;
-        const min =
-          expanded.reduce((s, c) => s + ops.minRegionWidth(c), 0) +
-          SPLIT_DIVIDER_PX * (expanded.length - 1);
-        if (next[edge] < min) {
-          next[edge] = min;
-          changed = true;
-        }
-      });
-      return changed ? next : prev;
-    });
-  }, [plans]);
-
-  // Apply a layout op, reconciling docked region widths so panels keep their
-  // pixel widths across structural changes (see widthReconciliation.ts).
+  // Apply a layout op, reconciling docked region widths (written into
+  // next.regionWidth) so panels keep their pixel widths across structural
+  // changes (see widthReconciliation.ts). The old auto-grow effect is gone:
+  // the reconciler enforces the min-width floor on every commit, so a
+  // too-narrow region is unrepresentable in committed state.
   const applyOp = React.useCallback((next: DockLayout) => {
-    const { widths, changed } = reconcileRegionWidths(
-      layoutRef.current,
-      next,
-      regionWidthRef.current,
-    );
+    if (next === layoutRef.current) return; // no-op op: nothing to commit.
+    reconcileRegionWidths(layoutRef.current, next);
     layoutRef.current = next;
-    regionWidthRef.current = widths;
     setLayout(next);
-    if (changed) setRegionWidth(widths);
+  }, []);
+
+  // Restore a previously COMMITTED layout exactly (Escape after a drag that
+  // committed an op up front). No reconciliation: the snapshot already
+  // carries valid widths -- regionWidth lives in the layout, so "put the
+  // pre-drag layout back" restores geometry by construction, where the
+  // reconciler's content-matching would treat restored columns as new and
+  // reset them to defaults.
+  const restoreLayout = React.useCallback((snapshot: DockLayout) => {
+    layoutRef.current = snapshot;
+    setLayout(snapshot);
   }, []);
 
   // Imperative panel lifecycle API (exposed via context). Stable identity so
@@ -284,20 +271,30 @@ export function DockManager({
       setLayout((prev) => {
         let changed = false;
         const floating = prev.floating.map((w) => {
+          if (w.id === draggingWindowIdRef.current) return w;
           let x = w.x;
           let y = w.y;
-          const wh = w.height ?? heights.get(w.id) ?? 0;
+          // Anchoring and pulling operate on what the user SEES: the RENDERED
+          // height, which the map above just measured. The model height is
+          // only a fallback for a window with no DOM yet. (Using the model
+          // height first yanked collapsed pinned-height windows around by the
+          // height of their hidden content.)
+          const wh = heights.get(w.id) ?? w.height ?? 0;
           if (prevSize !== null && (deltaW !== 0 || deltaH !== 0)) {
             if (w.x + w.width / 2 > prevSize.w / 2) x += deltaW;
             if (w.y + wh / 2 > prevSize.h / 2) y += deltaH;
-            // A REAL container resize pulls windows fully on-screen when they
-            // fit (overhang from a drag is the user's choice; losing the far
-            // edge -- and its minimize/resize controls -- to a browser resize
+            // A container SHRINK pulls windows fully on-screen when they fit
+            // (overhang from a drag is the user's choice; losing the far edge
+            // -- and its minimize/resize controls -- to a browser resize
             // isn't). A window larger than the container pins to the
-            // top/left. NOT applied on the observer's initial fire, which
-            // would second-guess deliberate placement.
-            x = Math.min(x, Math.max(0, rect.width - w.width));
-            if (wh > 0) y = Math.min(y, Math.max(0, rect.height - wh));
+            // top/left. Per axis, shrink only: a width-only resize must not
+            // yank a bottom-overhanging window upward, and a GROW loses
+            // nothing, so it must not cancel deliberate overhang either. NOT
+            // applied on the observer's initial fire, which would
+            // second-guess deliberate placement.
+            if (deltaW < 0) x = Math.min(x, Math.max(0, rect.width - w.width));
+            if (deltaH < 0 && wh > 0)
+              y = Math.min(y, Math.max(0, rect.height - wh));
           }
           [x, y] = clampCorner(x, y, rect.width, rect.height);
           if (x === w.x && y === w.y) return w;
@@ -552,6 +549,7 @@ export function DockManager({
     let el: HTMLElement = el0;
 
     setDraggingGroupId(groupIdForDim);
+    draggingWindowIdRef.current = windowId;
     const restoreCursor = grabbingCursor();
     let crect = container.getBoundingClientRect();
     let targets = collectTargets(windowId);
@@ -565,8 +563,8 @@ export function DockManager({
     const draggingUnmergeable = (
       layoutRef.current.floating.find((w) => w.id === windowId)?.stack ?? []
     ).some((gid) => ops.isGroupUnmergeable(layoutRef.current, panels, gid));
-    const restingLeft = el.offsetLeft;
-    const restingTop = el.offsetTop;
+    let restingLeft = el.offsetLeft;
+    let restingTop = el.offsetTop;
 
     let latest: PointerEvent | null = null;
     let raf: number | null = null;
@@ -582,15 +580,22 @@ export function DockManager({
         targetsLayout = layoutRef.current;
         targets = collectTargets(windowId);
         crect = container.getBoundingClientRect();
-      }
-      if (!el.isConnected) {
-        // Reconciliation recreated the window's DOM node mid-drag; without
-        // re-resolving, the per-frame transform would land on the detached
-        // node and the window would snap back to rest until release.
-        el =
-          container.querySelector<HTMLElement>(
-            `[data-floating-window="${windowId}"]`,
-          ) ?? el;
+        if (!el.isConnected) {
+          // Reconciliation recreated the window's DOM node mid-drag; without
+          // re-resolving, the per-frame transform would land on the detached
+          // node and the window would snap back to rest until release.
+          el =
+            container.querySelector<HTMLElement>(
+              `[data-floating-window="${windowId}"]`,
+            ) ?? el;
+        }
+        // A mid-drag layout change may have moved the dragged window's
+        // RESTING position (e.g. a server update). The transform is relative
+        // to rest, so re-baseline against the freshly rendered offsets --
+        // otherwise the window rides at a stale offset from the cursor for
+        // the remainder of the drag. (offsetLeft/Top ignore the transform.)
+        restingLeft = el.offsetLeft;
+        restingTop = el.offsetTop;
       }
       // Off-screen panels are allowed (the body may overflow the right/bottom),
       // but we keep the top-left corner within the container so the handle is
@@ -644,11 +649,13 @@ export function DockManager({
         restoreCursor();
         showHint(null);
         setDraggingGroupId(null);
+        draggingWindowIdRef.current = null;
         resetLeafPreview();
         if (cancelled) {
           // A deferred-float drag already committed its float op; put the
-          // pre-drag layout back so Escape really means "never mind".
-          if (restoreOnCancel !== undefined) applyOp(restoreOnCancel);
+          // pre-drag layout back so Escape really means "never mind" --
+          // including region widths, which the snapshot carries.
+          if (restoreOnCancel !== undefined) restoreLayout(restoreOnCancel);
           return;
         }
 
@@ -719,8 +726,38 @@ export function DockManager({
       el.style.opacity = "";
       restoreSelect();
       restoreCursor();
+      draggingWindowIdRef.current = null;
       if (raf !== null) cancelAnimationFrame(raf);
     };
+  };
+
+  /** Run a drag whose gesture COMMITS layout ops up front (float a group or
+   * column, tear out a tab, expand-then-drag). Pairs the commit with its
+   * Escape-restore snapshot BY CONSTRUCTION: the snapshot is taken here,
+   * before `commit` runs, so no call site can commit without one. `commit`
+   * applies its ops (flushed where the new window's DOM must exist) and
+   * returns the drag parameters, or null to abort (nothing committed). */
+  const dragAfterCommit = (
+    e: PointerEvent,
+    commit: () => {
+      windowId: WindowId;
+      groupIdForDim: GroupId | null;
+      grabX: number;
+      grabY: number;
+    } | null,
+  ) => {
+    const before = layoutRef.current;
+    const params = commit();
+    if (params === null) return;
+    beginWindowDrag(
+      params.windowId,
+      params.groupIdForDim,
+      e.pointerId,
+      e.pointerType,
+      params.grabX,
+      params.grabY,
+      before,
+    );
   };
 
   // --- Deferred drags (float/tear, then drag the new window) -------------
@@ -810,19 +847,24 @@ export function DockManager({
     event,
     windowId,
   ) => {
-    const win = layoutRef.current.floating.find((w) => w.id === windowId);
-    if (win === undefined) return;
-    const crect = containerRect();
-    const grabX = event.clientX - crect.left - win.x;
-    const grabY = event.clientY - crect.top - win.y;
+    if (layoutRef.current.floating.every((w) => w.id !== windowId)) return;
+    // Press-time POINTER coordinates, but the window's CURRENT model position
+    // at drag start: the window may move between press and the drag threshold
+    // (container-resize anchoring), and offsets frozen against the press-time
+    // position would teleport it back on the first drag frame.
+    const pressX = event.clientX;
+    const pressY = event.clientY;
     armPress(event, (e) => {
+      const win = layoutRef.current.floating.find((w) => w.id === windowId);
+      if (win === undefined) return;
+      const crect = containerRect();
       beginWindowDrag(
         windowId,
         null,
         e.pointerId,
         e.pointerType,
-        grabX,
-        grabY,
+        pressX - crect.left - win.x,
+        pressY - crect.top - win.y,
       );
     });
   };
@@ -839,21 +881,45 @@ export function DockManager({
     const loc = ops.findGroupLocation(layoutRef.current, groupId);
     // A group alone in its floating window just moves that window on drag.
     if (loc?.kind === "floating") {
-      const win = layoutRef.current.floating.find((w) => w.id === loc.windowId);
-      if (win !== undefined && win.stack.length === 1) {
-        const crect = containerRect();
-        const grabX = event.clientX - crect.left - win.x;
-        const grabY = event.clientY - crect.top - win.y;
+      const win0 = layoutRef.current.floating.find(
+        (w) => w.id === loc.windowId,
+      );
+      if (win0 !== undefined && win0.stack.length === 1) {
+        const windowId = win0.id;
+        // Press-time pointer, drag-start model position (see startWindowDrag).
+        const pressX = event.clientX;
+        const pressY = event.clientY;
         armPress(
           event,
           (e) => {
-            // A drag from the expand (+) button tears out the FULL panel:
-            // expand first (flushed so the window height renders), then drag.
-            if (expandOnDrag)
-              flushSync(() =>
-                applyOp(ops.expandGroup(layoutRef.current, groupId)),
+            const win = layoutRef.current.floating.find(
+              (w) => w.id === windowId,
+            );
+            if (win === undefined) return;
+            const crect = containerRect();
+            const grabX = pressX - crect.left - win.x;
+            const grabY = pressY - crect.top - win.y;
+            if (expandOnDrag) {
+              // A drag from the expand (+) button tears out the FULL panel:
+              // expand first (flushed so the window height renders), then
+              // drag. The expand is an up-front COMMIT, so it goes through
+              // dragAfterCommit and Escape restores the minimized state.
+              dragAfterCommit(e, () => {
+                flushSync(() =>
+                  applyOp(ops.expandGroup(layoutRef.current, groupId)),
+                );
+                return { windowId, groupIdForDim: null, grabX, grabY };
+              });
+            } else {
+              beginWindowDrag(
+                windowId,
+                null,
+                e.pointerId,
+                e.pointerType,
+                grabX,
+                grabY,
               );
-            beginWindowDrag(win.id, null, e.pointerId, e.pointerType, grabX, grabY);
+            }
           },
           onClick,
         );
@@ -861,48 +927,44 @@ export function DockManager({
       }
     }
     armPress(event, (e) => {
-      const rect = floatRectFor(`[data-dock-group="${groupId}"]`);
-      // A panel whose body is a full-bleed nested area needs a definite height
-      // to fill (it collapses to 0 in an auto-height window). Give the undocked
-      // window the panel's current rendered height in that case; ordinary panels
-      // keep auto-height (content-sized) as before.
-      const needsHeight = (
-        layoutRef.current.groups[groupId]?.panelIds ?? []
-      ).some((p) => panels[p]?.fullBleed === true);
-      const before = layoutRef.current;
-      const res = ops.floatGroup(
-        layoutRef.current,
-        groupId,
-        rect.x,
-        rect.y,
-        rect.width,
-        needsHeight ? rect.height : undefined,
-      );
-      // Null only for an area's backing group, which no UI surface offers a
-      // group-drag for; bail rather than drag a window that doesn't exist.
-      if (res.windowId === null) return;
-      // applyOp reconciles region widths: undocking this column removes it from
-      // the region's column set, so siblings keep their widths and the region
-      // shrinks by the removed column's width. A drag from the expand (+)
-      // button floats the panel EXPANDED -- dragging it should produce a full
-      // panel, not a minimized stub.
-      flushSync(() =>
-        applyOp(
-          expandOnDrag
-            ? ops.expandGroup(res.layout, groupId)
-            : res.layout,
-        ),
-      );
-      const crect = containerRect();
-      beginWindowDrag(
-        res.windowId,
-        groupId,
-        e.pointerId,
-        e.pointerType,
-        e.clientX - crect.left - rect.x,
-        e.clientY - crect.top - rect.y,
-        before,
-      );
+      dragAfterCommit(e, () => {
+        const rect = floatRectFor(`[data-dock-group="${groupId}"]`);
+        // A panel whose body is a full-bleed nested area needs a definite
+        // height to fill (it collapses to 0 in an auto-height window). Give
+        // the undocked window the panel's current rendered height in that
+        // case; ordinary panels keep auto-height (content-sized) as before.
+        const needsHeight = (
+          layoutRef.current.groups[groupId]?.panelIds ?? []
+        ).some((p) => panels[p]?.fullBleed === true);
+        const res = ops.floatGroup(
+          layoutRef.current,
+          groupId,
+          rect.x,
+          rect.y,
+          rect.width,
+          needsHeight ? rect.height : undefined,
+        );
+        // Null only for an area's backing group, which no UI surface offers a
+        // group-drag for; bail rather than drag a window that doesn't exist.
+        if (res.windowId === null) return null;
+        // applyOp reconciles region widths: undocking this column removes it
+        // from the region's column set, so siblings keep their widths and the
+        // region shrinks by the removed column's width. A drag from the
+        // expand (+) button floats the panel EXPANDED -- dragging it should
+        // produce a full panel, not a minimized stub.
+        flushSync(() =>
+          applyOp(
+            expandOnDrag ? ops.expandGroup(res.layout, groupId) : res.layout,
+          ),
+        );
+        const crect = containerRect();
+        return {
+          windowId: res.windowId,
+          groupIdForDim: groupId,
+          grabX: e.clientX - crect.left - rect.x,
+          grabY: e.clientY - crect.top - rect.y,
+        };
+      });
     }, onClick);
   };
 
@@ -912,35 +974,35 @@ export function DockManager({
     columnNodeId,
   ) => {
     armPress(event, (e) => {
-      // Measure the COLUMN wrapper (not the 1em handle): floatRectFor clamps
-      // width/height into sane floating ranges, same as a group undock.
-      const rect = floatRectFor(`[data-dock-column="${columnNodeId}"]`);
-      const before = layoutRef.current;
-      const res = ops.floatColumn(
-        layoutRef.current,
-        edge,
-        columnNodeId,
-        rect.x,
-        rect.y,
-        rect.width,
-        rect.height,
-      );
-      // Null when the column was restructured under us or isn't a pure
-      // column anymore; just don't drag.
-      if (res.windowId === null) return;
-      // applyOp reconciles region widths: removing this column from the
-      // edge's column set lets survivors keep their px and shrinks the region.
-      flushSync(() => applyOp(res.layout));
-      const crect = containerRect();
-      beginWindowDrag(
-        res.windowId,
-        null, // no single origin group to dim; the whole column left the tree.
-        e.pointerId,
-        e.pointerType,
-        e.clientX - crect.left - rect.x,
-        e.clientY - crect.top - rect.y,
-        before,
-      );
+      dragAfterCommit(e, () => {
+        // Measure the COLUMN wrapper (not the 1em handle): floatRectFor clamps
+        // width/height into sane floating ranges, same as a group undock.
+        const rect = floatRectFor(`[data-dock-column="${columnNodeId}"]`);
+        const res = ops.floatColumn(
+          layoutRef.current,
+          edge,
+          columnNodeId,
+          rect.x,
+          rect.y,
+          rect.width,
+          rect.height,
+        );
+        // Null when the column was restructured under us or isn't a pure
+        // column anymore; just don't drag.
+        if (res.windowId === null) return null;
+        // applyOp reconciles region widths: removing this column from the
+        // edge's column set lets survivors keep their px and shrinks the
+        // region.
+        flushSync(() => applyOp(res.layout));
+        const crect = containerRect();
+        return {
+          // No single origin group to dim; the whole column left the tree.
+          windowId: res.windowId,
+          groupIdForDim: null,
+          grabX: e.clientX - crect.left - rect.x,
+          grabY: e.clientY - crect.top - rect.y,
+        };
+      });
     });
   };
 
@@ -1035,55 +1097,56 @@ export function DockManager({
 
     const tearOut = (e: PointerEvent) => {
       cleanup();
-      const src = floatRectFor(`[data-dock-group="${groupId}"]`);
-      const before = layoutRef.current;
-      const res = ops.tearOutPanel(
-        layoutRef.current,
-        groupId,
-        panelId,
-        src.x,
-        src.y,
-        src.width,
-      );
-      flushSync(() => applyOp(res.layout));
+      dragAfterCommit(e, () => {
+        const src = floatRectFor(`[data-dock-group="${groupId}"]`);
+        const res = ops.tearOutPanel(
+          layoutRef.current,
+          groupId,
+          panelId,
+          src.x,
+          src.y,
+          src.width,
+        );
+        flushSync(() => applyOp(res.layout));
 
-      // Anchor the new window so the cursor lands on its tab strip. Unlike a
-      // group drag (which floats on the first 3px of motion), a tear-out only
-      // triggers after the pointer has left the strip, so we can't reuse the
-      // accumulated offset -- re-measure the new window's strip and reposition.
-      const crect = containerRect();
-      const winEl = containerRef.current?.querySelector<HTMLElement>(
-        `[data-floating-window="${res.windowId}"]`,
-      );
-      let grabX = 40;
-      let grabY = 18;
-      if (winEl != null) {
-        const winRect = winEl.getBoundingClientRect();
-        grabX = Math.min(40, winRect.width / 2);
-        const stripEl2 = winEl.querySelector<HTMLElement>("[data-dock-strip]");
-        if (stripEl2 != null) {
-          const sRect = stripEl2.getBoundingClientRect();
-          grabY = sRect.top - winRect.top + sRect.height / 2;
-        } else {
-          // Strip not found (defensive): anchor within the window's actual
-          // height rather than a fixed 18px that may overshoot a short window.
-          grabY = Math.min(18, winRect.height / 2);
+        // Anchor the new window so the cursor lands on its tab strip. Unlike
+        // a group drag (which floats on the first 3px of motion), a tear-out
+        // only triggers after the pointer has left the strip, so we can't
+        // reuse the accumulated offset -- re-measure the new window's strip
+        // and reposition.
+        const crect = containerRect();
+        const winEl = containerRef.current?.querySelector<HTMLElement>(
+          `[data-floating-window="${res.windowId}"]`,
+        );
+        let grabX = 40;
+        let grabY = 18;
+        if (winEl != null) {
+          const winRect = winEl.getBoundingClientRect();
+          grabX = Math.min(40, winRect.width / 2);
+          const stripEl2 =
+            winEl.querySelector<HTMLElement>("[data-dock-strip]");
+          if (stripEl2 != null) {
+            const sRect = stripEl2.getBoundingClientRect();
+            grabY = sRect.top - winRect.top + sRect.height / 2;
+          } else {
+            // Strip not found (defensive): anchor within the window's actual
+            // height rather than a fixed 18px that may overshoot a short
+            // window.
+            grabY = Math.min(18, winRect.height / 2);
+          }
         }
-      }
-      const newX = e.clientX - crect.left - grabX;
-      const newY = e.clientY - crect.top - grabY;
-      flushSync(() =>
-        applyOp(ops.moveWindow(layoutRef.current, res.windowId, newX, newY)),
-      );
-      beginWindowDrag(
-        res.windowId,
-        res.floatingGroupId,
-        e.pointerId,
-        e.pointerType,
-        grabX,
-        grabY,
-        before,
-      );
+        const newX = e.clientX - crect.left - grabX;
+        const newY = e.clientY - crect.top - grabY;
+        flushSync(() =>
+          applyOp(ops.moveWindow(layoutRef.current, res.windowId, newX, newY)),
+        );
+        return {
+          windowId: res.windowId,
+          groupIdForDim: res.floatingGroupId,
+          grabX,
+          grabY,
+        };
+      });
     };
 
     const apply = () => {
@@ -1412,7 +1475,9 @@ export function DockManager({
                     const plan = planRegion(tree0, layout0.groups);
                     const cols = plan.expandedColumns;
                     if (cols.length === 0) return () => {};
-                    const startRegion = regionWidthRef.current[edge];
+                    const startRegion = regionWidthsOf(layoutRef.current)[
+                      edge
+                    ];
                     // Weights are pixels for side-by-side columns (the
                     // reconciler wrote them); a single surfaced column's px
                     // is the regionWidth itself (its weight may be a height).
@@ -1435,17 +1500,18 @@ export function DockManager({
                       const total = widths.reduce((a, b) => a + b, 0);
                       // Only rewrite weights for genuinely side-by-side
                       // columns; a single surfaced column may be a vertical
-                      // child whose weight is a HEIGHT (see applyOp).
+                      // child whose weight is a HEIGHT (see applyOp). The
+                      // total goes through the setRegionWidth op so the model
+                      // stays the single source of truth for the width.
+                      let next = layoutRef.current;
                       if (!plan.singleColumn) {
                         const byId: Record<string, number> = {};
                         ids.forEach((id, i) => {
                           byId[id] = widths[i];
                         });
-                        applyOp(
-                          ops.setNodeWeights(layoutRef.current, edge, byId),
-                        );
+                        next = ops.setNodeWeights(next, edge, byId);
                       }
-                      setRegionWidth((prev) => ({ ...prev, [edge]: total }));
+                      applyOp(ops.setRegionWidth(next, edge, total));
                     };
                   }}
                 />

--- a/src/viser/client/src/dock/FloatingWindowView.tsx
+++ b/src/viser/client/src/dock/FloatingWindowView.tsx
@@ -63,15 +63,15 @@ export const FloatingWindowView = React.memo(function FloatingWindowView({
     (id) => dock.groups[id]?.collapsed === true,
   );
   const fixedHeight = win.height !== undefined && !collapsed;
-  // A pinned height is capped to the container so the bottom resize grip stays
-  // reachable when the browser window shrinks below the saved height (the
-  // groups inside scroll). Floored at MIN_HEIGHT_PX for tiny containers.
+  // A pinned height is capped to the container so the window stays usable when
+  // the browser shrinks below the saved height (the groups inside scroll).
+  // Deliberately independent of win.y: moving a window must never change its
+  // size, so a pinned-height window dragged low simply overhangs the bottom
+  // edge -- exactly like an auto-height window does. Floored at MIN_HEIGHT_PX
+  // for tiny containers.
   const renderedHeight =
     win.height !== undefined && containerHeight > 0
-      ? Math.min(
-          win.height,
-          Math.max(MIN_HEIGHT_PX, containerHeight - win.y - 8),
-        )
+      ? Math.min(win.height, Math.max(MIN_HEIGHT_PX, containerHeight - 8))
       : win.height;
 
   // Animate collapse/expand by FLIP-ing the window height: each render notes
@@ -119,20 +119,32 @@ export const FloatingWindowView = React.memo(function FloatingWindowView({
     prevHeightRef.current = target;
     if (start === null || Math.abs(start - target) < 1) return;
     if (prefersReducedMotion()) return;
+    // ONE WRITER PER STYLE PROPERTY: React owns `height` (it renders the
+    // pinned renderedHeight), so the animation drives min-height/max-height
+    // -- properties React never writes on the Paper. Pinning both forces the
+    // box through the transition in either direction, and clearing them on
+    // cancel hands control back cleanly BY CONSTRUCTION: there is no React
+    // style-cache entry for them to disagree with. (Animating `height` here
+    // and "handing it back" by clearing the inline value left the window at
+    // 0px: React's cache still held the old height, so it never re-wrote it.)
     p.style.transition = "none";
-    p.style.height = `${start}px`;
+    p.style.minHeight = `${start}px`;
+    p.style.maxHeight = `${start}px`;
     void p.offsetHeight; // force a reflow so the start height takes effect
-    p.style.transition = "height 180ms ease";
-    p.style.height = `${target}px`;
+    p.style.transition = "min-height 180ms ease, max-height 180ms ease";
+    p.style.minHeight = `${target}px`;
+    p.style.maxHeight = `${target}px`;
     const cancel = () => {
       flipCancelRef.current = null;
       p.style.transition = "";
-      p.style.height = ""; // hand height back to React (matches `target`)
+      p.style.minHeight = "";
+      p.style.maxHeight = "";
       p.removeEventListener("transitionend", onEnd);
     };
     const onEnd = (e: TransitionEvent) => {
-      // Child transitions bubble; only our own height transition ends the FLIP.
-      if (e.target === p) cancel();
+      // Child transitions bubble; only our own animation ends the FLIP (both
+      // pinned properties finish together -- listen for one of them).
+      if (e.target === p && e.propertyName === "max-height") cancel();
     };
     flipCancelRef.current = cancel;
     p.addEventListener("transitionend", onEnd);

--- a/src/viser/client/src/dock/TabGroupFrame.tsx
+++ b/src/viser/client/src/dock/TabGroupFrame.tsx
@@ -13,7 +13,68 @@ import {
 } from "./DockStyles.css";
 import { keyActivate, prefersReducedMotion } from "./gestures";
 import { GripPill, HandleIconButton } from "./handles";
-import { TabGroup } from "./types";
+import { PanelSpec, TabGroup } from "./types";
+
+// The active panel's BODY, memoized so it is rebuilt/reconciled only when its
+// OWN inputs change -- not on every unrelated dock op. A tab switch or a
+// dock/undock elsewhere busts the dock context, so every TabGroupFrame
+// re-renders; without this, each one would re-invoke `panel.render()` and
+// re-reconcile the whole ScrollArea/Box wrapper chain. The memo holds because
+// panel specs are referentially STABLE across layout ops (the registry keys
+// content by id -- see ControlPanelDock), so an unrelated op leaves
+// (panel, fill, maxContentHeight) untouched and React skips the subtree. The
+// live content inside still updates via its own state subscriptions.
+const PanelBody = React.memo(function PanelBody({
+  panel,
+  fill,
+  maxContentHeight,
+}: {
+  panel: PanelSpec | undefined;
+  fill: boolean;
+  maxContentHeight?: number;
+}) {
+  if (panel?.fullBleed === true) {
+    // Full-bleed: render the content directly with no padding and no ScrollArea
+    // wrapper -- the content (e.g. a nested DockArea) fills the body and manages
+    // its own scrolling. (Wrapping a fill-height child in ScrollArea.Autosize,
+    // which sizes to content, would collapse it to 0 height.)
+    return (
+      <Box
+        style={{
+          width: "100%",
+          ...(fill
+            ? {
+                flexGrow: 1,
+                minHeight: 0,
+                display: "flex",
+                flexDirection: "column" as const,
+              }
+            : {}),
+        }}
+      >
+        {panel.render()}
+      </Box>
+    );
+  }
+  return (
+    <ScrollArea.Autosize
+      mah={fill ? undefined : maxContentHeight}
+      className={dockBodyScroll}
+      style={
+        fill ? { flexGrow: 1, minHeight: 0, width: "100%" } : { width: "100%" }
+      }
+    >
+      <Box
+        style={{
+          padding: panel?.unpadded === true ? undefined : "0.6em 0.75em",
+          width: "100%",
+        }}
+      >
+        {panel?.render() ?? null}
+      </Box>
+    </ScrollArea.Autosize>
+  );
+});
 
 // Tab handle height, also the band height for the strip's repeating bottom-rule
 // gradient. In em relative to the strip's own font-size so the two stay aligned.
@@ -184,42 +245,12 @@ export function TabGroupFrame({
   //   Collapse would fight the flex sizing. Instead we render the body plainly
   //   and let the leaf's flex-grow transition (see the outer Box / DockLeafView
   //   column Paper) animate the height; when collapsed we just hide the body.
-  const fullBleed = panels[group.activeId]?.fullBleed === true;
-  const body = fullBleed ? (
-    // Full-bleed: render the content directly with no padding and no ScrollArea
-    // wrapper -- the content (e.g. a nested DockArea) fills the body and manages
-    // its own scrolling. (Wrapping a fill-height child in ScrollArea.Autosize,
-    // which sizes to content, would collapse it to 0 height.)
-    <Box
-      style={{
-        width: "100%",
-        ...(fill
-          ? { flexGrow: 1, minHeight: 0, display: "flex", flexDirection: "column" as const }
-          : {}),
-      }}
-    >
-      {panels[group.activeId]?.render() ?? null}
-    </Box>
-  ) : (
-    <ScrollArea.Autosize
-      mah={fill ? undefined : maxContentHeight}
-      className={dockBodyScroll}
-      style={
-        fill ? { flexGrow: 1, minHeight: 0, width: "100%" } : { width: "100%" }
-      }
-    >
-      <Box
-        style={{
-          padding:
-            panels[group.activeId]?.unpadded === true
-              ? undefined
-              : "0.6em 0.75em",
-          width: "100%",
-        }}
-      >
-        {panels[group.activeId]?.render() ?? null}
-      </Box>
-    </ScrollArea.Autosize>
+  const body = (
+    <PanelBody
+      panel={panels[group.activeId]}
+      fill={fill}
+      maxContentHeight={maxContentHeight}
+    />
   );
   const contents = fill ? (
     // Docked: the body stays mounted and fills the group's flexible area

--- a/src/viser/client/src/dock/hitTest.test.ts
+++ b/src/viser/client/src/dock/hitTest.test.ts
@@ -628,6 +628,38 @@ describe("area target", () => {
     expect(out.result).toEqual({ kind: "merge", targetGroupId: "area" });
   });
 
+  it("inset hitRect: the leftmost tab is still droppable over the strip", () => {
+    // regression: a full-bleed area's hitRect is inset on the left/right/bottom
+    // (so its frame falls through to the host). The left inset used to slice
+    // the leftmost tab's "insert before" zone, so dropping as the FIRST tab was
+    // impossible (it fell through to the host). The strip must use full width.
+    const INSET = 40;
+    const t = areaTarget();
+    t.hitRect = rect(
+      frame.left + INSET,
+      frame.top,
+      frame.width - 2 * INSET,
+      frame.height - INSET,
+    );
+    // Pointer over the LEFT half of tab 0, inside the inset band (x < left+40).
+    const out = run(layout, [t], frame.left + 10, frame.top + STRIP_OFFSET + 15)!;
+    expect(out.result).toEqual({
+      kind: "insertTab",
+      targetGroupId: "area",
+      index: 0,
+    });
+    // And the rightmost edge of the strip (after the last tab) still inserts.
+    const right = run(layout, [t], frame.right - 5, frame.top + STRIP_OFFSET + 15)!;
+    expect(right.result).toEqual({
+      kind: "insertTab",
+      targetGroupId: "area",
+      index: 2,
+    });
+    // The BODY keeps the inset: a far-left point below the strip is NOT the
+    // area (falls through -- here there's no other target, so null).
+    expect(run(layout, [t], frame.left + 10, 400)).toBeNull();
+  });
+
   it("an EMPTY area (stripRect null, no tabs) -> merge anywhere in the frame", () => {
     const empty = areaTarget({ stripRect: null, tabs: [] });
     // Anywhere inside the frame resolves to merge -- the empty area is one big

--- a/src/viser/client/src/dock/hitTest.ts
+++ b/src/viser/client/src/dock/hitTest.ts
@@ -123,6 +123,31 @@ export interface ContainerRect {
 export const inside = (r: DOMRect, x: number, y: number) =>
   x >= r.left && x <= r.right && y >= r.top && y <= r.bottom;
 
+/** Whether a pointer hits a drop target.
+ *
+ * Normally just `inside(hitRect ?? rect)`. The one wrinkle is a nested area's
+ * inset `hitRect`: a full-bleed area's body is inset on the left/right/bottom
+ * so its frame falls through to the HOST panel's edge zones -- but the area's
+ * tab STRIP spans the area's full width, with the first/last tabs flush at the
+ * left/right edges. So the strip band must use the FULL width: otherwise the
+ * horizontal inset slices the leftmost/rightmost tabs' insert zones at the top
+ * corners and they become undroppable (the drop falls through to the host).
+ * The body keeps the inset. */
+export const hitsTarget = (t: GroupTarget, x: number, y: number): boolean => {
+  if (
+    t.hitRect !== undefined &&
+    t.ctx.kind === "area" &&
+    t.stripRect !== null &&
+    y >= t.stripRect.top &&
+    y <= t.stripRect.bottom &&
+    x >= t.rect.left &&
+    x <= t.rect.right
+  ) {
+    return true;
+  }
+  return inside(t.hitRect ?? t.rect, x, y);
+};
+
 /** Resolve a tab insertion for a pointer over a strip. Uses the nearest tab
  * (2D), not just horizontal position, so it works when the tabs wrap onto
  * multiple rows. Returns the insert index plus the insertion line's geometry
@@ -308,9 +333,7 @@ export function hitTest(
   // the one painted underneath).
   let g: GroupTarget | undefined;
   for (const t of targets.groups) {
-    // Hit-test against hitRect (an inset frame for full-bleed areas) when given,
-    // but everything below still sizes hints from the full `rect`.
-    if (inside(t.hitRect ?? t.rect, clientX, clientY)) g = t;
+    if (hitsTarget(t, clientX, clientY)) g = t;
   }
   if (g === undefined) return null;
   const r = g.rect;

--- a/src/viser/client/src/dock/hitTest.ts
+++ b/src/viser/client/src/dock/hitTest.ts
@@ -18,8 +18,10 @@ import {
   WindowId,
 } from "./types";
 
-/** Default width of a freshly-created docked region. */
-export const DEFAULT_REGION_PX = 300;
+// Re-exported for existing consumers; the constant lives in types.ts now that
+// the region width is part of the layout MODEL (DockLayout.regionWidth).
+export { DEFAULT_REGION_PX } from "./types";
+import { DEFAULT_REGION_PX } from "./types";
 // Screen-edge zone width (only active on an empty edge).
 const EDGE_ZONE_PX = 48;
 // Thin band at a docked region's outer top/bottom edge -> full-span row above/

--- a/src/viser/client/src/dock/layoutOps.ts
+++ b/src/viser/client/src/dock/layoutOps.ts
@@ -22,6 +22,7 @@ import {
   NodeId,
   PanelId,
   PanelRegistry,
+  regionWidthsOf,
   SPLIT_DIVIDER_PX,
   TabGroup,
   WindowId,
@@ -1212,6 +1213,21 @@ export function setNodeWeights(
     if (node.type === "split") node.children.forEach(apply);
   };
   apply(draft.docked[edge]!);
+  return draft;
+}
+
+/** Set an edge's region width (px) directly -- the region resizer's write
+ * path. The value becomes the carry-over base for width reconciliation on
+ * commit (which still enforces its min/max invariants). */
+export function setRegionWidth(
+  layout: DockLayout,
+  edge: DockEdge,
+  px: number,
+): DockLayout {
+  if (!Number.isFinite(px) || regionWidthsOf(layout)[edge] === px)
+    return layout;
+  const draft = clone(layout);
+  draft.regionWidth = { ...regionWidthsOf(layout), [edge]: px };
   return draft;
 }
 

--- a/src/viser/client/src/dock/layoutOps.ts
+++ b/src/viser/client/src/dock/layoutOps.ts
@@ -2,9 +2,9 @@
 //
 // Every exported op takes a layout and returns a *new* layout, leaving the
 // input untouched. The layout is plain serializable data (no React nodes), so
-// we clone with structuredClone and mutate the copy -- simpler and less
-// error-prone than threading immutable updates through the split tree, and
-// cheap because layouts are small.
+// we deep-clone and mutate the copy -- simpler and less error-prone than
+// threading immutable updates through the split tree, and cheap because
+// layouts are small.
 
 import {
   AreaId,
@@ -29,7 +29,29 @@ import {
 } from "./types";
 import { freshId } from "./gestures";
 
-const clone = <T>(value: T): T => structuredClone(value);
+// A typed recursive deep-clone, ~10x faster than structuredClone for the
+// layout's plain JSON-ish shape (objects/arrays/numbers/strings/booleans --
+// no Dates/Maps/Sets/functions/RegExp, guaranteed by DockLayout being the
+// serialization contract). Copies only present own-enumerable keys, so an
+// absent optional field (height, regionWidth, stackWeights, collapsed, ...)
+// stays absent rather than materializing as `undefined` -- the same
+// absent-vs-undefined semantics structuredClone preserves and that width
+// reconciliation / persistence rely on.
+const clone = <T>(value: T): T => {
+  if (Array.isArray(value)) {
+    return (value as unknown[]).map(clone) as unknown as T;
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key in value as Record<string, unknown>) {
+      if (Object.prototype.hasOwnProperty.call(value, key)) {
+        out[key] = clone((value as Record<string, unknown>)[key]);
+      }
+    }
+    return out as T;
+  }
+  return value;
+};
 
 // ---------------------------------------------------------------------------
 // Tree helpers (operate on cloned nodes; return new nodes).

--- a/src/viser/client/src/dock/regionPlan.test.ts
+++ b/src/viser/client/src/dock/regionPlan.test.ts
@@ -69,17 +69,18 @@ describe("reconcile: dropping an expanded panel below a strip", () => {
     const l = emptyLayout();
     l.groups = groups(["a"], ["b"]);
     l.docked.right = leaf("a", 320);
+    l.regionWidth = { left: 0, right: 320 };
     const prev = toggleCollapsed(l, "a");
-    const w0 = reconcileRegionWidths(l, prev, { left: 0, right: 320 }).widths;
+    reconcileRegionWidths(l, prev);
 
     // Drop b BELOW the strip: tree becomes column[a(collapsed), b].
     const next = structuredClone(prev);
     const a = next.docked.right!;
     next.docked.right = col([a, leaf("b")]);
-    const { widths } = reconcileRegionWidths(prev, next, w0);
-    expect(widths.right).toBe(320);
+    reconcileRegionWidths(prev, next);
+    expect(next.regionWidth!.right).toBe(320);
     // And the rendered region uses that width (no strip chrome).
     const plan = planRegion(next.docked.right!, next.groups);
-    expect(plannedReservedWidth(plan, widths.right)).toBe(320);
+    expect(plannedReservedWidth(plan, next.regionWidth!.right)).toBe(320);
   });
 });

--- a/src/viser/client/src/dock/types.ts
+++ b/src/viser/client/src/dock/types.ts
@@ -44,6 +44,10 @@ export const MINIMIZED_STRIP_PX = 36;
  * chrome widths, so resize math stays 1:1 with the cursor. */
 export const SPLIT_DIVIDER_PX = 7;
 
+/** Width (px) a docked region starts at (and that a newly docked column gets)
+ * before the user resizes it. */
+export const DEFAULT_REGION_PX = 300;
+
 /** Clamp `v` into [lo, hi]. Shared by every place a size/position is bounded
  * (resize gestures, width reconciliation, hint geometry). */
 export const clamp = (v: number, lo: number, hi: number): number =>
@@ -161,6 +165,17 @@ export interface DockLayout {
   groups: Record<GroupId, TabGroup>;
   /** Docked region pinned to each edge, or null when that edge is empty. */
   docked: Record<DockEdge, DockNode | null>;
+  /** Docked region widths in px per edge: the EXPANDED width-columns' summed
+   * pixels (minimized strips and dividers render on top -- see regionPlan).
+   * THE single source of truth for region width. It travels with the layout
+   * through every op (clones carry it) and is rewritten only by width
+   * reconciliation in applyOp -- so snapshot/restore, persistence, and undo
+   * preserve widths by construction. Kept while an edge is empty or fully
+   * minimized so the width survives for restore.
+   *
+   * Optional so layout literals (e.g. in tests) stay terse; a missing value
+   * reads as DEFAULT_REGION_PX per edge (see regionWidthsOf). */
+  regionWidth?: Record<DockEdge, number>;
   /** Floating windows, painted in array order (last = topmost). */
   floating: FloatingWindow[];
   /** Nested dockable areas, keyed by id. Each is a flat tab group embedded in a
@@ -187,4 +202,13 @@ export const emptyLayout = (): DockLayout => ({
   docked: { left: null, right: null },
   floating: [],
   areas: {},
+});
+
+/** The layout's region widths with defaults filled in (the one place the
+ * missing-field fallback lives). */
+export const regionWidthsOf = (
+  layout: DockLayout,
+): Record<DockEdge, number> => ({
+  left: layout.regionWidth?.left ?? DEFAULT_REGION_PX,
+  right: layout.regionWidth?.right ?? DEFAULT_REGION_PX,
 });

--- a/src/viser/client/src/dock/widthReconciliation.test.ts
+++ b/src/viser/client/src/dock/widthReconciliation.test.ts
@@ -1,15 +1,22 @@
-// Tests for the region-width model: regionWidth tracks only the EXPANDED
-// width-columns' pixels; minimized columns keep their preserved px in their
-// weight but render as fixed strips ON TOP of regionWidth. Reconciliation
-// must (a) recompute the expanded sum when a column's minimized state flips,
-// (b) exclude minimized columns from structural-change sums, and (c) leave
-// pure-internal changes alone.
+// Tests for the region-width model: layout.regionWidth tracks only the
+// EXPANDED width-columns' pixels; minimized columns keep their preserved px
+// in their weight but render as fixed strips ON TOP of regionWidth. The
+// width lives in the layout itself (single source of truth), and
+// reconciliation -- run on every commit -- must (a) recompute the expanded
+// sum when a column's minimized state flips, (b) exclude minimized columns
+// from structural-change sums, and (c) leave pure-internal changes alone.
 
 import { describe, expect, it } from "vitest";
 import { toggleCollapsed } from "./layoutOps";
-import { DockLayout, emptyLayout } from "./types";
+import { DockEdge, DockLayout, emptyLayout, regionWidthsOf } from "./types";
 import { reconcileRegionWidths } from "./widthReconciliation";
 import { leaf, row, group } from "./testUtils";
+
+/** Reconcile and return next's resulting widths (the new single source). */
+function recon(prev: DockLayout, next: DockLayout): Record<DockEdge, number> {
+  reconcileRegionWidths(prev, next);
+  return regionWidthsOf(next);
+}
 
 /** Layout with three side-by-side right-docked columns at px weights. */
 function threeColumns(widths: [number, number, number]): DockLayout {
@@ -20,37 +27,31 @@ function threeColumns(widths: [number, number, number]): DockLayout {
     leaf("b", widths[1]),
     leaf("c", widths[2]),
   ]);
+  l.regionWidth = { left: 0, right: widths[0] + widths[1] + widths[2] };
   return l;
 }
-
-const START = { left: 0, right: 900 };
 
 describe("reconcileRegionWidths with minimized columns", () => {
   it("collapse toggle drops the column from the expanded sum", () => {
     const prev = threeColumns([300, 300, 300]);
     const next = toggleCollapsed(prev, "b");
-    const { widths, changed } = reconcileRegionWidths(prev, next, START);
-    expect(changed).toBe(true);
-    expect(widths.right).toBe(600); // a + c only; b renders as a strip.
+    expect(recon(prev, next).right).toBe(600); // a + c only; b is a strip.
   });
 
   it("expand toggle rejoins at the preserved pixel weight", () => {
     const prev0 = threeColumns([300, 300, 300]);
     const prev = toggleCollapsed(prev0, "b"); // b minimized
-    const afterCollapse = reconcileRegionWidths(prev0, prev, START).widths;
-    expect(afterCollapse.right).toBe(600);
+    expect(recon(prev0, prev).right).toBe(600);
     const next = toggleCollapsed(prev, "b"); // b expands again
-    const { widths } = reconcileRegionWidths(prev, next, afterCollapse);
-    expect(widths.right).toBe(900); // b's preserved 300 rejoins.
+    expect(recon(prev, next).right).toBe(900); // b's preserved 300 rejoins.
   });
 
   it("two of three minimized: sum is the lone expanded column", () => {
     const prev = threeColumns([300, 280, 320]);
     const mid = toggleCollapsed(prev, "a");
-    const w1 = reconcileRegionWidths(prev, mid, START).widths;
+    recon(prev, mid);
     const next = toggleCollapsed(mid, "b");
-    const { widths } = reconcileRegionWidths(mid, next, w1);
-    expect(widths.right).toBe(320); // only c is expanded.
+    expect(recon(mid, next).right).toBe(320); // only c is expanded.
   });
 
   it("fully minimized keeps the previous width for restore", () => {
@@ -58,18 +59,15 @@ describe("reconcileRegionWidths with minimized columns", () => {
     let next = toggleCollapsed(prev, "a");
     next = toggleCollapsed(next, "b");
     next = toggleCollapsed(next, "c");
-    const { widths } = reconcileRegionWidths(prev, next, START);
-    // No expanded columns left: regionWidth keeps its value (the rail renders
-    // at strip width regardless; the value only matters again on expand).
-    expect(widths.right).toBe(900);
+    // No expanded columns left: regionWidth keeps its value (the strips render
+    // at fixed width regardless; the value only matters again on expand).
+    expect(recon(prev, next).right).toBe(900);
   });
 
   it("pure-internal change (same set, same pattern) leaves widths alone", () => {
     const prev = threeColumns([300, 300, 300]);
     const next = structuredClone(prev);
-    const { widths, changed } = reconcileRegionWidths(prev, next, START);
-    expect(changed).toBe(false);
-    expect(widths).toEqual(START);
+    expect(recon(prev, next)).toEqual({ left: 0, right: 900 });
   });
 
   it("structural change sums only the expanded columns", () => {
@@ -77,16 +75,46 @@ describe("reconcileRegionWidths with minimized columns", () => {
     const l = emptyLayout();
     l.groups = { a: group("a"), b: group("b") };
     l.docked.right = row([leaf("a", 400), leaf("b", 250)]);
+    l.regionWidth = { left: 0, right: 650 };
     const prev = toggleCollapsed(l, "b");
-    const prevW = reconcileRegionWidths(l, prev, { left: 0, right: 650 });
-    expect(prevW.widths.right).toBe(400);
+    expect(recon(l, prev).right).toBe(400);
 
     // Remove a's column entirely (structural: column set changes).
     const next = structuredClone(prev);
     const tree = next.docked.right!;
     if (tree.type === "split") next.docked.right = tree.children[1];
-    const { widths } = reconcileRegionWidths(prev, next, prevW.widths);
     // The only remaining column is minimized: fall back to its preserved px.
-    expect(widths.right).toBe(250);
+    expect(recon(prev, next).right).toBe(250);
+  });
+
+  it("restoring a snapshot onto an empty edge keeps the preserved width", () => {
+    // regression: Escape after an undock restores the layout snapshot; the
+    // re-appearing single column must come back at the edge's preserved
+    // width (carried in the layout), not the default.
+    const docked = threeColumns([460, 0, 0]);
+    docked.docked.right = leaf("a", 1); // single column, weight is NOT px
+    docked.groups = { a: group("a") };
+    docked.regionWidth = { left: 0, right: 460 };
+    const floated = structuredClone(docked);
+    floated.docked.right = null; // the column floated away; width preserved.
+    expect(recon(docked, floated).right).toBe(460);
+    const restored = structuredClone(docked);
+    expect(recon(floated, restored).right).toBe(460);
+  });
+});
+
+describe("reconcileRegionWidths min-width floor", () => {
+  it("raises a too-narrow width to the expanded columns' summed minimum", () => {
+    // Two 220px-minimum columns + divider = 447; a carried width of 300 is
+    // unrepresentable and must be floored on commit (replaces the old
+    // auto-grow effect).
+    const prev = emptyLayout();
+    prev.groups = { a: group("a") };
+    prev.docked.right = leaf("a", 1);
+    prev.regionWidth = { left: 0, right: 300 };
+    const next = structuredClone(prev);
+    next.groups["b"] = group("b");
+    next.docked.right = row([leaf("a", 300), leaf("b", 300)]);
+    expect(recon(prev, next).right).toBeGreaterThanOrEqual(447);
   });
 });

--- a/src/viser/client/src/dock/widthReconciliation.ts
+++ b/src/viser/client/src/dock/widthReconciliation.ts
@@ -1,13 +1,21 @@
 // Region-width reconciliation across layout ops: keeps docked panels at their
 // pixel widths when the layout's STRUCTURE changes. Pure except for mutating
-// `next`'s top-column weights (the caller owns `next`, a fresh draft).
+// `next` (the caller owns it, a fresh draft): top-column weights may be
+// rewritten to pixels, and `next.regionWidth` is always (re)written.
 //
 // Width model: a region's width-determining columns store their EXPANDED
-// pixel widths as tree weights, and `regionWidth[edge]` is the sum over the
-// EXPANDED columns only. Fully-minimized columns keep their preserved pixel
-// width in their weight (it's what they get back on expand) but render as
-// fixed MINIMIZED_STRIP_PX strips that sit ON TOP of regionWidth -- so resize
-// math and the rendered layout agree, and resizing never touches a strip.
+// pixel widths as tree weights, and `layout.regionWidth[edge]` is the sum
+// over the EXPANDED columns only. Fully-minimized columns keep their
+// preserved pixel width in their weight (it's what they get back on expand)
+// but render as fixed MINIMIZED_STRIP_PX strips that sit ON TOP of
+// regionWidth -- so resize math and the rendered layout agree, and resizing
+// never touches a strip.
+//
+// The width lives IN the layout (DockLayout.regionWidth), so it has one
+// source of truth: clones carry it through every op, snapshots restore it,
+// and this reconciliation -- run on every applyOp commit -- is the only
+// writer. Layouts that bypassed the ops (test literals, injected layouts)
+// simply lack the field and get defaults here.
 
 import {
   collectLeafGroups,
@@ -15,18 +23,17 @@ import {
   minRegionWidth,
   widthColumns,
 } from "./layoutOps";
-import { planRegion } from "./regionPlan";
+import { planRegion, RegionPlan } from "./regionPlan";
 import {
   clamp,
+  DEFAULT_REGION_PX,
   DockEdge,
   DockLayout,
   DockNode,
   MIN_PANEL_WIDTH_PX,
+  regionWidthsOf,
   SPLIT_DIVIDER_PX,
 } from "./types";
-import { DEFAULT_REGION_PX } from "./hitTest";
-
-export type RegionWidths = { left: number; right: number };
 
 const DIVIDER_PX = SPLIT_DIVIDER_PX;
 
@@ -48,7 +55,9 @@ function colsMax(cols: DockNode[]): number {
   );
 }
 
-/** Reconcile docked region widths across a layout transition.
+/** Reconcile docked region widths across a layout transition, writing the
+ * result into `next.regionWidth` (and, for structural changes, into the
+ * top columns' weights).
  *
  * - When a region's SET of width-determining columns changes (dock/undock/
  *   merge/unmerge/snap/split), the column weights are rewritten to absolute
@@ -59,21 +68,21 @@ function colsMax(cols: DockNode[]): number {
  *   pixel weights: a column entering minimization leaves the sum (its strip
  *   renders on top); one expanding rejoins at its preserved width.
  * - Pure-internal changes (resize, reorder, floating moves) leave both the
- *   column set and the pattern alone, so widths are untouched.
- *
- * Mutates `next.docked` column weights in place; returns the next region
- * widths plus whether any region changed. */
-export function reconcileRegionWidths(
-  prev: DockLayout,
-  next: DockLayout,
-  prevWidths: RegionWidths,
-): { widths: RegionWidths; changed: boolean } {
-  const nextRW = { ...prevWidths };
-  let changed = false;
+ *   column set and the pattern alone, so widths carry over untouched. An op
+ *   that deliberately wrote `next.regionWidth` (setRegionWidth) is trusted:
+ *   its value is the carry-over base.
+ * - INVARIANT, enforced on every commit: regionWidth is never below the
+ *   expanded columns' summed minimum (so docking a panel into a region grows
+ *   it instead of squeezing panels below their per-panel minimum). */
+export function reconcileRegionWidths(prev: DockLayout, next: DockLayout): void {
+  // Carry-over base: the op's own value when it set one (clones inherit
+  // prev's, so a differing value is a deliberate write), else prev's.
+  const nextRW = regionWidthsOf(next.regionWidth !== undefined ? next : prev);
+  const prevRW = regionWidthsOf(prev);
 
   (["left", "right"] as DockEdge[]).forEach((edge) => {
     const nextTree = next.docked[edge];
-    if (nextTree === null) return;
+    if (nextTree === null) return; // empty edge: keep the width for restore.
     const prevTree = prev.docked[edge];
     // Use the WIDTH-determining horizontal columns, not the literal top-level
     // columns. They differ when the root is a column (stacked) split -- e.g.
@@ -101,19 +110,19 @@ export function reconcileRegionWidths(
         prevPlan === null ||
         prevPlan.isStrip.length !== nextPlan.isStrip.length ||
         prevPlan.isStrip.some((s, i) => s !== nextPlan.isStrip[i]);
-      if (!patternChanged || nextPlan.singleColumn) return;
-      const expanded = nextPlan.expandedColumns;
-      if (expanded.length === 0) return; // fully minimized: keep for restore.
-      const sum = expanded.reduce((s, c) => s + c.weight, 0);
-      const clamped = clamp(
-        sum,
-        colsMin(expanded),
-        Math.max(MIN_PANEL_WIDTH_PX, colsMax(expanded)),
-      );
-      if (clamped !== nextRW[edge]) {
-        nextRW[edge] = clamped;
-        changed = true;
+      if (patternChanged && !nextPlan.singleColumn) {
+        const expanded = nextPlan.expandedColumns;
+        if (expanded.length > 0) {
+          // Fully minimized would keep the width for restore; otherwise:
+          const sum = expanded.reduce((s, c) => s + c.weight, 0);
+          nextRW[edge] = clamp(
+            sum,
+            colsMin(expanded),
+            Math.max(MIN_PANEL_WIDTH_PX, colsMax(expanded)),
+          );
+        }
       }
+      applyMinFloor(nextRW, edge, nextPlan);
       return;
     }
 
@@ -128,11 +137,11 @@ export function reconcileRegionWidths(
     const prevInfo = prevCols.map((c) => ({
       groups: new Set(collectLeafGroups(c)),
       // Weights ARE pixels once a region has multiple columns (this function
-      // wrote them); a single expanded column's px lives in the regionWidth
-      // state instead (its weight may be a height -- see below).
+      // wrote them); a single expanded column's px lives in regionWidth
+      // instead (its weight may be a height -- see below).
       px:
         prevExpanded.length === 1 && prevExpanded[0] === c
-          ? prevWidths[edge]
+          ? prevRW[edge]
           : c.weight,
       used: false,
     }));
@@ -149,7 +158,15 @@ export function reconcileRegionWidths(
         // pixel width isn't automatically still legal for it.
         return clamp(match.px, minRegionWidth(c), maxRegionWidth(c));
       }
-      // New column: a sensible default, clamped to its panels' min/max.
+      // New column, previously EMPTY edge: the edge's preserved regionWidth
+      // IS this content's width -- e.g. a layout snapshot being restored
+      // (Escape after an undock), where the carried width must round-trip
+      // exactly rather than reset to the default.
+      if (prevCols.length === 0 && nextCols.length === 1) {
+        return clamp(nextRW[edge], minRegionWidth(c), maxRegionWidth(c));
+      }
+      // New column joining existing content: a sensible default, clamped to
+      // its panels' min/max.
       return clamp(DEFAULT_REGION_PX, minRegionWidth(c), maxRegionWidth(c));
     });
     // Set the columns' weights to their pixel widths so each renders at
@@ -185,8 +202,23 @@ export function reconcileRegionWidths(
             Math.max(MIN_PANEL_WIDTH_PX, colsMax(expandedCols)),
           )
         : summed;
-    changed = true;
+    applyMinFloor(nextRW, edge, nextPlan);
   });
 
-  return { widths: nextRW, changed };
+  next.regionWidth = nextRW;
+}
+
+/** The on-every-commit invariant: an edge's width is never below its expanded
+ * columns' summed minimum. Subsumes the old auto-grow effect (which watched
+ * for this after the fact) -- with the floor applied here, a too-narrow
+ * region is unrepresentable in committed state. */
+function applyMinFloor(
+  rw: Record<DockEdge, number>,
+  edge: DockEdge,
+  plan: RegionPlan,
+): void {
+  const expanded = plan.expandedColumns;
+  if (expanded.length === 0) return; // fully minimized: width kept for restore.
+  const min = colsMin(expanded);
+  if (rw[edge] < min) rw[edge] = min;
 }

--- a/tests/e2e/dock_helpers.py
+++ b/tests/e2e/dock_helpers.py
@@ -172,13 +172,15 @@ def group_id_for_panel(page: Page, panel_id: str) -> str:
 
 
 def floating_window_for_panel(page: Page, panel_id: str) -> dict | None:
+    """The full FloatingWindow model object holding `panel_id`, or None.
+    (Note: a `height` key is absent for auto-height windows.)"""
     return page.evaluate(
         """(pid) => {
             const l = window.__dockLayout;
             for (const win of l.floating) {
                 for (const gid of win.stack) {
                     if (l.groups[gid]?.panelIds.includes(pid))
-                        return { id: win.id, x: win.x, y: win.y };
+                        return { ...win };
                 }
             }
             return null;

--- a/tests/e2e/test_dock_playground_area.py
+++ b/tests/e2e/test_dock_playground_area.py
@@ -308,3 +308,44 @@ def test_drag_window_over_own_area_no_self_merge(
         )
     finally:
         page.close()
+
+
+# ===========================================================================
+# (e) REGRESSION: dropping a panel as the LEFTMOST tab of a full-bleed nested
+#     area (the docked "Connected" main panel hosts area-main). The area's
+#     hit rect is inset on the left/right/bottom so its frame falls through to
+#     the host's edge zones -- but the tab STRIP spans the full width, so the
+#     leftmost tab's "insert before" zone (flush at the left edge, inside the
+#     inset band) must still be droppable. It used to fall through to the host.
+# ===========================================================================
+def test_drop_as_leftmost_tab_in_fullbleed_area(dock_context, vite_server: int) -> None:
+    page = _open(dock_context, vite_server, 1500, 900)
+    try:
+        # Dock the unmergeable main panel (hosts the full-bleed area-main, which
+        # starts with [props, history]) on the right; a floating panel to drag.
+        set_layout(
+            page,
+            dock_layout(
+                docked_right=columns("monitor"),
+                floating=[window("controls", x=300, y=200)],
+            ),
+        )
+        assert _area_panel_ids(page, "area-main") == ["props", "history"]
+
+        # The leftmost area tab ("props") sits flush at the area's left edge,
+        # inside the left inset band. Drop controls on its LEFT half -> index 0.
+        props = _box(page, '[data-dock-area="area-main"] [data-dock-tab="props"]')
+        if props is None:
+            pytest.skip("area-main props tab not laid out this run")
+        target = (props["x"] + props["w"] * 0.2, props["y"] + props["h"] / 2)
+        _drag(page, _grip(page, "t-controls"), target)
+
+        # Hard assertion (no skip): on the bug, the drop fell through to the
+        # host and controls never reached the area -- which a skip would hide.
+        after = _area_panel_ids(page, "area-main")
+        assert after == ["controls", "props", "history"], (
+            f"controls should be the LEFTMOST tab; area order is {after}"
+        )
+        assert _floating_window_id_for_panel(page, "controls") is None
+    finally:
+        page.close()

--- a/tests/e2e/test_dock_playground_quirks.py
+++ b/tests/e2e/test_dock_playground_quirks.py
@@ -461,3 +461,164 @@ def test_drop_below_strip_restores_region_width(dock_context, vite_server) -> No
     assert all(w >= 200 for w in widths), (
         f"region must restore to a usable width after the drop, got {widths}"
     )
+
+
+# ---------------------------------------------------------------------------
+# 10. Escape after an undock restores the region's NON-DEFAULT width. The
+#     width lives in the layout model (DockLayout.regionWidth), so the
+#     pre-drag snapshot restores it by construction.
+# ---------------------------------------------------------------------------
+def test_escape_after_undock_restores_region_width(dock_context, vite_server) -> None:
+    page = _open(dock_context, vite_server)
+    set_layout(page, dock_layout(docked_right=columns("controls")))
+
+    def leaf_w() -> float:
+        return page.eval_on_selector(
+            '[data-dock-leaf][data-dock-edge="right"]',
+            "e => e.getBoundingClientRect().width",
+        )
+
+    # Widen the region well past the 300px default with the edge resizer.
+    handle = page.eval_on_selector(
+        '[data-dock-region-resize="right"]',
+        "e => { const r = e.getBoundingClientRect(); "
+        "return { x: r.x + r.width/2, y: r.y + r.height/2 }; }",
+    )
+    page.mouse.move(handle["x"], handle["y"])
+    page.mouse.down()
+    page.mouse.move(handle["x"] - 150, handle["y"], steps=10)
+    page.mouse.up()
+    page.wait_for_timeout(120)
+    widened = leaf_w()
+    assert widened > 400, f"setup: resize did not widen the region ({widened})"
+
+    # Drag the group out (commits a float op up front), then Escape.
+    gx, gy = _grip(page, "controls")
+    page.mouse.move(gx, gy)
+    page.mouse.down()
+    page.mouse.move(gx + 6, gy + 6, steps=2)
+    page.mouse.move(600, 400, steps=12)
+    page.wait_for_timeout(120)
+    page.keyboard.press("Escape")
+    page.wait_for_timeout(120)
+    page.mouse.up()
+    page.wait_for_timeout(120)
+
+    assert _layout(page)["docked"]["right"] is not None
+    assert abs(leaf_w() - widened) < 2, (
+        f"Escape must restore the widened region ({widened} -> {leaf_w()})"
+    )
+    page.close()
+
+
+# ---------------------------------------------------------------------------
+# 11. Escape after a drag from the expand (+) button of a MINIMIZED floating
+#     window restores the minimized state (the expand is an up-front commit,
+#     paired with its restore snapshot by dragAfterCommit).
+# ---------------------------------------------------------------------------
+def test_escape_after_expand_on_drag_restores_minimized(
+    dock_context, vite_server
+) -> None:
+    page = _open(dock_context, vite_server)
+    set_layout(
+        page,
+        dock_layout(floating=[window(group("controls", collapsed=True), x=400, y=200)]),
+    )
+    gid = "t-controls"
+    btn = page.eval_on_selector(
+        f'[data-dock-group="{gid}"] [data-dock-minimize]',
+        "e => { const r = e.getBoundingClientRect(); "
+        "return { x: r.x + r.width/2, y: r.y + r.height/2 }; }",
+    )
+    page.mouse.move(btn["x"], btn["y"])
+    page.mouse.down()
+    page.mouse.move(btn["x"] + 6, btn["y"] + 6, steps=2)
+    page.mouse.move(btn["x"] + 80, btn["y"] + 120, steps=10)
+    page.wait_for_timeout(120)  # expand-on-drag has committed by now
+    page.keyboard.press("Escape")
+    page.wait_for_timeout(120)
+    page.mouse.up()
+    page.wait_for_timeout(120)
+    assert page.evaluate(
+        "(gid) => window.__dockLayout.groups[gid].collapsed === true", gid
+    ), "Escape must restore the pre-drag minimized state"
+    page.close()
+
+
+# ---------------------------------------------------------------------------
+# 12. A container resize between PRESS and the drag threshold must not
+#     teleport the window: grab offsets resolve against the window's CURRENT
+#     model position at drag start.
+# ---------------------------------------------------------------------------
+def test_no_teleport_when_viewport_resizes_mid_press(dock_context, vite_server) -> None:
+    page = _open(dock_context, vite_server)
+    set_layout(page, dock_layout(floating=[window("controls", x=700, y=200)]))
+    gx, gy = _grip(page, "controls")
+    page.mouse.move(gx, gy)
+    page.mouse.down()
+    # Mid-press (still under the 3px threshold) the browser narrows; the
+    # ResizeObserver anchors the window left to x=420.
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.wait_for_timeout(150)
+    moved = _floating_window_for_panel(page, "controls")
+    assert moved is not None and moved["x"] < 500, "setup: anchor did not move it"
+    anchored_x = moved["x"]
+    # Now drag: cursor moves left 100px; the window must track RELATIVE to
+    # its anchored position, not jump back to press-time coordinates.
+    page.mouse.move(gx - 50, gy + 25, steps=6)
+    page.mouse.move(gx - 100, gy + 50, steps=6)
+    page.mouse.up()
+    page.wait_for_timeout(120)
+    win = _floating_window_for_panel(page, "controls")
+    assert win is not None
+    assert abs(win["x"] - (anchored_x - 100)) < 30, (
+        f"window teleported on drag start: expected ~{anchored_x - 100}, got {win['x']}"
+    )
+    page.close()
+
+
+# ---------------------------------------------------------------------------
+# 13. A container resize DURING a drag leaves the dragged window glued to the
+#     cursor (the observer skips the dragged window; the cursor is its source
+#     of truth), and the drop commits the cursor-aligned position.
+# ---------------------------------------------------------------------------
+def test_dragged_window_stays_on_cursor_through_resize(
+    dock_context, vite_server
+) -> None:
+    page = _open(dock_context, vite_server)
+    set_layout(page, dock_layout(floating=[window("controls", x=700, y=200)]))
+    win0 = _floating_window_for_panel(page, "controls")
+    assert win0 is not None
+    gx, gy = _grip(page, "controls")
+    grab_x = gx - win0["x"]  # pointer offset into the window
+
+    page.mouse.move(gx, gy)
+    page.mouse.down()
+    page.mouse.move(gx + 6, gy + 6, steps=2)
+    page.mouse.move(500, 300, steps=10)
+    # Shrink the viewport MID-DRAG: must not move the dragged window's model
+    # position out from under the cursor.
+    page.set_viewport_size({"width": 1100, "height": 700})
+    page.wait_for_timeout(150)
+    page.mouse.move(420, 320, steps=6)
+    page.wait_for_timeout(60)
+    # The RENDERED window must still be glued to the cursor while the button
+    # is held (the old observer write detached it by the resize delta, then
+    # visibly snapped it at release).
+    rendered = page.eval_on_selector(
+        "[data-floating-window]", "e => e.getBoundingClientRect().x"
+    )
+    expected = 420 - grab_x
+    assert abs(rendered - expected) < 30, (
+        f"window detached from the cursor mid-drag: rendered x={rendered}, "
+        f"expected ~{expected}"
+    )
+    page.mouse.up()
+    page.wait_for_timeout(120)
+
+    win = _floating_window_for_panel(page, "controls")
+    assert win is not None
+    assert abs(win["x"] - expected) < 30, (
+        f"drop should commit the cursor-aligned x (~{expected}), got {win['x']}"
+    )
+    page.close()

--- a/tests/e2e/test_dock_playground_state.py
+++ b/tests/e2e/test_dock_playground_state.py
@@ -30,6 +30,7 @@ from .dock_helpers import (
     columns,
     dock_layout,
     floating_group_ids,
+    floating_window_for_panel,
     group,
     open_playground,
     real_errors,
@@ -257,6 +258,50 @@ def test_container_resize_keeps_floating_corners_onscreen(page: Page) -> None:
     assert stranded == [], (
         f"floating window(s) stranded off-screen after resize: {stranded}"
     )
+
+
+def test_drag_does_not_resize_pinned_height_window(page: Page) -> None:
+    """Moving a floating window must never change its size: a pinned-height
+    window dragged toward the bottom keeps its full height and overhangs the
+    bottom edge (like auto-height windows do), instead of being squashed to
+    fit above its new y. Regression: the rendered-height cap depended on
+    win.y, so a resize-then-drag visibly shrank the window at drop."""
+    set_layout(
+        page,
+        dock_layout(
+            floating=[window("inspector", x=300, y=160, width=280, height=360)]
+        ),
+    )
+    before = _box(page, "[data-floating-window]")
+    assert before is not None and abs(before["height"] - 360) < 3
+
+    # Drag low enough that y + height overflows the 800px-tall container.
+    _drag_group(page, "t-inspector", (440, 640))
+    win = floating_window_for_panel(page, "inspector")
+    after = _box(page, "[data-floating-window]")
+    assert win is not None and after is not None
+    assert win["y"] > 500, "drag should have moved the window down"
+    assert win["height"] == 360, "model height must be untouched by a move"
+    assert abs(after["height"] - before["height"]) < 2, (
+        f"drag visually resized the window: {before['height']} -> {after['height']}"
+    )
+
+
+def test_width_only_viewport_resize_keeps_bottom_window_y(page: Page) -> None:
+    """Narrowing the browser WITHOUT changing its height must not move a
+    bottom-overhanging floating window vertically. Regression: the on-screen
+    pull ran on both axes whenever either container dimension changed, yanking
+    deliberately bottom-placed windows upward on a width-only resize."""
+    set_layout(
+        page,
+        dock_layout(floating=[window("controls", x=900, y=620, width=280, height=300)]),
+    )
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.wait_for_timeout(150)  # let ResizeObserver fire + React commit
+    win = floating_window_for_panel(page, "controls")
+    assert win is not None
+    assert win["height"] == 300
+    assert win["y"] == 620, f"width-only resize moved the window up: y={win['y']}"
 
 
 # ===========================================================================
@@ -521,3 +566,72 @@ def test_overlaid_region_divider_tracks_without_jump(page: Page) -> None:
     )
     # The minimized column is still overlaid (not lost).
     assert _is_collapsed(page, inner)
+
+
+def test_width_only_shrink_keeps_collapsed_strip_in_place(page: Page) -> None:
+    """Anchoring/pulling must use the RENDERED height. A collapsed
+    pinned-height window is a ~50px strip on screen; a height shrink that
+    leaves the strip comfortably on-screen must keep its distance to the
+    bottom edge, not yank it up by the hidden content's height."""
+    set_layout(
+        page,
+        dock_layout(
+            floating=[
+                window(
+                    group("controls", collapsed=True),
+                    x=600,
+                    y=700,
+                    width=280,
+                    height=380,
+                )
+            ]
+        ),
+    )
+    page.set_viewport_size({"width": 1280, "height": 750})
+    page.wait_for_timeout(150)
+    win = floating_window_for_panel(page, "controls")
+    assert win is not None
+    # Bottom-half anchor: distance to the bottom edge is preserved (was 100px
+    # in an 800px container -> y=650 in a 750px one). The old model-height
+    # pull would have yanked it to 750 - 380 = 370.
+    assert abs(win["y"] - 650) < 10, f"strip moved wrongly: y={win['y']}"
+
+
+def test_flip_expand_of_pinned_height_window_keeps_height(
+    browser, vite_server: int
+) -> None:
+    """Expanding a pinned-height floating window WITH ANIMATIONS ENABLED must
+    end at the pinned height. Regression: the FLIP animation cleared the
+    inline height on completion, but React's style cache still held it, so
+    the window rendered at 0px and vanished. (The shared dock_context forces
+    reduced motion, which skips the FLIP -- so this test makes its own
+    context.)"""
+    ctx = browser.new_context()  # animations ON: no reduced_motion here.
+    try:
+        pg = open_playground(ctx, vite_server)
+        set_layout(
+            pg,
+            dock_layout(
+                floating=[
+                    window(
+                        group("controls", collapsed=True),
+                        x=300,
+                        y=150,
+                        width=280,
+                        height=360,
+                    )
+                ]
+            ),
+        )
+        pg.eval_on_selector(
+            '[data-dock-group="t-controls"] [data-dock-minimize]',
+            "e => e.click()",
+        )
+        pg.wait_for_timeout(600)  # let the 180ms FLIP finish (or break)
+        box = pg.locator("[data-floating-window]").first.bounding_box()
+        assert box is not None
+        assert abs(box["height"] - 360) < 5, (
+            f"window should settle at its pinned 360px, got {box['height']}"
+        )
+    finally:
+        ctx.close()


### PR DESCRIPTION
Fixes some minor issues:
- Floating panels were resizing after being moved.
- Panels could not be dropped as the leftmost tab in the main panel.