### PR TITLE
Fix GPU buffer leaks, add resize-safe geometry sync

### DIFF
--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -12,6 +12,7 @@ import {
 import { BatchedMeshHoverOutlines } from "./mesh/BatchedMeshHoverOutlines";
 import { MeshBasicMaterial } from "three";
 import { normalizeScale } from "./utils/normalizeScale";
+import { syncPointCloudGeometry } from "./utils/pointCloudGeometry";
 // @ts-ignore - troika-three-text doesn't have type definitions
 import { Text as TroikaText } from "troika-three-text";
 import { BatchedLabelManagerContext } from "./BatchedLabelManagerContext";
@@ -108,28 +109,11 @@ export const PointCloud = React.forwardRef<
   React.useLayoutEffect(() => {
     const geom = geomRef.current;
     if (!geom) return;
-
-    if (props.points instanceof Float32Array) {
-      geom.setAttribute(
-        "position",
-        new THREE.Float32BufferAttribute(props.points, 3),
-      );
-    } else {
-      geom.setAttribute(
-        "position",
-        new THREE.Float16BufferAttribute(props.points, 3),
-      );
-    }
-
-    // Add color attribute if needed. Colors arrive as Uint8Array.
-    if (props.colors.length > 3) {
-      geom.setAttribute(
-        "color",
-        new THREE.BufferAttribute(props.colors, 3, true),
-      );
-    } else if (props.colors.length < 3) {
-      console.error(`Invalid color buffer length, got ${props.colors.length}`);
-    }
+    // Reuse the existing GPU buffers in place across updates. Replacing
+    // attributes with `setAttribute(new ...)` every update leaks the old buffer;
+    // a same-size swap reuses it; a point-count change reallocates safely. See
+    // syncPointCloudGeometry / syncBufferGeometry.
+    syncPointCloudGeometry(geom, props.points, props.colors);
   }, [props.points, props.colors]);
 
   // Material needs heavy per-frame uniform updates, so kept imperative.
@@ -427,6 +411,13 @@ export const InstancedAxes = React.forwardRef<
   const outlineCylinderGeom = React.useMemo(
     () => new THREE.CylinderGeometry(axes_radius, axes_radius, axes_length, 16),
     [axes_radius, axes_length],
+  );
+  // Dispose the outline geometry when it's replaced (axis dimensions change) or
+  // on unmount. It's consumed by BatchedMeshHoverOutlines, which clones it, so
+  // this original is ours to free.
+  React.useEffect(
+    () => () => outlineCylinderGeom.dispose(),
+    [outlineCylinderGeom],
   );
 
   // Compute transform matrices for each axis (x, y, z).

--- a/src/viser/client/src/mesh/SingleGlbAsset.tsx
+++ b/src/viser/client/src/mesh/SingleGlbAsset.tsx
@@ -62,6 +62,10 @@ export const SingleGlbAsset = React.forwardRef<
     material.toneMapped = true;
     return material;
   }, [contextSize]);
+  // R3F does not auto-dispose materials passed in via the `material` prop (only
+  // ones it instantiates from JSX), so free it explicitly when it's replaced
+  // (contextSize change) or on unmount -- matching BatchedMeshHoverOutlines.
+  React.useEffect(() => () => outlineMaterial.dispose(), [outlineMaterial]);
   const outlineRef = React.useRef<THREE.Group>(null);
   const hoverContext = React.useContext(HoverableContext)!;
   useFrame(() => {

--- a/src/viser/client/src/utils/bufferGeometrySync.test.ts
+++ b/src/viser/client/src/utils/bufferGeometrySync.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi } from "vitest";
+import * as THREE from "three";
+import { syncBufferGeometry } from "./bufferGeometrySync";
+
+/**
+ * A faithful, GL-context-free model of three.js's WebGLAttributes update path
+ * (renderers/webgl/WebGLAttributes.js) plus the geometry-dispose cleanup
+ * (WebGLGeometries.onGeometryDispose). vitest runs in Node with no WebGL2
+ * context, so a real renderer can't exercise the resize guard -- this model
+ * reproduces exactly the branch that throws, and the dispose path that avoids
+ * it, keyed off the same attribute objects our sync code mutates.
+ */
+function makeFakeRenderer(geometry: THREE.BufferGeometry) {
+  // Mirrors WebGLAttributes' `buffers` WeakMap (a plain Map here so the test can
+  // observe it). Value tracks the GL buffer's allocated byte size and version.
+  const uploaded = new Map<object, { size: number; version: number }>();
+  let deleteBufferCalls = 0;
+
+  // three frees an attribute's GL buffer only via the geometry 'dispose' event.
+  geometry.addEventListener("dispose", () => {
+    const drop = (attr: { array: { byteLength: number } } | null) => {
+      if (attr && uploaded.has(attr)) {
+        uploaded.delete(attr);
+        deleteBufferCalls++;
+      }
+    };
+    drop(geometry.getIndex());
+    for (const name in geometry.attributes) drop(geometry.attributes[name]);
+  });
+
+  // Mirrors WebGLAttributes.update(): create on first sight, else re-upload --
+  // and throw if a live buffer's size changed (the bug we're guarding against).
+  function uploadAttribute(attr: THREE.BufferAttribute) {
+    const cached = uploaded.get(attr);
+    if (cached === undefined) {
+      uploaded.set(attr, {
+        size: attr.array.byteLength,
+        version: attr.version,
+      });
+      return;
+    }
+    if (cached.version < attr.version) {
+      if (cached.size !== attr.array.byteLength) {
+        throw new Error(
+          "THREE.WebGLAttributes: The size of the buffer attribute's array " +
+            "buffer does not match the original size. Resizing buffer " +
+            "attributes is not supported.",
+        );
+      }
+      cached.version = attr.version;
+    }
+  }
+
+  return {
+    /** Simulate a render: upload index + every attribute. */
+    render() {
+      const index = geometry.getIndex();
+      if (index) uploadAttribute(index);
+      for (const name in geometry.attributes) {
+        uploadAttribute(geometry.attributes[name] as THREE.BufferAttribute);
+      }
+    },
+    liveBufferCount: () => uploaded.size,
+    deleteBufferCalls: () => deleteBufferCalls,
+  };
+}
+
+describe("syncBufferGeometry", () => {
+  it("reuses attribute objects in place when the layout is unchanged", () => {
+    const geom = new THREE.BufferGeometry();
+    const realloc1 = syncBufferGeometry(geom, {
+      position: { array: new Float32Array([0, 0, 0, 1, 1, 1]), itemSize: 3 },
+    });
+    expect(realloc1).toBe(true); // first call always allocates
+    const pos1 = geom.getAttribute("position") as THREE.BufferAttribute;
+    const version = pos1.version;
+
+    const newPoints = new Float32Array([2, 2, 2, 3, 3, 3]);
+    const realloc2 = syncBufferGeometry(geom, {
+      position: { array: newPoints, itemSize: 3 },
+    });
+    expect(realloc2).toBe(false); // same layout -> reuse
+    expect(geom.getAttribute("position")).toBe(pos1); // same object -> same GL buffer
+    expect(geom.getAttribute("position").array).toBe(newPoints); // data swapped in
+    expect(pos1.version).toBeGreaterThan(version); // re-upload requested
+  });
+
+  it("disposes once on a length change so the old GL buffers are freed", () => {
+    const geom = new THREE.BufferGeometry();
+    syncBufferGeometry(geom, {
+      position: { array: new Float32Array(6), itemSize: 3 },
+    });
+    const disposeSpy = vi.spyOn(geom, "dispose");
+
+    const realloc = syncBufferGeometry(geom, {
+      position: { array: new Float32Array(9), itemSize: 3 },
+    });
+    expect(realloc).toBe(true);
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+    expect(geom.getAttribute("position").count).toBe(3);
+  });
+
+  it("reallocates on a precision change (float32 <-> float16)", () => {
+    const geom = new THREE.BufferGeometry();
+    syncBufferGeometry(geom, {
+      position: { array: new Float32Array(6), itemSize: 3 },
+    });
+    const pos1 = geom.getAttribute("position");
+
+    syncBufferGeometry(geom, {
+      position: { array: new Uint16Array(6), itemSize: 3, float16: true },
+    });
+    const pos2 = geom.getAttribute("position");
+    expect(pos2).not.toBe(pos1);
+    expect(
+      (pos2 as unknown as { isFloat16BufferAttribute?: boolean })
+        .isFloat16BufferAttribute,
+    ).toBe(true);
+  });
+
+  it("syncs an index buffer alongside attributes", () => {
+    const geom = new THREE.BufferGeometry();
+    syncBufferGeometry(
+      geom,
+      { position: { array: new Float32Array(9), itemSize: 3 } },
+      new Uint32Array([0, 1, 2]),
+    );
+    expect(geom.getIndex()!.count).toBe(3);
+
+    // Same-length index -> reuse.
+    const idx1 = geom.getIndex();
+    const realloc = syncBufferGeometry(
+      geom,
+      { position: { array: new Float32Array(9), itemSize: 3 } },
+      new Uint32Array([2, 1, 0]),
+    );
+    expect(realloc).toBe(false);
+    expect(geom.getIndex()).toBe(idx1);
+  });
+
+  // The core regression: against a faithful model of three's WebGLAttributes,
+  // resizing must NOT throw, and old buffers must be freed (not leaked).
+  describe("matches three.js WebGLAttributes semantics", () => {
+    it("does not throw when the point count changes", () => {
+      const geom = new THREE.BufferGeometry();
+      const gpu = makeFakeRenderer(geom);
+
+      syncBufferGeometry(geom, {
+        position: { array: new Float32Array(6), itemSize: 3 },
+        color: { array: new Uint8Array(6), itemSize: 3, normalized: true },
+      });
+      gpu.render();
+      expect(gpu.liveBufferCount()).toBe(2);
+
+      // Grow the cloud: this is the exact scenario that used to throw.
+      syncBufferGeometry(geom, {
+        position: { array: new Float32Array(9), itemSize: 3 },
+        color: { array: new Uint8Array(9), itemSize: 3, normalized: true },
+      });
+      expect(() => gpu.render()).not.toThrow();
+      expect(gpu.deleteBufferCalls()).toBe(2); // old buffers freed, not leaked
+      expect(gpu.liveBufferCount()).toBe(2); // recreated at new size
+    });
+
+    it("reuses buffers (no dispose, no new buffers) on same-size updates", () => {
+      const geom = new THREE.BufferGeometry();
+      const gpu = makeFakeRenderer(geom);
+      syncBufferGeometry(geom, {
+        position: { array: new Float32Array(6), itemSize: 3 },
+      });
+      gpu.render();
+
+      for (let i = 0; i < 100; i++) {
+        syncBufferGeometry(geom, {
+          position: { array: new Float32Array(6), itemSize: 3 },
+        });
+        gpu.render();
+      }
+      expect(gpu.deleteBufferCalls()).toBe(0); // never disposed
+      expect(gpu.liveBufferCount()).toBe(1); // same single buffer throughout
+    });
+
+    // Negative control: prove the model actually catches the bug. The old
+    // in-place-without-dispose approach DOES throw under the same model.
+    it("(control) naive resize without dispose throws under the model", () => {
+      const geom = new THREE.BufferGeometry();
+      const gpu = makeFakeRenderer(geom);
+      const attr = new THREE.BufferAttribute(new Float32Array(6), 3);
+      geom.setAttribute("position", attr);
+      gpu.render();
+
+      // Mutate in place to a different length WITHOUT disposing -- the bug.
+      attr.array = new Float32Array(9);
+      (attr as { count: number }).count = 3;
+      attr.needsUpdate = true;
+      expect(() => gpu.render()).toThrow(/Resizing buffer attributes/);
+    });
+  });
+});

--- a/src/viser/client/src/utils/bufferGeometrySync.ts
+++ b/src/viser/client/src/utils/bufferGeometrySync.ts
@@ -1,0 +1,166 @@
+import * as THREE from "three";
+
+/**
+ * Declarative, in-place sync of a persistent THREE.BufferGeometry.
+ *
+ * Reusing GPU buffers across data updates matters because three.js tracks each
+ * attribute's GL buffer in a WeakMap keyed by the attribute object. Two failure
+ * modes bite naive update code:
+ *
+ *   1. `setAttribute(name, new BufferAttribute(...))` on every update orphans
+ *      the old attribute's GL buffer -- three never calls `gl.deleteBuffer` on a
+ *      replaced attribute, so it leaks until (and only if) the JS GC reclaims
+ *      the wrapper. For a streaming source that's megabytes of GPU memory leaked
+ *      per update and eventual WebGL context loss.
+ *
+ *   2. Swapping `attribute.array` to a DIFFERENT-length array and bumping
+ *      `needsUpdate` makes three throw on the next render: "THREE.WebGLAttributes:
+ *      The size of the buffer attribute's array buffer does not match the
+ *      original size. Resizing buffer attributes is not supported." (Resizing a
+ *      live GL buffer in place is genuinely unsupported.)
+ *
+ * `syncBufferGeometry` threads the needle:
+ *
+ *   - Fast path (layout unchanged -- same typed-array kind, length, itemSize,
+ *     float16-ness): swap the backing array and bump `needsUpdate`. three
+ *     re-uploads via `bufferSubData` into the SAME GL buffer. No allocation, no
+ *     leak, no throw.
+ *
+ *   - Realloc path (first call, length change, or precision change): call
+ *     `geometry.dispose()` once. That deletes every attribute's GL buffer AND
+ *     unregisters the attributes (see three's WebGLGeometries.onGeometryDispose
+ *     -> WebGLAttributes.remove), so the next render allocates fresh buffers at
+ *     the new size. The whole-geometry dispose is deliberate: the only leak-free
+ *     way to free a single attribute's GL buffer is to dispose the geometry that
+ *     owns it. We then attach fresh attributes for everything we were given.
+ *
+ * The fast path is the zero-cost case we optimize for -- a same-size streaming
+ * update touches no GPU allocator and no JS heap beyond a `needsUpdate` flag.
+ */
+
+export type SyncTypedArray =
+  | Float32Array
+  | Float64Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Uint16Array
+  | Uint32Array
+  | Int8Array
+  | Int16Array
+  | Int32Array;
+
+export interface AttributeSpec {
+  /**
+   * Backing data. For float16, pass a Uint16Array of packed half-float bits and
+   * set `float16: true`.
+   */
+  array: SyncTypedArray;
+  itemSize: number;
+  normalized?: boolean;
+  /** Treat a Uint16Array as packed half-floats (THREE.Float16BufferAttribute). */
+  float16?: boolean;
+}
+
+/**
+ * Can `existing` be reused in place for `spec`, or does its GL buffer have to be
+ * reallocated? Reusable only when nothing about the buffer's GPU layout changes.
+ */
+function layoutMatches(
+  existing: THREE.BufferAttribute,
+  spec: AttributeSpec,
+): boolean {
+  const existingIsF16 =
+    (existing as { isFloat16BufferAttribute?: boolean })
+      .isFloat16BufferAttribute ?? false;
+  return (
+    existing.array.constructor === spec.array.constructor &&
+    existing.array.length === spec.array.length &&
+    existing.itemSize === spec.itemSize &&
+    existingIsF16 === (spec.float16 ?? false)
+  );
+}
+
+function makeAttribute(spec: AttributeSpec): THREE.BufferAttribute {
+  if (spec.float16) {
+    // Note: Float16BufferAttribute copies into a fresh Uint16Array internally.
+    return new THREE.Float16BufferAttribute(
+      spec.array as Uint16Array,
+      spec.itemSize,
+      spec.normalized,
+    );
+  }
+  return new THREE.BufferAttribute(spec.array, spec.itemSize, spec.normalized);
+}
+
+/**
+ * Sync a persistent BufferGeometry's attributes (and optional index) to new
+ * data, reusing GL buffers in place when the layout is unchanged. See the file
+ * header for the full rationale.
+ *
+ * Returns true if a reallocation occurred. Callers that rely on frustum culling
+ * or raycasting should recompute bounding volumes / vertex normals when this
+ * returns true (or whenever data moves) -- in-place updates leave the cached
+ * boundingSphere/boundingBox stale.
+ */
+export function syncBufferGeometry(
+  geometry: THREE.BufferGeometry,
+  attributes: Record<string, AttributeSpec>,
+  index?: SyncTypedArray,
+): boolean {
+  const names = Object.keys(attributes);
+
+  // Phase 1: decide whether anything needs reallocation. This is geometry-wide
+  // because freeing a single attribute's GL buffer leak-free requires disposing
+  // the geometry that owns it -- which frees all of them at once.
+  let needsRealloc = false;
+  for (const name of names) {
+    const existing = geometry.getAttribute(name) as
+      | THREE.BufferAttribute
+      | undefined;
+    if (existing === undefined || !layoutMatches(existing, attributes[name])) {
+      needsRealloc = true;
+      break;
+    }
+  }
+  if (!needsRealloc && index !== undefined) {
+    const existingIndex = geometry.getIndex();
+    if (
+      existingIndex === null ||
+      existingIndex.array.constructor !== index.constructor ||
+      existingIndex.array.length !== index.length
+    ) {
+      needsRealloc = true;
+    }
+  }
+
+  if (needsRealloc) {
+    // Free every existing GL buffer (a no-op before the first render) and
+    // unregister the attributes, so the next render allocates fresh buffers at
+    // the new size. Avoids both the resize throw and the orphaned-buffer leak.
+    geometry.dispose();
+    for (const name of names) {
+      geometry.setAttribute(name, makeAttribute(attributes[name]));
+    }
+    if (index !== undefined) {
+      geometry.setIndex(new THREE.BufferAttribute(index, 1));
+    }
+  } else {
+    // Fast path: same layout, so reuse the existing GL buffers. Swapping the
+    // array reference is zero-copy; `needsUpdate` bumps the version so three
+    // re-uploads via bufferSubData. Length is unchanged here, so `count` (a
+    // plain field set at construction) stays correct.
+    for (const name of names) {
+      const spec = attributes[name];
+      const attr = geometry.getAttribute(name) as THREE.BufferAttribute;
+      attr.array = spec.array;
+      attr.normalized = spec.normalized ?? false;
+      attr.needsUpdate = true;
+    }
+    if (index !== undefined) {
+      const attr = geometry.getIndex()!;
+      attr.array = index;
+      attr.needsUpdate = true;
+    }
+  }
+  return needsRealloc;
+}

--- a/src/viser/client/src/utils/pointCloudGeometry.test.ts
+++ b/src/viser/client/src/utils/pointCloudGeometry.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import * as THREE from "three";
+import { syncPointCloudGeometry } from "./pointCloudGeometry";
+
+// Reusing the same BufferAttribute object across updates is what keeps the
+// underlying WebGL buffer alive and reused. Allocating a fresh
+// BufferAttribute on every update (the old behavior) orphans the previous GPU
+// buffer -- three.js tracks buffers in a WeakMap keyed by the attribute and
+// never calls gl.deleteBuffer on a replaced attribute, so it leaks until
+// (maybe) GC. Asserting object identity is a GL-context-free proxy for "no new
+// GPU buffer was allocated".
+describe("syncPointCloudGeometry", () => {
+  it("reuses the position/color BufferAttributes across same-precision updates", () => {
+    const geom = new THREE.BufferGeometry();
+    syncPointCloudGeometry(
+      geom,
+      new Float32Array([0, 0, 0, 1, 1, 1]),
+      new Uint8Array([255, 0, 0, 0, 255, 0]),
+    );
+    const pos1 = geom.getAttribute("position") as THREE.BufferAttribute;
+    const col1 = geom.getAttribute("color");
+    const posVersion = pos1.version;
+
+    const newPoints = new Float32Array([2, 2, 2, 3, 3, 3]);
+    syncPointCloudGeometry(geom, newPoints, new Uint8Array([0, 0, 255, 255, 255, 0]));
+
+    expect(geom.getAttribute("position")).toBe(pos1); // same object -> same GPU buffer
+    expect(geom.getAttribute("color")).toBe(col1);
+    expect(geom.getAttribute("position").array).toBe(newPoints); // data swapped in
+    // needsUpdate is a write-only setter that bumps version; check the version
+    // advanced so three re-uploads the buffer.
+    expect(pos1.version).toBeGreaterThan(posVersion);
+  });
+
+  it("updates the attribute count when the point count changes", () => {
+    const geom = new THREE.BufferGeometry();
+    syncPointCloudGeometry(geom, new Float32Array(6), new Uint8Array(6));
+    syncPointCloudGeometry(geom, new Float32Array(9), new Uint8Array(9));
+    expect(geom.getAttribute("position").count).toBe(3);
+    expect(geom.getAttribute("color").count).toBe(3);
+  });
+
+  it("allocates a new attribute only when precision changes (float32 <-> float16)", () => {
+    const geom = new THREE.BufferGeometry();
+    syncPointCloudGeometry(geom, new Float32Array(6), new Uint8Array(6));
+    const pos1 = geom.getAttribute("position");
+    syncPointCloudGeometry(geom, new Uint16Array(6), new Uint8Array(6)); // float16
+    expect(geom.getAttribute("position")).not.toBe(pos1);
+  });
+});

--- a/src/viser/client/src/utils/pointCloudGeometry.ts
+++ b/src/viser/client/src/utils/pointCloudGeometry.ts
@@ -1,0 +1,29 @@
+import * as THREE from "three";
+import { AttributeSpec, syncBufferGeometry } from "./bufferGeometrySync";
+
+/**
+ * Update a point cloud's position/color attributes on an existing, persistent
+ * BufferGeometry, reusing GPU buffers in place whenever the layout is unchanged.
+ *
+ * This is a thin wrapper over `syncBufferGeometry`; see that file for why buffer
+ * reuse matters and how length/precision changes are handled leak-free and
+ * without the three.js "Resizing buffer attributes is not supported" throw.
+ */
+export function syncPointCloudGeometry(
+  geometry: THREE.BufferGeometry,
+  points: Float32Array | Uint16Array, // Uint16Array carries float16 data.
+  colors: Uint8Array,
+): void {
+  const pointsIsF32 = points instanceof Float32Array;
+  const attributes: Record<string, AttributeSpec> = {
+    position: { array: points, itemSize: 3, float16: !pointsIsF32 },
+  };
+
+  if (colors.length > 3) {
+    attributes.color = { array: colors, itemSize: 3, normalized: true };
+  } else if (colors.length < 3) {
+    console.error(`Invalid color buffer length, got ${colors.length}`);
+  }
+
+  syncBufferGeometry(geometry, attributes);
+}

--- a/src/viser/client/src/vendor/instanced-mesh/LOCAL_PATCHES.md
+++ b/src/viser/client/src/vendor/instanced-mesh/LOCAL_PATCHES.md
@@ -1,0 +1,33 @@
+# Local patches to the vendored `instanced-mesh` library
+
+This directory is a vendored copy of the `@three.ez/instanced-mesh` library
+(MIT, Copyright (c) 2024 Andrea Gargaro -- see `LICENSE`). It was vendored into
+Viser in commit `49b2a7f9` ("Reversed depth buffer, material update fixes",
+#674).
+
+Because it is vendored rather than an npm dependency, any local changes will be
+silently lost if these files are re-synced from upstream. **When re-vendoring,
+re-apply the patches below.** Each patch site is also marked inline with a
+`=== VISER LOCAL PATCH ===` / `=== END VISER LOCAL PATCH ===` comment block, so
+
+```
+grep -rn "VISER LOCAL PATCH" src/viser/client/src/vendor/instanced-mesh
+```
+
+lists every divergence from upstream.
+
+## Patches
+
+### 1. Free the raw `instanceIndex` GL buffer on dispose
+
+- **Files:** `core/utils/GLInstancedBufferAttribute.ts`, `core/InstancedMesh2.ts`
+- **What:** `GLInstancedBufferAttribute` gains a `dispose(gl)` method that calls
+  `gl.deleteBuffer(this.buffer)`; `InstancedMesh2.dispose()` calls it for the
+  mesh's `instanceIndex` and every LOD object's `instanceIndex`.
+- **Why:** the `instanceIndex` buffer is created directly via `gl.createBuffer()`
+  and is never tracked by three.js's `WebGLAttributes`, so three never frees it.
+  Without this, every InstancedMesh2 recreation leaks that GL buffer until WebGL
+  context loss. Covered by `core/InstancedMesh2.dispose.test.ts`.
+- **Re-apply check:** confirm upstream still creates `instanceIndex` as a raw
+  `GLInstancedBufferAttribute` (untracked by three). If upstream adds its own
+  disposal for it, this patch may become redundant -- verify before dropping.

--- a/src/viser/client/src/vendor/instanced-mesh/core/InstancedMesh2.dispose.test.ts
+++ b/src/viser/client/src/vendor/instanced-mesh/core/InstancedMesh2.dispose.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import * as THREE from "three";
+import { InstancedMesh2 } from "./InstancedMesh2.js";
+
+// Minimal WebGL2 mock that only implements the buffer calls
+// GLInstancedBufferAttribute touches, plus counters so we can assert that the
+// raw `instanceIndex` GL buffer is freed deterministically (i.e. the code does
+// NOT rely on the JS garbage collector to reclaim GPU memory).
+function makeMockGl() {
+  let created = 0;
+  let deleted = 0;
+  const live = new Set<object>();
+  const gl = {
+    ARRAY_BUFFER: 0x8892,
+    DYNAMIC_DRAW: 0x88e8,
+    UNSIGNED_INT: 0x1405,
+    createBuffer() {
+      created++;
+      const buffer = { id: created };
+      live.add(buffer);
+      return buffer;
+    },
+    bindBuffer() {},
+    bufferData() {},
+    deleteBuffer(buffer: object) {
+      deleted++;
+      live.delete(buffer);
+    },
+  };
+  return { gl, stats: () => ({ created, deleted, live: live.size }) };
+}
+
+describe("InstancedMesh2 GPU buffer disposal", () => {
+  it("frees the instanceIndex GL buffer on dispose (no reliance on GC)", () => {
+    const { gl, stats } = makeMockGl();
+    const renderer = { getContext: () => gl } as unknown as THREE.WebGLRenderer;
+
+    const mesh = new InstancedMesh2(
+      new THREE.BoxGeometry(),
+      new THREE.MeshBasicMaterial(),
+      { capacity: 128, renderer },
+    );
+
+    // Construction allocates exactly one raw GL buffer (instanceIndex).
+    expect(stats().created).toBe(1);
+    expect(stats().live).toBe(1);
+
+    mesh.dispose();
+
+    // dispose() must explicitly delete that buffer -- three.js never tracks it,
+    // so without an explicit deleteBuffer it leaks until (maybe) GC.
+    expect(stats().deleted).toBe(1);
+    expect(stats().live).toBe(0);
+  });
+
+  it("does not leak instanceIndex buffers across repeated create/dispose", () => {
+    const { gl, stats } = makeMockGl();
+    const renderer = { getContext: () => gl } as unknown as THREE.WebGLRenderer;
+
+    // Simulates BatchedMeshBase rebuilding the mesh on every geometry change.
+    for (let i = 0; i < 50; i++) {
+      const mesh = new InstancedMesh2(
+        new THREE.BoxGeometry(),
+        new THREE.MeshBasicMaterial(),
+        { capacity: 64, renderer },
+      );
+      mesh.dispose();
+    }
+
+    const s = stats();
+    expect(s.created).toBe(50);
+    expect(s.deleted).toBe(50); // net zero live buffers
+    expect(s.live).toBe(0);
+  });
+});

--- a/src/viser/client/src/vendor/instanced-mesh/core/InstancedMesh2.ts
+++ b/src/viser/client/src/vendor/instanced-mesh/core/InstancedMesh2.ts
@@ -857,6 +857,21 @@ export class InstancedMesh2<
     this.morphTexture?.dispose();
     this.boneTexture?.dispose();
     this.uniformsTexture?.dispose();
+
+    // === VISER LOCAL PATCH (see vendor/instanced-mesh/LOCAL_PATCHES.md) ===
+    // Re-apply this block after any upstream re-vendor.
+    // Free the raw GL buffer backing `instanceIndex`. Unlike the textures
+    // above (and unlike normal geometry attributes), this buffer is created
+    // via `gl.createBuffer()` and is never tracked by three.js, so it leaks on
+    // every mesh recreation unless we delete it explicitly here.
+    if (this._renderer) {
+      const gl = this._renderer.getContext() as WebGL2RenderingContext;
+      this.instanceIndex?.dispose(gl);
+      if (this.LODinfo) {
+        for (const obj of this.LODinfo.objects) obj.instanceIndex?.dispose(gl);
+      }
+    }
+    // === END VISER LOCAL PATCH ===
   }
 
   public override updateMatrixWorld(force?: boolean): void {

--- a/src/viser/client/src/vendor/instanced-mesh/core/utils/GLInstancedBufferAttribute.ts
+++ b/src/viser/client/src/vendor/instanced-mesh/core/utils/GLInstancedBufferAttribute.ts
@@ -73,4 +73,17 @@ export class GLInstancedBufferAttribute extends GLBufferAttribute {
     // This method is intentionally empty but necessary to avoid exceptions when cloning geometry.
     return this;
   }
+
+  // === VISER LOCAL PATCH (see vendor/instanced-mesh/LOCAL_PATCHES.md) ===
+  // Re-apply this method after any upstream re-vendor.
+  /**
+   * Frees the underlying GL buffer. This buffer is created directly via
+   * `gl.createBuffer()` and is NOT tracked by three.js's WebGLAttributes, so
+   * it must be deleted explicitly -- otherwise it leaks on every mesh
+   * recreation (the JS garbage collector cannot free GPU memory promptly).
+   */
+  public dispose(gl: WebGL2RenderingContext): void {
+    gl.deleteBuffer(this.buffer);
+  }
+  // === END VISER LOCAL PATCH ===
 }


### PR DESCRIPTION
Four GPU memory leaks where buffers were orphaned or never freed:

- Point clouds: setAttribute(new ...) on every update orphaned the old position/color GL buffers (three never deletes a replaced attribute's buffer). Replace with in-place array swaps that reuse the same GL buffer via bufferSubData. A naive in-place swap would throw on a point-count change ("Resizing buffer attributes is not supported"), so introduce syncBufferGeometry: a declarative reconcile that takes the zero-cost fast path when the layout is unchanged and disposes+reallocates (leak- and throw-free) on a length/precision change.

- InstancedMesh2.dispose() never freed the raw instanceIndex GL buffer (created via gl.createBuffer, untracked by three). Add GLInstancedBufferAttribute.dispose(gl) and call it for the mesh and all LOD objects. These are vendored files; mark the patch sites and record them in vendor/instanced-mesh/LOCAL_PATCHES.md for re-vendor safety.

- SingleGlbAsset outlineMaterial and InstancedAxes outlineCylinderGeom were never disposed (R3F does not auto-dispose prop-passed resources). Add dispose-on-unmount/replace effects.