### PR TITLE
Pre-1.1.0 audit: fix 14 review findings, regenerate example docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,9 @@
 
 - **Dock/panel changes require a spec trace.** `src/viser/client/src/dock/dock-ux-spec.md` (it lives next to the code it governs) is
   normative for the dock system; after any behavior change, re-trace the
-  touched claims per its §10 protocol (normative text, gesture table,
-  decision index). Where code and spec disagree, decide on paper first.
+  touched claims per the re-trace protocol in its "How to use it" preamble
+  (normative text, gesture table, decision index). Where code and spec
+  disagree, decide on paper first.
 - **Gates before committing client code** (from `src/viser/client`):
   `npx tsc --noEmit`, `npx eslint src/`, `npx prettier --check src/`,
   `npx vitest run src`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,9 +53,9 @@ See [Contributing Visuals](./source/contributing_visuals.md) for guidelines on c
 
 ## Auto-Generated Example Documentation
 
-Example documentation is automatically generated from the examples in the `examples/` directory using the `update_example_docs.py` script. To update the example documentation after making changes to examples:
+Example documentation is automatically generated from the examples in the `examples/` directory using the `generate_example_docs.py` script. To update the example documentation after making changes to examples:
 
 ```bash
 cd docs
-python update_example_docs.py
+python generate_example_docs.py
 ```

--- a/docs/source/examples/_example_gallery.rst
+++ b/docs/source/examples/_example_gallery.rst
@@ -258,6 +258,15 @@ GUI Controls
                </div>
            </a>
        </div>
+       <div class="example-card" style="border-radius: 3px; overflow: hidden; background: white; transition: transform 0.2s;">
+           <a href="examples/gui/panels/" style="text-decoration: none; color: inherit; display: block;">
+               <img src="_static/examples/thumbs/02_gui_11_panels.png" alt="Standalone panels" style="width: 100%; height: auto; aspect-ratio: 16/9; object-fit: cover; display: block;">
+               <div style="padding: 15px;">
+                   <h4 style="margin: 0; padding: 0; font-size: 16px; font-weight: 600; color: #333; margin-bottom: 8px;">Standalone panels</h4>
+                   <p style="margin: 0; padding: 0; color: #666; font-size: 13px; line-height: 1.4;">Create dockable / floating GUI panels that live outside the main control panel, and place them programmatically.</p>
+               </div>
+           </a>
+       </div>
    </div>
 
 User Interaction

--- a/docs/source/examples/demos/colmap_visualizer.rst
+++ b/docs/source/examples/demos/colmap_visualizer.rst
@@ -58,7 +58,8 @@ Code
        reorient_scene: bool = True,
    ) -> None:
        server = viser.ViserServer()
-       server.gui.configure_theme(titlebar_content=None, control_layout="collapsible")
+       server.gui.configure_theme(titlebar_content=None)
+       server.gui.main_panel.dock_right()
    
        # Load the colmap info.
        cameras = read_cameras_binary(colmap_path / "cameras.bin")

--- a/docs/source/examples/gui/index.rst
+++ b/docs/source/examples/gui/index.rst
@@ -17,3 +17,4 @@ Examples demonstrating interactive GUI elements.
    uplot
    plots_as_images
    commands
+   panels

--- a/docs/source/examples/gui/panels.rst
+++ b/docs/source/examples/gui/panels.rst
@@ -1,0 +1,122 @@
+Standalone panels
+=================
+
+Create dockable / floating GUI panels that live outside the main control panel,
+and place them programmatically.
+
+A panel is a dockable container; tabs are its content. Placement is imperative:
+
+* :meth:`viser.GuiApi.add_panel` creates a standalone panel.
+* :meth:`viser.PanelHandle.add_tab` adds a tab to fill with GUI elements.
+* :meth:`viser.PanelHandle.dock_left` / :meth:`viser.PanelHandle.dock_right` dock
+  to a viewport edge.
+* :meth:`viser.PanelHandle.dock_above` / :meth:`viser.PanelHandle.dock_below`
+  stack a panel relative to another panel.
+* :meth:`viser.PanelHandle.float` floats a panel at an explicit position. The
+  coordinates are relative to the viewport (the canvas inside any docked panels),
+  so a float lands clear of docked panels and shifts to stay within the canvas if
+  the docked regions change.
+* :meth:`viser.PanelHandle.set_width` / :meth:`viser.PanelHandle.set_height`
+  size a panel (``set_height`` applies to floating panels only).
+
+Panels start expanded. :meth:`viser.PanelHandle.minimize` /
+:meth:`viser.PanelHandle.expand` collapse or reveal one imperatively --
+applied to the panel's containing window or docked column, exactly like
+the on-screen minimize control (the panel header's ``-`` button or the
+dock chevrons).
+
+Placement is replayed to clients that connect later, but is not continuously
+synchronized: once a panel is placed, users can freely drag, dock, and minimize
+it in the browser. The server owns a panel's existence -- there is no close
+button; a panel disappears only when :meth:`viser.PanelHandle.remove` is called.
+
+:attr:`viser.GuiApi.main_panel` exposes the same placement commands for the main
+control panel, and is a legal dock anchor for other panels.
+
+**Source:** ``examples/02_gui/11_panels.py``
+
+.. figure:: ../../_static/examples/02_gui_11_panels.png
+   :width: 100%
+   :alt: Standalone panels
+
+Code
+----
+
+.. code-block:: python
+   :linenos:
+
+   import time
+   
+   import numpy as np
+   
+   import viser
+   
+   
+   def main() -> None:
+       server = viser.ViserServer()
+   
+       server.scene.add_frame("/axes", axes_length=1.0, axes_radius=0.02)
+   
+       # A panel docked to the right edge, with two tabs. Panels start
+       # expanded; minimize() below collapses the log panel imperatively, and
+       # the user can minimize/expand freely in the browser.
+       stats_panel = server.gui.add_panel()
+       with stats_panel.add_tab("Stats", viser.Icon.CHART_BAR):
+           counter = server.gui.add_number("Counter", initial_value=0, disabled=True)
+           server.gui.add_markdown("Live values update in this docked panel.")
+       with stats_panel.add_tab("Notes", viser.Icon.NOTES):
+           server.gui.add_markdown("A second tab in the same panel.")
+       stats_panel.dock_right()
+       stats_panel.set_width(320)
+   
+       # A floating panel at an explicit position. x/y are viewport-relative (the
+       # canvas inside docked panels), so this stays clear of the left-docked main
+       # panel below and shifts if the docked regions change.
+       tools_panel = server.gui.add_panel()
+       with tools_panel.add_tab("Tools", viser.Icon.TOOL):
+           randomize = server.gui.add_button("Randomize point cloud")
+       tools_panel.float(x=30, y=30, width=260)
+       # Start the tools panel minimized (a floating panel collapses to its
+       # header bar). Collapse applies to the panel's CONTAINER -- panels
+       # stacked together minimize together -- so we demo it on a panel with
+       # its own window; log_panel below shares a column with stats_panel,
+       # and minimizing it would rail them both.
+       tools_panel.minimize()
+   
+       # A panel stacked below the docked stats panel (a column split).
+       log_panel = server.gui.add_panel()
+       with log_panel.add_tab("Log", viser.Icon.TERMINAL):
+           log = server.gui.add_markdown("Waiting for events...")
+       log_panel.dock_below(stats_panel)
+   
+       # The main control panel can be placed too -- here, docked to the left.
+       server.gui.main_panel.dock_left()
+   
+       rng = np.random.default_rng(0)
+       points = rng.normal(size=(2000, 3)) * 0.5
+       log_lines: list[str] = []
+   
+       def append_log(message: str) -> None:
+           # Keep a short rolling history so the log reads like a real log, not a
+           # single replaced line.
+           log_lines.append(message)
+           del log_lines[:-8]  # keep the last 8 lines
+           log.content = "\n\n".join(log_lines)
+   
+       @randomize.on_click
+       def _(_) -> None:
+           nonlocal points
+           points = rng.normal(size=(2000, 3)) * 0.5
+           append_log(f"Randomized at t={counter.value}.")
+   
+       while True:
+           counter.value += 1
+           server.scene.add_point_cloud(
+               "/points", points=points, colors=(120, 180, 255), point_size=0.02
+           )
+           time.sleep(0.5)
+   
+   
+   if __name__ == "__main__":
+       main()
+   

--- a/docs/source/examples/gui/theming.rst
+++ b/docs/source/examples/gui/theming.rst
@@ -68,34 +68,47 @@ Code
        show_logo = server.gui.add_checkbox("Show logo", initial_value=True)
        show_share_button = server.gui.add_checkbox("Show share button", initial_value=True)
        brand_color = server.gui.add_rgb("Brand color", (230, 180, 30))
-       control_layout = server.gui.add_dropdown(
-           "Control layout", ("floating", "fixed", "collapsible")
-       )
        control_width = server.gui.add_dropdown(
            "Control width", ("small", "medium", "large"), initial_value="medium"
+       )
+       # Control-panel placement is now done with `main_panel` (the `control_layout`
+       # theme argument is deprecated). Dock the control panel to either edge, or
+       # leave it floating.
+       panel_dock = server.gui.add_dropdown(
+           "Control panel dock", ("floating", "left", "right")
        )
        synchronize = server.gui.add_button("Apply theme", icon=viser.Icon.CHECK)
    
        def synchronize_theme() -> None:
            server.gui.configure_theme(
                titlebar_content=titlebar_theme if titlebar.value else None,
-               control_layout=control_layout.value,
                control_width=control_width.value,
                dark_mode=dark_mode.value,
                show_logo=show_logo.value,
                show_share_button=show_share_button.value,
                brand_color=brand_color.value,
            )
+           if panel_dock.value == "left":
+               server.gui.main_panel.dock_left()
+               dock_code = "server.gui.main_panel.dock_left()"
+           elif panel_dock.value == "right":
+               server.gui.main_panel.dock_right()
+               dock_code = "server.gui.main_panel.dock_right()"
+           else:  # "floating"
+               # Negative coords are gaps from the far edge, so this floats the panel
+               # back to the top-right corner (its original spot).
+               server.gui.main_panel.float(x=-15, y=15)
+               dock_code = "server.gui.main_panel.float(x=-15, y=15)"
            gui_theme_code.content = f"""
                ### Current applied theme
                ```
                server.gui.configure_theme(
                    titlebar_content={"titlebar_content" if titlebar.value else None},
-                   control_layout="{control_layout.value}",
                    control_width="{control_width.value}",
                    dark_mode={dark_mode.value},
                    show_logo={show_logo.value},
                    show_share_button={show_share_button.value},
                    brand_color={brand_color.value},
                )
+               {dock_code}
                ```

--- a/docs/source/examples/scene/meshes_batched.rst
+++ b/docs/source/examples/scene/meshes_batched.rst
@@ -345,11 +345,11 @@ Code
            # Update mesh properties.
            with server.atomic():
                mesh_handle.batched_positions = positions
-               mesh_handle.batched_scales = scales
+               mesh_handle.batched_scales = scales.astype(np.float32)
                mesh_handle.batched_colors = colors
    
                axes_handle.batched_positions = positions
-               axes_handle.batched_scales = scales
+               axes_handle.batched_scales = scales.astype(np.float32)
    
            time.sleep(1.0 / 60.0)
    

--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -533,7 +533,13 @@ class GuiApi:
     ) -> None:
         if message.transfer_uuid not in self._current_file_upload_states:
             return
-        assert message.source_component_uuid in self._gui_input_handle_from_uuid
+        # NOTE: the source component may legitimately be gone from
+        # `_gui_input_handle_from_uuid` here -- `button.remove()` during a
+        # multi-part upload pops it. Keep buffering and acking parts anyway
+        # (asserting would raise in an asyncio task: no ack, and the
+        # `_current_file_upload_states` entry would leak forever); completion
+        # degrades cleanly in `_finish_file_upload`, which pops the transfer
+        # state and then no-ops on the removed/missing handle.
 
         state = self._current_file_upload_states[message.transfer_uuid]
         state["parts"][message.part_index] = message.content
@@ -604,6 +610,8 @@ class GuiApi:
 
     def reset(self) -> None:
         """Reset the GUI."""
+        from ._viser import ViserServer
+
         root_container = self._container_handle_from_uuid["root"]
         while root_container._children:
             next(iter(root_container._children.values())).remove()
@@ -629,6 +637,17 @@ class GuiApi:
         # panel still sees this deliberate reset (counter increment beats its
         # last-applied), while a normal reconnect replay -- same counter -- is
         # ignored. (None width/height clears any override -> default/theme.)
+        #
+        # SERVER-SCOPED ONLY: a client-scoped `client.gui.reset()` resets the
+        # GUI elements it owns but must NOT touch the main panel's placement.
+        # A client-scoped GuiApi mints its own `_layout_run_id`, so the four
+        # default CONTROL_PANEL_ID messages below would reach the client's
+        # placement gate with an unseen run_id -- which the gate treats as a
+        # fresh, deliberate command -- clobbering server-authored placement
+        # (e.g. undocking a `main_panel.dock_left()` control panel to the
+        # default top-right float, for that one client).
+        if not isinstance(self._owner, ViserServer):
+            return
         reset_counter = self._next_layout_counter()
         self._websock_interface.queue_message(
             _messages.GuiSetPanelPositionMessage(

--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -637,7 +637,7 @@ class GuiApi:
         # late joiners -- and connected clients -- get the default control panel
         # (a top-right float) instead of a layout the user never asked
         # for. Placement is write-only, so we just send; there's no state to read.
-        # Bump the main panel's layout counter once and stamp it on all three
+        # Bump the main panel's layout counter once and stamp it on all four
         # reset messages, so a connected client that had rearranged the control
         # panel still sees this deliberate reset (counter increment beats its
         # last-applied), while a normal reconnect replay -- same counter -- is
@@ -2349,7 +2349,12 @@ class GuiApi:
             A handle that can be used to interact with the GUI element.
         """
 
-        value = cast("tuple[int, int, int]", _colors_to_int_tuple(initial_value))
+        value = cast(
+            "tuple[int, int, int]",
+            # warn_stacklevel: user -> deprecated_positional_shim wrapper ->
+            # add_rgb -> _colors_to_int_tuple.
+            _colors_to_int_tuple(initial_value, warn_stacklevel=4),
+        )
         uuid = _make_uuid()
         order = _apply_default_order(order)
         return GuiRgbHandle(
@@ -2397,7 +2402,12 @@ class GuiApi:
         Returns:
             A handle that can be used to interact with the GUI element.
         """
-        value = cast("tuple[int, int, int, int]", _colors_to_int_tuple(initial_value))
+        value = cast(
+            "tuple[int, int, int, int]",
+            # warn_stacklevel: user -> deprecated_positional_shim wrapper ->
+            # add_rgba -> _colors_to_int_tuple.
+            _colors_to_int_tuple(initial_value, warn_stacklevel=4),
+        )
         uuid = _make_uuid()
         order = _apply_default_order(order)
         return GuiRgbaHandle(

--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -493,13 +493,18 @@ class GuiApi:
         self,
         client_id: ClientId,
         transfer_uuid: str,
-        source_component_uuid: str,
+        # None on the wire for server->client downloads; upload transfers carry
+        # the upload button's uuid, but that handle may have been removed
+        # mid-transfer -- both degrade to the same no-op below.
+        source_component_uuid: str | None,
     ) -> None:
         """Finalize a completed upload by assembling the file contents and
         firing the handle's update callbacks. Shared by the normal multi-part
         path and the zero-byte path (which has no parts)."""
         state = self._current_file_upload_states.pop(transfer_uuid, None)
         if state is None:
+            return
+        if source_component_uuid is None:
             return
 
         handle = self._gui_input_handle_from_uuid.get(source_component_uuid, None)

--- a/src/viser/_gui_handles.py
+++ b/src/viser/_gui_handles.py
@@ -211,10 +211,23 @@ class _GuiInputHandle(
             # Preserve each element's expected Python type -- float for vectors,
             # int for colors. A blanket `float(...)` would turn an int tuple into
             # floats, and the `tuple(...)` cast below does not restore types.
+            #
+            # When the target type is int (bool excluded) and the incoming
+            # element is a float, ROUND instead of casting: `int(2.9)`
+            # truncates toward zero, which silently corrupts values that were
+            # meant to be near-integers. We use the round() builtin, which is
+            # round-half-even ("banker's rounding": 0.5 -> 0, 1.5 -> 2) --
+            # exact .5 inputs are rare for this path and half-even is the
+            # documented Python convention.
             elems = value.tolist()
             current = self._impl.value
             if isinstance(current, tuple) and len(current) == len(elems):
-                value = tuple(type(c)(e) for c, e in zip(current, elems))  # type: ignore
+                value = tuple(
+                    type(c)(round(e))
+                    if type(c) is int and isinstance(e, float)
+                    else type(c)(e)
+                    for c, e in zip(current, elems)
+                )  # type: ignore
             else:
                 value = tuple(elems)  # type: ignore
 
@@ -354,7 +367,7 @@ class GuiMultiSliderHandle(
     """
 
 
-def _colors_to_int_tuple(value: Any) -> tuple[int, ...]:
+def _colors_to_int_tuple(value: Any, *, warn_stacklevel: int = 3) -> tuple[int, ...]:
     """Coerce an RGB/RGBA color to an int tuple in [0, 255].
 
     Integer channels are taken as absolute [0, 255]; float channels are
@@ -362,9 +375,22 @@ def _colors_to_int_tuple(value: Any) -> tuple[int, ...]:
     255 (white) but ``1`` -> 1. The result is clamped to [0, 255] -- matching
     ``colors_to_uint8`` -- so out-of-range inputs (e.g. a float ``255.0`` or a
     negative value) degrade gracefully instead of producing a wild value.
-    Generalized to any channel count (RGB and RGBA)."""
+    Generalized to any channel count (RGB and RGBA).
+
+    Float channels > 1.0 emit a warning: before viser 1.1.0 they were passed
+    through unchanged (a float ``100.0`` behaved like the int ``100``), so old
+    code passing float [0, 255] colors now silently clamps to white without
+    it. ``warn_stacklevel`` should point the warning at user code; the default
+    fits the direct ``add_rgb(initial_value=...)`` call sites."""
     if isinstance(value, np.ndarray):
         assert value.ndim == 1, f"Expected a 1D color, got shape {value.shape}."
+    if any(not np.issubdtype(type(v), np.integer) and v > 1.0 for v in value):
+        warnings.warn(
+            "Float color channels are interpreted on [0, 1] and scaled to "
+            f"[0, 255]; values > 1.0 are clamped to 255 (got {tuple(value)!r}). "
+            "Use ints for absolute [0, 255] channels.",
+            stacklevel=warn_stacklevel,
+        )
     return tuple(
         max(0, min(255, int(v) if np.issubdtype(type(v), np.integer) else int(v * 255)))
         for v in value
@@ -385,7 +411,11 @@ class GuiRgbHandle(GuiInputHandle[Tuple[int, int, int]], GuiRgbProps):
         self, value: Tuple[int, int, int] | np.ndarray
     ) -> Tuple[int, int, int]:
         # Float channels are [0, 1] (scaled to [0, 255]); int channels absolute.
-        return cast(Tuple[int, int, int], _colors_to_int_tuple(value))
+        # warn_stacklevel: user assignment -> props_setattr -> value.fset ->
+        # this method -> _colors_to_int_tuple = 5 frames.
+        return cast(
+            Tuple[int, int, int], _colors_to_int_tuple(value, warn_stacklevel=5)
+        )
 
 
 class GuiRgbaHandle(GuiInputHandle[Tuple[int, int, int, int]], GuiRgbaProps):
@@ -402,7 +432,11 @@ class GuiRgbaHandle(GuiInputHandle[Tuple[int, int, int, int]], GuiRgbaProps):
         self, value: Tuple[int, int, int, int] | np.ndarray
     ) -> Tuple[int, int, int, int]:
         # Float channels are [0, 1] (scaled to [0, 255]); int channels absolute.
-        return cast(Tuple[int, int, int, int], _colors_to_int_tuple(value))
+        # warn_stacklevel: user assignment -> props_setattr -> value.fset ->
+        # this method -> _colors_to_int_tuple = 5 frames.
+        return cast(
+            Tuple[int, int, int, int], _colors_to_int_tuple(value, warn_stacklevel=5)
+        )
 
 
 class GuiVector2Handle(GuiInputHandle[Tuple[float, float]], GuiVector2Props):
@@ -718,6 +752,14 @@ class _TabContainerMixin:
         source of truth for a tab's id/label/icon. Every mutation (add, remove,
         icon change) rebuilds through here, so the parallel tuples can never
         desync in length or order."""
+        if self._impl.removed:
+            # Tear-down path: PanelHandle.remove() tombstones BEFORE draining
+            # its tabs (the tombstone must be an atomic check-and-set against
+            # concurrent removers), so the drain's write-backs land here after
+            # removal. Skip the wire write-back: props_setattr would
+            # (correctly) reject a props write on a removed handle, and the
+            # client drops the whole entity via its remove message anyway.
+            return
         self._tab_container_ids = tuple(h._id for h in self._tab_handles)
         self._tab_labels = tuple(h._label for h in self._tab_handles)
         self._tab_icons_html = tuple(
@@ -897,7 +939,9 @@ class _PlacementMixin:
         removed (the main panel); `PanelHandle` overrides it."""
         return False
 
-    def _queue_placement(self, message: _PlacementMessage) -> None:
+    def _queue_placement(
+        self, message: _PlacementMessage, *, anchor: PanelHandle | None = None
+    ) -> None:
         api = self._placement_gui_api
         # The removed check and the enqueue are ONE atomic step under the
         # lifecycle lock: a `remove()` on another thread otherwise slips
@@ -910,6 +954,15 @@ class _PlacementMixin:
             # dead uuid.
             if self._placement_removed():
                 raise RuntimeError(f"Cannot place a removed {type(self).__name__}.")
+            # Re-check the anchor (dock_above/dock_below) under the SAME lock:
+            # `_resolve_anchor_uuid` runs before this lock is taken, so an
+            # `anchor.remove()` on another thread -- whose tombstone is set
+            # under this lock; the anchor shares our GuiApi per the scope
+            # check -- could otherwise slip between that check and this
+            # enqueue, persisting a split placement that references a dead
+            # anchor uuid. Same error the sequential path promises.
+            if anchor is not None and anchor._impl.removed:
+                raise ValueError("Cannot dock relative to a removed panel.")
             # Stamp the layout-update counter (bumped on EVERY placement
             # command, global across panels -- D50: conflicting container-
             # scoped collapse axes replay in counter order) and this GuiApi's
@@ -926,12 +979,16 @@ class _PlacementMixin:
             api._websock_interface.queue_message(stamped)
 
     def _set_position(
-        self, position: EdgePlacement | SplitPlacement | FloatPlacement
+        self,
+        position: EdgePlacement | SplitPlacement | FloatPlacement,
+        *,
+        anchor: PanelHandle | None = None,
     ) -> None:
         self._queue_placement(
             GuiSetPanelPositionMessage(
                 self._placement_uuid, position, counter=0, run_id=""
-            )
+            ),
+            anchor=anchor,
         )
 
     def _resolve_anchor_uuid(self, anchor: PlaceableHandle) -> str:
@@ -992,7 +1049,10 @@ class _PlacementMixin:
                 "kind": "split",
                 "anchor_uuid": self._resolve_anchor_uuid(anchor),
                 "side": "above",
-            }
+            },
+            # Re-validated under the lifecycle lock (see _queue_placement);
+            # main_panel needs no removed-check (it cannot be removed).
+            anchor=anchor if isinstance(anchor, PanelHandle) else None,
         )
 
     def dock_below(self, anchor: PlaceableHandle) -> None:
@@ -1007,7 +1067,10 @@ class _PlacementMixin:
                 "kind": "split",
                 "anchor_uuid": self._resolve_anchor_uuid(anchor),
                 "side": "below",
-            }
+            },
+            # Re-validated under the lifecycle lock (see _queue_placement);
+            # main_panel needs no removed-check (it cannot be removed).
+            anchor=anchor if isinstance(anchor, PanelHandle) else None,
         )
 
     def float(
@@ -1189,28 +1252,37 @@ class PanelHandle(
 
         This is the only way a panel disappears -- there is no UI close button
         (see :class:`PanelHandle`)."""
-        if self._impl.removed:
-            warnings.warn(
-                "Attempted to remove an already removed PanelHandle.",
-                stacklevel=2,
-            )
-            return
-        # Remove tabs first: each tab.remove() writes back to this panel's tab
-        # tuples, which the removed-guard in props_setattr would reject once the
-        # panel is marked removed (mirrors GuiTabGroupHandle.remove).
-        for tab in tuple(self._tab_handles):
-            tab.remove()
         gui_api = self._impl.gui_api
-        # Tombstone + remove-message (whose buffer push purges the panel's
-        # placement updates) as ONE atomic step under the lifecycle lock, so a
-        # concurrent placement command can't slip between the removed check
-        # and its enqueue (see _queue_placement).
+        # Tombstone CHECK-AND-SET + remove-message (whose buffer push purges
+        # the panel's placement updates) as ONE atomic step under the
+        # lifecycle lock. This serves two races:
+        # - a concurrent placement command can't slip between the removed
+        #   check and its enqueue (see _queue_placement);
+        # - two concurrent remove() calls (or remove() racing gui.reset()'s
+        #   drain) resolve to exactly one winner -- checking `removed` before
+        #   taking the lock let both pass, queue duplicate remove messages,
+        #   and double-pop the registry (KeyError, aborting reset mid-drain).
         with gui_api._panel_lifecycle_lock:
+            if self._impl.removed:
+                warnings.warn(
+                    "Attempted to remove an already removed PanelHandle.",
+                    stacklevel=2,
+                )
+                return
             self._impl.removed = True
             gui_api._websock_interface.queue_message(
                 GuiPanelRemoveMessage(self._impl.uuid)
             )
-        gui_api._panel_handle_from_uuid.pop(self._impl.uuid)
+        # Only the tombstone winner reaches here, so the pop and tab drain run
+        # exactly once. `.pop(..., None)` is belt-and-suspenders. The drain
+        # runs AFTER the tombstone and OUTSIDE the lock (a plain,
+        # non-reentrant Lock): each tab.remove() writes back to this panel's
+        # tab tuples, which _rebuild_tab_props now skips for a removed panel
+        # (props_setattr would reject the write; the client drops the whole
+        # entity via the remove message anyway).
+        gui_api._panel_handle_from_uuid.pop(self._impl.uuid, None)
+        for tab in tuple(self._tab_handles):
+            tab.remove()
 
 
 class MainPanelHandle(_PlacementMixin):

--- a/src/viser/_gui_handles.py
+++ b/src/viser/_gui_handles.py
@@ -367,7 +367,7 @@ class GuiMultiSliderHandle(
     """
 
 
-def _colors_to_int_tuple(value: Any, *, warn_stacklevel: int = 3) -> tuple[int, ...]:
+def _colors_to_int_tuple(value: Any, *, warn_stacklevel: int) -> tuple[int, ...]:
     """Coerce an RGB/RGBA color to an int tuple in [0, 255].
 
     Integer channels are taken as absolute [0, 255]; float channels are
@@ -380,8 +380,11 @@ def _colors_to_int_tuple(value: Any, *, warn_stacklevel: int = 3) -> tuple[int, 
     Float channels > 1.0 emit a warning: before viser 1.1.0 they were passed
     through unchanged (a float ``100.0`` behaved like the int ``100``), so old
     code passing float [0, 255] colors now silently clamps to white without
-    it. ``warn_stacklevel`` should point the warning at user code; the default
-    fits the direct ``add_rgb(initial_value=...)`` call sites."""
+    it. ``warn_stacklevel`` must point the warning at USER code, and every call
+    path has a different depth (required, no default, so a new call site has to
+    count its own frames): ``add_rgb``/``add_rgba`` need 4 -- user ->
+    deprecated_positional_shim wrapper -> add_rgb* -> here -- and the ``.value``
+    assignment path needs 5."""
     if isinstance(value, np.ndarray):
         assert value.ndim == 1, f"Expected a 1D color, got shape {value.shape}."
     if any(not np.issubdtype(type(v), np.integer) and v > 1.0 for v in value):

--- a/src/viser/_gui_handles.py
+++ b/src/viser/_gui_handles.py
@@ -1277,13 +1277,14 @@ class PanelHandle(
                 GuiPanelRemoveMessage(self._impl.uuid)
             )
         # Only the tombstone winner reaches here, so the pop and tab drain run
-        # exactly once. `.pop(..., None)` is belt-and-suspenders. The drain
-        # runs AFTER the tombstone and OUTSIDE the lock (a plain,
-        # non-reentrant Lock): each tab.remove() writes back to this panel's
-        # tab tuples, which _rebuild_tab_props now skips for a removed panel
-        # (props_setattr would reject the write; the client drops the whole
-        # entity via the remove message anyway).
-        gui_api._panel_handle_from_uuid.pop(self._impl.uuid, None)
+        # exactly once -- a strict pop() raises if that invariant ever breaks,
+        # which beats hiding the breakage. The drain runs AFTER the tombstone
+        # and OUTSIDE the lock (a plain, non-reentrant Lock): each
+        # tab.remove() writes back to this panel's tab tuples, which
+        # _rebuild_tab_props skips for a removed panel (props_setattr would
+        # reject the write; the client drops the whole entity via the remove
+        # message anyway).
+        gui_api._panel_handle_from_uuid.pop(self._impl.uuid)
         for tab in tuple(self._tab_handles):
             tab.remove()
 

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -1789,10 +1789,11 @@ class GuiSetPanelPositionMessage(
     uuid: str
     position: Union[EdgePlacement, SplitPlacement, FloatPlacement]
     counter: int
-    """Per-panel layout-update counter (bumped on EVERY placement call). The
-    client applies a replayed/late placement only if this exceeds the last it
-    applied for the panel -- OR the user hasn't manually moved the panel yet --
-    so a reconnect/re-run doesn't clobber a layout the user rearranged, while the
+    """Layout-update counter (bumped on EVERY placement call): one monotonic
+    counter per GuiApi run, shared across panels (D50). The client applies a
+    replayed/late placement only if this exceeds the last counter it applied
+    for that panel axis -- there is no user-touched arm (D52) -- so a
+    reconnect replay doesn't clobber a layout the user rearranged, while the
     server can still re-assert by calling a placement method again."""
     run_id: str
     """Random id of the GuiApi instance that sent this (fresh per server process

--- a/src/viser/client/src/ControlPanel/ControlPanelDock.tsx
+++ b/src/viser/client/src/ControlPanel/ControlPanelDock.tsx
@@ -417,11 +417,17 @@ function ControlPanelDockSync({
           pos.x === null &&
           pos.y === null;
         if (!defaultFloat) return placement;
-        const { x, y, width } = topRightGeometry();
+        // Canvas-INDEPENDENT top-right: negative x is the dock's "gap from
+        // the right edge" anchor form, re-resolved against the live canvas on
+        // every resize. topRightGeometry()'s absolute coords would freeze
+        // whatever canvas width existed at apply time -- an early apply
+        // during startup recorded 960px-era coords as a left-relative anchor
+        // and the panel sat mid-canvas once the viewport reached 1280px
+        // (caught by test_floating_panel_default_placement in CI).
         return {
           ...placement,
-          position: { kind: "float", x, y },
-          width: placement.width ?? width,
+          position: { kind: "float", x: -PANEL_PAD_PX, y: PANEL_PAD_PX },
+          width: placement.width ?? topRightGeometry().width,
         };
       },
       [topRightGeometry],

--- a/src/viser/client/src/ControlPanel/placementCoordinator.tsx
+++ b/src/viser/client/src/ControlPanel/placementCoordinator.tsx
@@ -324,8 +324,6 @@ export function usePlacementCoordinator(
               c.tabIds,
               {
                 position: null,
-                width: null,
-                height: null,
                 collapsed: c.collapsed,
               },
               (anchorUuid) => resolveAnchor(anchorUuid),

--- a/src/viser/client/src/ControlPanel/placementGate.test.ts
+++ b/src/viser/client/src/ControlPanel/placementGate.test.ts
@@ -162,20 +162,27 @@ describe("gatePlacement", () => {
     expect(g.placement.height).toBeUndefined();
   });
 
-  it("a FRESH width/height clear (stored value null) survives as null", () => {
-    // gui.reset() sends width/height None ("clear the override"); the gate
-    // must pass the null VALUE through as a command, not conflate it with a
-    // gated-off axis -- the regression that left reset windows pinned forever.
-    const g = gatePlacement(
-      entry({ height: { value: null, counter: 3, runId: RUN_A } }),
-      undefined,
-      true,
-    );
-    expect(g.anyFresh).toBe(true);
-    expect(g.placement.height).toBeNull(); // fresh clear -> revert to auto
-    expect(g.placement.width).toBeUndefined(); // absent axis -> untouched
-    expect(g.applied).toEqual({ height: { [RUN_A]: 3 } });
-  });
+  // gui.reset() sends width/height None ("clear the override"); the gate must
+  // pass the null VALUE through as a command, not conflate it with a
+  // gated-off axis -- the `?? null` regression left reset windows pinned
+  // forever. Table-driven over BOTH axes so neither can silently regress.
+  it.each([
+    { axis: "height" as const, other: "width" as const },
+    { axis: "width" as const, other: "height" as const },
+  ])(
+    "a FRESH $axis clear (stored value null) survives as null",
+    ({ axis, other }) => {
+      const g = gatePlacement(
+        entry({ [axis]: { value: null, counter: 3, runId: RUN_A } }),
+        undefined,
+        true,
+      );
+      expect(g.anyFresh).toBe(true);
+      expect(g.placement[axis]).toBeNull(); // fresh clear -> revert to default
+      expect(g.placement[other]).toBeUndefined(); // absent axis -> untouched
+      expect(g.applied).toEqual({ [axis]: { [RUN_A]: 3 } });
+    },
+  );
 });
 
 // The gate -> applyPanelPlacement chain as the placement coordinator drives it

--- a/src/viser/client/src/ControlPanel/placementGate.test.ts
+++ b/src/viser/client/src/ControlPanel/placementGate.test.ts
@@ -74,7 +74,8 @@ describe("gatePlacement", () => {
     );
     expect(g.anyFresh).toBe(false);
     expect(g.placement.position).toBeNull();
-    expect(g.placement.width).toBeNull();
+    // Gated-off width is ABSENT (undefined) -- null would be a fresh clear.
+    expect(g.placement.width).toBeUndefined();
   });
 
   it("server re-assert (same run, higher counter) applies", () => {
@@ -150,15 +151,30 @@ describe("gatePlacement", () => {
     expect(g.placement.position).toEqual(DOCK_RIGHT);
   });
 
-  it("no entry at all: nothing fresh, all axes null", () => {
+  it("no entry at all: nothing fresh, every axis absent", () => {
     const g = gatePlacement(undefined, undefined, true);
     expect(g.anyFresh).toBe(false);
-    expect(g.placement).toEqual({
-      position: null,
-      width: null,
-      height: null,
-      collapsed: null,
-    });
+    expect(g.placement.position).toBeNull();
+    expect(g.placement.collapsed).toBeNull();
+    // Width/height are tri-state: absent is undefined, NOT null (null would
+    // read as a fresh clear-to-default command downstream).
+    expect(g.placement.width).toBeUndefined();
+    expect(g.placement.height).toBeUndefined();
+  });
+
+  it("a FRESH width/height clear (stored value null) survives as null", () => {
+    // gui.reset() sends width/height None ("clear the override"); the gate
+    // must pass the null VALUE through as a command, not conflate it with a
+    // gated-off axis -- the regression that left reset windows pinned forever.
+    const g = gatePlacement(
+      entry({ height: { value: null, counter: 3, runId: RUN_A } }),
+      undefined,
+      true,
+    );
+    expect(g.anyFresh).toBe(true);
+    expect(g.placement.height).toBeNull(); // fresh clear -> revert to auto
+    expect(g.placement.width).toBeUndefined(); // absent axis -> untouched
+    expect(g.applied).toEqual({ height: { [RUN_A]: 3 } });
   });
 });
 

--- a/src/viser/client/src/ControlPanel/placementGate.ts
+++ b/src/viser/client/src/ControlPanel/placementGate.ts
@@ -44,8 +44,11 @@ import type {
 import type { PanelPlacement } from "../dock/layoutOps";
 
 export interface GatedPlacement {
-  /** Bundle for applyPanelPlacement: fresh axes carry their value, gated-off or
-   * absent axes are null (= "don't touch this axis"). */
+  /** Bundle for applyPanelPlacement: fresh axes carry their value -- including
+   * a fresh width/height NULL, the server's explicit "clear the override"
+   * command, which must survive into the bundle. Gated-off or absent axes are
+   * null for position/collapsed and undefined for width/height (= "don't touch
+   * this axis"). */
   placement: PanelPlacement;
   /** The (counter, runId) stamps of the axes included above, to record as
    * applied after the layout op commits. */
@@ -88,8 +91,11 @@ export function gatePlacement(
   return {
     placement: {
       position: position?.value ?? null,
-      width: width?.value ?? null,
-      height: height?.value ?? null,
+      // Width/height are tri-state in the bundle: undefined = gated off, null
+      // = a FRESH clear (`?? null` here would silently conflate the two and
+      // drop clear-to-default commands).
+      width: width === undefined ? undefined : width.value,
+      height: height === undefined ? undefined : height.value,
       collapsed: collapsed?.value ?? null,
     },
     applied: appliedOut,

--- a/src/viser/client/src/Outlines.tsx
+++ b/src/viser/client/src/Outlines.tsx
@@ -61,6 +61,12 @@ export const Outlines = React.forwardRef<THREE.Group, OutlinesProps>(
     const oldGeometry = React.useRef<THREE.BufferGeometry>();
     const oldPosition = React.useRef<THREE.BufferAttribute>();
     const oldPositionVersion = React.useRef(-1);
+    // Whether the CURRENT outline mesh's geometry is an owned creased clone
+    // (built with a nonzero angle) vs the parent's shared geometry. Every
+    // dispose decision must read this recorded flag -- gating on the current
+    // `angle` prop is wrong on angle flips: PI->0 would leak the old clone,
+    // and 0->PI would dispose the parent's live shared geometry.
+    const ownsGeometry = React.useRef(false);
     React.useLayoutEffect(() => {
       const group = localRef.current;
       if (!group) return;
@@ -92,10 +98,11 @@ export const Outlines = React.forwardRef<THREE.Group, OutlinesProps>(
           oldPosition.current = position;
           oldPositionVersion.current = position?.version ?? -1;
 
-          // Remove old mesh.
+          // Remove old mesh. Dispose its geometry only if WE cloned it
+          // (recorded when the old mesh was built; see ownsGeometry above).
           let mesh = group.children[0] as any;
           if (mesh) {
-            if (angle) mesh.geometry.dispose();
+            if (ownsGeometry.current) mesh.geometry.dispose();
             group.remove(mesh);
           }
 
@@ -120,6 +127,7 @@ export const Outlines = React.forwardRef<THREE.Group, OutlinesProps>(
           mesh.geometry = angle
             ? toCreasedNormals(parent.geometry, angle)
             : parent.geometry;
+          ownsGeometry.current = angle !== 0;
         }
       }
     });
@@ -161,8 +169,11 @@ export const Outlines = React.forwardRef<THREE.Group, OutlinesProps>(
           THREE.Material
         >;
         if (mesh) {
-          // Dispose the geometry if it was cloned via toCreasedNormals.
-          if (angle) mesh.geometry.dispose();
+          // Dispose the geometry only if it was cloned via toCreasedNormals.
+          // Read the ref, not `angle`: this []-deps cleanup closure captures
+          // the FIRST-render angle, which can differ from the angle the
+          // current mesh was actually built with.
+          if (ownsGeometry.current) mesh.geometry.dispose();
           group.remove(mesh);
         }
       };

--- a/src/viser/client/src/Outlines.tsx
+++ b/src/viser/client/src/Outlines.tsx
@@ -67,6 +67,13 @@ export const Outlines = React.forwardRef<THREE.Group, OutlinesProps>(
     // `angle` prop is wrong on angle flips: PI->0 would leak the old clone,
     // and 0->PI would dispose the parent's live shared geometry.
     const ownsGeometry = React.useRef(false);
+    // The live outline mesh, recorded at build time. The unmount cleanup
+    // cannot re-derive it from localRef: React detaches the ref (-> null)
+    // during the deletion phase BEFORE passive cleanups run, so a
+    // `localRef.current.children[0]` lookup there is always null and the
+    // dispose would silently never happen (leaking the creased clone once per
+    // unmount -- every hover cycle for unmountOnHide gizmos).
+    const outlineMeshRef = React.useRef<THREE.Mesh | null>(null);
     React.useLayoutEffect(() => {
       const group = localRef.current;
       if (!group) return;
@@ -128,6 +135,7 @@ export const Outlines = React.forwardRef<THREE.Group, OutlinesProps>(
             ? toCreasedNormals(parent.geometry, angle)
             : parent.geometry;
           ownsGeometry.current = angle !== 0;
+          outlineMeshRef.current = mesh;
         }
       }
     });
@@ -158,24 +166,14 @@ export const Outlines = React.forwardRef<THREE.Group, OutlinesProps>(
 
     React.useEffect(() => {
       return () => {
-        // Dispose everything on unmount.
+        // Dispose everything on unmount. Both reads go through refs recorded
+        // at build time (see outlineMeshRef/ownsGeometry above): localRef is
+        // already null here, and the first-render `angle` closure capture is
+        // stale on flips.
         material.dispose();
-
-        const group = localRef.current;
-        if (!group) return;
-
-        const mesh = group.children[0] as THREE.Mesh<
-          THREE.BufferGeometry,
-          THREE.Material
-        >;
-        if (mesh) {
-          // Dispose the geometry only if it was cloned via toCreasedNormals.
-          // Read the ref, not `angle`: this []-deps cleanup closure captures
-          // the FIRST-render angle, which can differ from the angle the
-          // current mesh was actually built with.
-          if (ownsGeometry.current) mesh.geometry.dispose();
-          group.remove(mesh);
-        }
+        const mesh = outlineMeshRef.current;
+        if (mesh !== null && ownsGeometry.current) mesh.geometry.dispose();
+        outlineMeshRef.current = null;
       };
     }, []);
 

--- a/src/viser/client/src/Outlines.tsx
+++ b/src/viser/client/src/Outlines.tsx
@@ -61,19 +61,17 @@ export const Outlines = React.forwardRef<THREE.Group, OutlinesProps>(
     const oldGeometry = React.useRef<THREE.BufferGeometry>();
     const oldPosition = React.useRef<THREE.BufferAttribute>();
     const oldPositionVersion = React.useRef(-1);
-    // Whether the CURRENT outline mesh's geometry is an owned creased clone
-    // (built with a nonzero angle) vs the parent's shared geometry. Every
-    // dispose decision must read this recorded flag -- gating on the current
-    // `angle` prop is wrong on angle flips: PI->0 would leak the old clone,
-    // and 0->PI would dispose the parent's live shared geometry.
-    const ownsGeometry = React.useRef(false);
-    // The live outline mesh, recorded at build time. The unmount cleanup
-    // cannot re-derive it from localRef: React detaches the ref (-> null)
-    // during the deletion phase BEFORE passive cleanups run, so a
+    // The creased clone WE own for the current outline mesh, or null when the
+    // mesh shares the parent's geometry. Recording the disposable resource
+    // itself is what makes every dispose site correct by construction: gating
+    // on the current `angle` prop was the original bug (PI->0 leaked the old
+    // clone, 0->PI disposed the parent's live shared geometry), and the
+    // unmount cleanup cannot re-derive the mesh from localRef -- React
+    // detaches the ref (-> null) before passive cleanups run, so a
     // `localRef.current.children[0]` lookup there is always null and the
-    // dispose would silently never happen (leaking the creased clone once per
+    // dispose would silently never happen (leaking the clone once per
     // unmount -- every hover cycle for unmountOnHide gizmos).
-    const outlineMeshRef = React.useRef<THREE.Mesh | null>(null);
+    const ownedGeometryRef = React.useRef<THREE.BufferGeometry | null>(null);
     React.useLayoutEffect(() => {
       const group = localRef.current;
       if (!group) return;
@@ -105,11 +103,12 @@ export const Outlines = React.forwardRef<THREE.Group, OutlinesProps>(
           oldPosition.current = position;
           oldPositionVersion.current = position?.version ?? -1;
 
-          // Remove old mesh. Dispose its geometry only if WE cloned it
-          // (recorded when the old mesh was built; see ownsGeometry above).
+          // Remove the old mesh, freeing the creased clone if we own one
+          // (never the parent's shared geometry; see ownedGeometryRef above).
           let mesh = group.children[0] as any;
           if (mesh) {
-            if (ownsGeometry.current) mesh.geometry.dispose();
+            ownedGeometryRef.current?.dispose();
+            ownedGeometryRef.current = null;
             group.remove(mesh);
           }
 
@@ -134,8 +133,7 @@ export const Outlines = React.forwardRef<THREE.Group, OutlinesProps>(
           mesh.geometry = angle
             ? toCreasedNormals(parent.geometry, angle)
             : parent.geometry;
-          ownsGeometry.current = angle !== 0;
-          outlineMeshRef.current = mesh;
+          ownedGeometryRef.current = angle !== 0 ? mesh.geometry : null;
         }
       }
     });
@@ -166,14 +164,13 @@ export const Outlines = React.forwardRef<THREE.Group, OutlinesProps>(
 
     React.useEffect(() => {
       return () => {
-        // Dispose everything on unmount. Both reads go through refs recorded
-        // at build time (see outlineMeshRef/ownsGeometry above): localRef is
-        // already null here, and the first-render `angle` closure capture is
-        // stale on flips.
+        // Dispose everything on unmount, reading only what was recorded at
+        // build time (see ownedGeometryRef above): localRef is already null
+        // here, and the first-render `angle` closure capture is stale on
+        // flips.
         material.dispose();
-        const mesh = outlineMeshRef.current;
-        if (mesh !== null && ownsGeometry.current) mesh.geometry.dispose();
-        outlineMeshRef.current = null;
+        ownedGeometryRef.current?.dispose();
+        ownedGeometryRef.current = null;
       };
     }, []);
 

--- a/src/viser/client/src/Outlines.tsx
+++ b/src/viser/client/src/Outlines.tsx
@@ -10,8 +10,8 @@ import {
   useThree,
   ThreeElement,
 } from "@react-three/fiber";
-import { toCreasedNormals } from "three-stdlib";
 import { OutlinesMaterial } from "./OutlinesMaterial";
+import { buildOutlineGeometry } from "./utils/outlineGeometry";
 
 type OutlinesProps = ThreeElement<typeof THREE.Group> & {
   /** Outline color, default: black */
@@ -103,14 +103,15 @@ export const Outlines = React.forwardRef<THREE.Group, OutlinesProps>(
           oldPosition.current = position;
           oldPositionVersion.current = position?.version ?? -1;
 
-          // Remove the old mesh, freeing the creased clone if we own one
-          // (never the parent's shared geometry; see ownedGeometryRef above).
+          // Free the creased copy if we own one (never the parent's shared
+          // geometry; see ownedGeometryRef above) -- unconditionally, not
+          // gated on the child still being attached: the group is exposed via
+          // the forwarded ref, so an externally-removed child must not strand
+          // the owned geometry.
+          ownedGeometryRef.current?.dispose();
+          ownedGeometryRef.current = null;
           let mesh = group.children[0] as any;
-          if (mesh) {
-            ownedGeometryRef.current?.dispose();
-            ownedGeometryRef.current = null;
-            group.remove(mesh);
-          }
+          if (mesh) group.remove(mesh);
 
           if (parent.skeleton) {
             mesh = new THREE.SkinnedMesh();
@@ -130,10 +131,9 @@ export const Outlines = React.forwardRef<THREE.Group, OutlinesProps>(
             mesh.material = material;
             group.add(mesh);
           }
-          mesh.geometry = angle
-            ? toCreasedNormals(parent.geometry, angle)
-            : parent.geometry;
-          ownedGeometryRef.current = angle !== 0 ? mesh.geometry : null;
+          const built = buildOutlineGeometry(parent.geometry, angle);
+          mesh.geometry = built.geometry;
+          ownedGeometryRef.current = built.owned ? built.geometry : null;
         }
       }
     });

--- a/src/viser/client/src/Splatting/GaussianSplats.tsx
+++ b/src/viser/client/src/Splatting/GaussianSplats.tsx
@@ -372,19 +372,30 @@ function SplatRendererImpl() {
             merged.gaussianBuffer,
             merged.groupIndices,
           );
-        } else {
-          const sorter = new (await SorterModulePromise).Sorter(
+          return;
+        }
+        // Await the module BEFORE constructing, so bailing out below never
+        // orphans a live Sorter (embind objects are only freed by an explicit
+        // .delete(); GC does not reclaim their WASM-heap allocations).
+        const module = await SorterModulePromise;
+        // The component may have unmounted while the module was loading.
+        if (sorterDisposedRef.current) return;
+        if (SorterRef.current) {
+          // Multiple buffer updates raced past the await; an earlier
+          // continuation already constructed the Sorter. Same-promise
+          // continuations resume in registration order, so we're the newer
+          // buffer version: push our data into the live instance instead of
+          // constructing (and leaking) a second one.
+          SorterRef.current.setBuffer(
             merged.gaussianBuffer,
             merged.groupIndices,
           );
-          // The component may have unmounted while the module was loading; if
-          // so, free the just-created Sorter instead of orphaning it.
-          if (sorterDisposedRef.current) {
-            sorter.delete();
-            return;
-          }
-          SorterRef.current = sorter;
+          return;
         }
+        SorterRef.current = new module.Sorter(
+          merged.gaussianBuffer,
+          merged.groupIndices,
+        );
       })();
     }
   }, [merged.gaussianBuffer, merged.groupIndices]);

--- a/src/viser/client/src/dock/FloatingWindowView.tsx
+++ b/src/viser/client/src/dock/FloatingWindowView.tsx
@@ -846,10 +846,15 @@ function FloatingStackDivider({
     // Push-through budget (user-adjudicated): dragging DOWN past the point
     // where every cell below the divider sits at its minimum keeps going by
     // GROWING the window -- the excess lands on the cell above the divider.
-    // Budget from the drag-start snapshot so it's stable across frames.
-    const startPx = wasFixed
-      ? stack.map((g) => startWeights[g])
-      : stack.map((g) => renderedPx[g]);
+    // Budget from the drag-start RENDERED snapshot in both modes: stored
+    // stackWeights are scale-free (snapToWindowStack seeds ~1s; rendering
+    // normalizes), so reading them as px on an already-pinned stack computes
+    // a zero belowCapacity and routes the whole downward delta into window
+    // growth while the lower cell never shrinks. renderedPx is the on-screen
+    // truth in px regardless of mode, and committing px-scale weights is
+    // exactly what the auto->pinned path already does (cascadeResize and the
+    // renderer both normalize).
+    const startPx = stack.map((g) => renderedPx[g]);
     const belowCapacity = startPx
       .slice(dividerIndex + 1)
       .reduce((s, px) => s + Math.max(0, px - MIN_STACK_CELL_PX), 0);

--- a/src/viser/client/src/dock/hitTest.ts
+++ b/src/viser/client/src/dock/hitTest.ts
@@ -175,7 +175,7 @@ export const inside = (r: DOMRect, x: number, y: number) =>
  * horizontal inset slices the leftmost/rightmost tabs' insert zones at the top
  * corners and they become undroppable (the drop falls through to the host).
  * The body keeps the inset. */
-export const hitsTarget = (t: GroupTarget, x: number, y: number): boolean => {
+const hitsTarget = (t: GroupTarget, x: number, y: number): boolean => {
   if (
     t.hitRect !== undefined &&
     t.ctx.kind === "area" &&
@@ -250,7 +250,7 @@ export const tabInsertion = (
  * insertion line (between rows / above the first / below the last). Lets a drop
  * land at a specific position in a minimized tab set, mirroring how dropping
  * between expanded horizontal tabs works. */
-export const verticalTabInsertion = (
+const verticalTabInsertion = (
   tabs: { rect: DOMRect }[],
   y: number,
 ): {

--- a/src/viser/client/src/dock/layoutOps.scanRegressions.test.ts
+++ b/src/viser/client/src/dock/layoutOps.scanRegressions.test.ts
@@ -42,8 +42,6 @@ describe("scan regressions: per-axis float placement", () => {
       ["p:0"],
       {
         position: { kind: "float", x: 40, y: 40 },
-        width: null,
-        height: null,
         collapsed: null,
       },
       () => null,

--- a/src/viser/client/src/dock/layoutOps.ts
+++ b/src/viser/client/src/dock/layoutOps.ts
@@ -859,7 +859,7 @@ export function insertTabsInto(
     delete draft.groups[sourceId];
   }
   if (incoming.length === 0) return layout;
-  const i = Math.max(0, Math.min(target.paneIds.length, index));
+  const i = clampIndex(index, target.paneIds.length);
   target.paneIds = [
     ...target.paneIds.slice(0, i),
     ...incoming,
@@ -1099,8 +1099,7 @@ function movePaneInPlace(
   removePaneInPlace(draft, paneId); // detach first -> no duplication possible
   const dest = draft.groups[destGroupId];
   if (dest === undefined) return;
-  const i = index === undefined ? dest.paneIds.length : index;
-  dest.paneIds.splice(Math.max(0, Math.min(dest.paneIds.length, i)), 0, paneId);
+  dest.paneIds.splice(clampIndex(index, dest.paneIds.length), 0, paneId);
   if (dest.paneIds.length === 1) dest.activeId = paneId;
 }
 
@@ -1413,10 +1412,7 @@ export function snapToWindowStack(
   for (const g of groupIds)
     nextWeights[g] = (meanTarget * shareOf(g)) / meanShare;
   target.stackWeights = nextWeights;
-  const i =
-    index === undefined
-      ? target.stack.length
-      : Math.max(0, Math.min(target.stack.length, index));
+  const i = clampIndex(index, target.stack.length);
   target.stack.splice(i, 0, ...groupIds);
   // Copy (don't alias) the source's height object: sourceHeight is read from the
   // original layout, so assigning it directly would share a reference between the
@@ -1455,7 +1451,7 @@ export function reorderTab(
   const group = layout.groups[groupId];
   if (group === undefined || !group.paneIds.includes(paneId)) return layout;
   const without = group.paneIds.filter((p) => p !== paneId);
-  const clamped = Math.max(0, Math.min(without.length, insertIndex));
+  const clamped = clampIndex(insertIndex, without.length);
   without.splice(clamped, 0, paneId);
   const unchanged =
     without.length === group.paneIds.length &&

--- a/src/viser/client/src/dock/layoutOps.ts
+++ b/src/viser/client/src/dock/layoutOps.ts
@@ -1943,14 +1943,19 @@ export type PanelPosition =
   | { kind: "float"; x: number | null; y: number | null };
 
 /** The placement state the dock applies to a panel: a per-axis bundle the
- * caller assembles from the client-owned placement store. Each field is the
- * latest value the server wrote (or null when never set / gated off). Each
- * axis is independent and applied only when non-null -- a set_width carries no
- * position, so applying width can never re-dock a panel. */
+ * caller assembles from the client-owned placement store. Each axis is
+ * independent and applied only when present -- a set_width carries no
+ * position, so applying width can never re-dock a panel.
+ *
+ * Width/height are tri-state: a number applies that size, `undefined` means
+ * the axis is absent / gated off ("don't touch"), and `null` is a fresh CLEAR
+ * -- the server's width/height `None`, reverting the override to its default
+ * (auto height; default/theme width). Position and collapsed have no clear
+ * form on the wire, so for them `null` simply means "absent". */
 export interface PanelPlacement {
   position: PanelPosition | null;
-  width: number | null;
-  height: number | null;
+  width?: number | null;
+  height?: number | null;
   collapsed: boolean | null;
 }
 
@@ -2153,12 +2158,14 @@ function resolveAnchorLeaf(
  * both standalone panels and the control panel).
  *
  * Each field of `placement` is the latest value the server wrote, and is always
- * applied when present -- there is no before/after gating. Because the three
+ * applied when present -- there is no before/after gating. Because the
  * write-only commands are independent (a set_width carries no position), applying
  * any single field can never re-dock a panel: a position re-docks/re-floats only
  * when `position != null`, and that only happens when the server actually sent a
- * position command. The caller's per-command dedup (appliedPlacementKey) keeps an
- * unrelated re-render from re-applying the same bundle.
+ * position command. A present width/height may also be a CLEAR (null; see the
+ * PanelPlacement tri-state note). The caller's per-command dedup
+ * (appliedPlacementKey) keeps an unrelated re-render from re-applying the same
+ * bundle.
  *
  * Options:
  * - `floatIfUnplaced` (default true): when the placement has no position AND the
@@ -2201,12 +2208,14 @@ export function applyPanelPlacement(
   // position from the current bounds + window size.
   //
   // If the group is already the sole occupant of a floating window, reuse that
-  // window (preserving its id, z-order, and -- when the user has taken manual
-  // control of its position via a drag, i.e. anchor was cleared -- its current
-  // position). This is what makes a later size-only re-placement (set_width /
-  // set_height) update the size without recreating the window or yanking a
-  // user-dragged panel back to its server anchor. A fresh float (group docked or
-  // unplaced) makes a new window as before.
+  // window (preserving its id and z-order, and touching only the size axes
+  // present in this bundle). A fresh float (group docked or unplaced) makes a
+  // new window as before. Note size-only bundles never reach this function --
+  // a no-position bundle only floats a still-UNPLACED group (see the
+  // floatIfUnplaced branch below) -- so every call here carries an explicit
+  // position command, and the position always applies (§8/D52: a fresh command
+  // applies to touched and untouched panels alike; protecting a user-dragged
+  // window from STALE positions is the gate's job, not this function's).
   const floatAtRequested = (reqX: number, reqY: number): void => {
     const loc = findGroupLocation(draft, groupId);
     const reusable =
@@ -2220,10 +2229,11 @@ export function applyPanelPlacement(
       win = reusable;
       // Per-axis contract (§8): a position-only float() must not disturb the
       // size axes. Only axes PRESENT in this bundle touch the reused window --
-      // an absent/gated-off width or height leaves the user's size alone.
-      if (placement.width !== null) win.width = placement.width;
-      if (placement.height !== null)
-        win.height = windowHeight(placement.height);
+      // an absent/gated-off width or height leaves the user's size alone. A
+      // fresh height CLEAR (null) returns the window to auto-height.
+      if (placement.width != null) win.width = placement.width;
+      if (placement.height !== undefined)
+        win.height = windowHeight(placement.height ?? undefined);
     } else {
       const result = floatGroup(
         draft,
@@ -2238,21 +2248,20 @@ export function applyPanelPlacement(
       win = draft.floating.find((w) => w.id === result.windowId);
       if (win === undefined) return;
     }
-    // A user-dragged window (anchor cleared) keeps its position on a size-only
-    // re-placement; otherwise (re)anchor and resolve against the live canvas.
-    const userOwnsPosition = win === reusable && win.anchor === undefined;
-    if (!userOwnsPosition) {
-      win.anchor = { x: reqX, y: reqY };
-      const resolved = resolveRequestedFloatPosition(
-        reqX,
-        reqY,
-        win.width,
-        pinnedPxOf(win.height) ?? 0,
-        bounds,
-      );
-      win.x = resolved.x;
-      win.y = resolved.y;
-    }
+    // A position command means "float HERE": always (re)anchor and resolve
+    // against the live canvas, including for a window the user has dragged
+    // (its anchor was cleared) -- the gate already decided this command is
+    // fresh, and a fresh float(x, y) applies unconditionally (§8/D52).
+    win.anchor = { x: reqX, y: reqY };
+    const resolved = resolveRequestedFloatPosition(
+      reqX,
+      reqY,
+      win.width,
+      pinnedPxOf(win.height) ?? 0,
+      bounds,
+    );
+    win.x = resolved.x;
+    win.y = resolved.y;
   };
 
   const position = placement.position;
@@ -2327,17 +2336,24 @@ export function applyPanelPlacement(
 
   // Size: width is region width when docked / window width when floating; height
   // only applies to a floating window. Neither op relocates the group, so one
-  // location lookup serves both.
-  if (placement.width !== null || placement.height !== null) {
+  // location lookup serves both. A height CLEAR (null) reverts a pinned window
+  // to auto-height; a width clear is a dock-level no-op (there is no stored
+  // "default width" here -- the control panel's theme-default width is applied
+  // by ControlPanelDock's own width effect).
+  if (placement.width != null || placement.height !== undefined) {
     const loc = findGroupLocation(draft, groupId);
-    if (loc?.kind === "docked" && placement.width !== null) {
+    if (loc?.kind === "docked" && placement.width != null) {
       draft = setRegionWidth(draft, loc.edge, placement.width);
     } else if (loc?.kind === "floating") {
-      if (placement.width !== null) {
+      if (placement.width != null) {
         draft = resizeWindow(draft, loc.windowId, placement.width);
       }
-      if (placement.height !== null) {
-        draft = resizeWindowHeight(draft, loc.windowId, placement.height);
+      if (placement.height !== undefined) {
+        draft = resizeWindowHeight(
+          draft,
+          loc.windowId,
+          placement.height ?? undefined,
+        );
       }
     }
   }

--- a/src/viser/client/src/dock/panelPlacement.test.ts
+++ b/src/viser/client/src/dock/panelPlacement.test.ts
@@ -38,8 +38,6 @@ const BOUNDS_1000 = {
 
 const EMPTY: PanelPlacement = {
   position: null,
-  width: null,
-  height: null,
   collapsed: null,
 };
 
@@ -698,7 +696,7 @@ describe("orphan groups are uncommittable from applyPanelPlacement", () => {
     layout = applyPanelPlacement(
       layout,
       ["p"],
-      { position: null, width: 333, height: null, collapsed: null },
+      { position: null, width: 333, collapsed: null },
       () => null,
       { canvasBounds: BOUNDS_1000 },
     );
@@ -807,7 +805,9 @@ describe("placement re-gathers tabs dragged out of the panel", () => {
 
 describe("re-placing an already-floating panel reuses its window", () => {
   const BOUNDS = { width: 1000, height: 800, leftInset: 0, rightInset: 0 };
-  const floatP = (l: DockLayout, height: number | null) =>
+  // An explicit position command (panel.float(x=80, y=80)), optionally with a
+  // size axis -- the bundle shape of a fresh float() call.
+  const floatP = (l: DockLayout, height?: number | null) =>
     applyPanelPlacement(
       l,
       ["p"],
@@ -820,15 +820,27 @@ describe("re-placing an already-floating panel reuses its window", () => {
       () => null,
       { canvasBounds: BOUNDS },
     );
+  // A size-only bundle, as the gate emits for a lone set_height: the position
+  // axis is stale/absent, so the bundle cannot move the panel by construction.
+  const sizeOnly = (l: DockLayout, height: number | null) =>
+    applyPanelPlacement(
+      l,
+      ["p"],
+      { position: null, height, collapsed: null },
+      () => null,
+      {
+        canvasBounds: BOUNDS,
+      },
+    );
 
   it("set_height keeps the SAME window id (no churn) and pins the height", () => {
-    let layout = floatP(emptyLayout(), null);
+    let layout = floatP(emptyLayout());
     expect(layout.floating).toHaveLength(1);
     const id = layout.floating[0].id;
     expect(pinnedPxOf(layout.floating[0].height)).toBeUndefined();
 
-    // set_height(450): same position+width, now a height.
-    layout = floatP(layout, 450);
+    // set_height(450) arrives alone (per-axis message; no position in the bundle).
+    layout = sizeOnly(layout, 450);
     expect(layout.floating).toHaveLength(1);
     expect(layout.floating[0].id).toBe(id); // window reused, not recreated
     expect(pinnedPxOf(layout.floating[0].height)).toBe(450);
@@ -836,32 +848,63 @@ describe("re-placing an already-floating panel reuses its window", () => {
   });
 
   it("a size-only re-placement does NOT move a user-dragged panel", () => {
-    let layout = floatP(emptyLayout(), null);
+    let layout = floatP(emptyLayout());
     const id = layout.floating[0].id;
     // User drags it elsewhere (moveWindow clears the anchor -> user-owned).
     layout = moveWindow(layout, id, 500, 400);
     expect(layout.floating[0].anchor).toBeUndefined();
     expect(layout.floating[0].x).toBe(500);
 
-    // Server set_height re-runs placement (position still float 80,80). The
-    // user's position must be preserved, not yanked back to the anchor.
-    layout = floatP(layout, 450);
+    // A lone set_height carries no position axis, so it cannot yank the
+    // window back to its old server anchor -- by construction.
+    layout = sizeOnly(layout, 450);
     expect(layout.floating[0].id).toBe(id);
     expect(pinnedPxOf(layout.floating[0].height)).toBe(450);
     expect(layout.floating[0].x).toBe(500);
     expect(layout.floating[0].y).toBe(400);
   });
+
+  it("a FRESH float(x, y) moves even a user-dragged window (D52)", () => {
+    let layout = floatP(emptyLayout());
+    const id = layout.floating[0].id;
+    layout = moveWindow(layout, id, 500, 400); // user takes control
+    expect(layout.floating[0].anchor).toBeUndefined();
+
+    // The server re-asserts by SENDING a new float(80, 80); the gate passed
+    // it as fresh, so it applies to touched and untouched panels alike --
+    // regression pin for the old userOwnsPosition guard that swallowed it.
+    layout = floatP(layout);
+    expect(layout.floating[0].id).toBe(id); // window still reused
+    expect(layout.floating[0].x).toBe(80);
+    expect(layout.floating[0].y).toBe(80);
+    expect(layout.floating[0].anchor).toEqual({ x: 80, y: 80 });
+  });
+
+  it("a fresh height CLEAR (null) reverts a pinned window to auto", () => {
+    let layout = floatP(emptyLayout());
+    layout = sizeOnly(layout, 450);
+    expect(pinnedPxOf(layout.floating[0].height)).toBe(450);
+
+    // gui.reset() sends height=None: "clears the override -> auto". null in
+    // the bundle is a command, not an absent axis (that is undefined).
+    layout = sizeOnly(layout, null);
+    expect(pinnedPxOf(layout.floating[0].height)).toBeUndefined();
+
+    // Same through the reuse branch (clear riding a fresh position command).
+    layout = sizeOnly(layout, 450);
+    layout = floatP(layout, null);
+    expect(pinnedPxOf(layout.floating[0].height)).toBeUndefined();
+  });
 });
 
 describe("re-placing an already-DOCKED panel applies the new size", () => {
-  const dockP = (l: DockLayout, width: number | null) =>
+  const dockP = (l: DockLayout, width?: number) =>
     applyPanelPlacement(
       l,
       ["p"],
       {
         position: { kind: "edge", edge: "right" },
         width,
-        height: null,
         collapsed: null,
       },
       () => null,
@@ -871,7 +914,7 @@ describe("re-placing an already-DOCKED panel applies the new size", () => {
     // Regression: re-applying the edge placement used to detach+recreate the
     // leaf, giving it a new node id, so the width reconciler treated it as a new
     // column and reset the width to default -- silently dropping set_width.
-    let layout = dockP(emptyLayout(), null);
+    let layout = dockP(emptyLayout());
     const nodeId = (
       findGroupLocation(layout, findPaneGroup(layout, "p")!) as {
         nodeId: string;

--- a/src/viser/client/src/dock/types.ts
+++ b/src/viser/client/src/dock/types.ts
@@ -154,7 +154,7 @@ export const HANDLE_BTN_EM = 1.7;
  * divider from the per-side gap is what keeps the flanks equal by
  * construction -- a flat divider constant drifted them apart (3px total
  * meant 1px flanks beside 3px edge gutters). */
-export const DOCK_GAP_PX = 2;
+const DOCK_GAP_PX = 2;
 
 /** Layout footprint of a divider between two panes: a boundary rule with the
  * standard gap on each flank (see DOCK_GAP_PX). */

--- a/src/viser/client/src/mesh/SkinnedMesh.tsx
+++ b/src/viser/client/src/mesh/SkinnedMesh.tsx
@@ -3,7 +3,7 @@ import * as THREE from "three";
 import { ViserStandardMeshMaterial, ShadowSkinnedMesh } from "./MeshUtils";
 import { SkinnedMeshMessage } from "../WebsocketMessages";
 import { OutlinesIfHovered } from "../OutlinesIfHovered";
-import { ViewerContext } from "../ViewerContext";
+import { ViewerContext, ViewerMutable } from "../ViewerContext";
 import { useFrame } from "@react-three/fiber";
 import { normalizeScale } from "../utils/normalizeScale";
 
@@ -21,6 +21,16 @@ export const SkinnedMesh = React.forwardRef<
 
   // Reference to bones for animation updates.
   const bonesRef = React.useRef<THREE.Bone[]>();
+  // The exact skinnedMeshState entry this instance has claimed (set by the
+  // init effect below). MessageHandler builds a FRESH entry object per
+  // SkinnedMeshMessage, so on a same-tick delete + re-add of the same name a
+  // pending-unmount instance -- whose effects never re-run -- sees an entry it
+  // never claimed and must not touch it, even when the bone count happens to
+  // match (initializing it with OUR bones would block the replacement
+  // instance's own setup). A live instance re-claims on every prop update.
+  const ownedEntryRef = React.useRef<
+    ViewerMutable["skinnedMeshState"][string] | null
+  >(null);
 
   // Create geometry and skeleton using memoization.
   const { geometry, skeleton } = React.useMemo(() => {
@@ -105,6 +115,7 @@ export const SkinnedMesh = React.forwardRef<
     // WebsocketInterface), so guard reads like the bone-message handlers do.
     const state = viewerMutable.skinnedMeshState[message.name];
     if (state !== undefined) state.initialized = false;
+    ownedEntryRef.current = state ?? null;
     // The bones for this skeleton (added to the parent node imperatively in
     // useFrame below). Captured here so the cleanup can remove exactly these on
     // a skeleton change / unmount -- otherwise a re-added skinned mesh leaks its
@@ -135,12 +146,15 @@ export const SkinnedMesh = React.forwardRef<
     // so throwing here would skip the remaining subscribers and gl.render.
     const state = viewerMutable.skinnedMeshState[message.name];
     if (state === undefined) return;
+    // Identity guard for same-tick delete + re-add of the same name: only the
+    // instance whose init effect claimed THIS entry may touch it (see
+    // ownedEntryRef). A pending-unmount instance fails this check even when
+    // the replacement skeleton's bone count matches its own.
+    if (state !== ownedEntryRef.current) return;
     const bones = bonesRef.current;
-    // A same-tick delete + re-add (subtree removal or reconnect replay, then a
-    // SkinnedMeshMessage for the same name) can swap in an entry for a REBUILT
-    // skeleton with a different bone count while this instance's unmount is
-    // still pending. Initializing or posing OUR bones against that entry would
-    // index poses out of bounds -- the remounted instance owns the new entry.
+    // Belt over the identity guard: never index poses beyond our bones (a
+    // mismatched entry would crash the R3F subscriber loop and kill
+    // gl.render for the frame).
     if (state.poses.length !== (bones?.length ?? 0)) return;
     if (skeleton !== undefined && bones !== undefined) {
       if (!state.initialized) {

--- a/src/viser/client/src/mesh/SkinnedMesh.tsx
+++ b/src/viser/client/src/mesh/SkinnedMesh.tsx
@@ -100,8 +100,11 @@ export const SkinnedMesh = React.forwardRef<
 
   // Clean up geometry and skeleton when they change (they're created together).
   React.useEffect(() => {
+    // The state entry can be deleted while this component is still mounted
+    // (subtree-prefix removal in MessageHandler, reconnect clearing in
+    // WebsocketInterface), so guard reads like the bone-message handlers do.
     const state = viewerMutable.skinnedMeshState[message.name];
-    state.initialized = false;
+    if (state !== undefined) state.initialized = false;
     // The bones for this skeleton (added to the parent node imperatively in
     // useFrame below). Captured here so the cleanup can remove exactly these on
     // a skeleton change / unmount -- otherwise a re-added skinned mesh leaks its
@@ -125,7 +128,13 @@ export const SkinnedMesh = React.forwardRef<
 
   // Update bone transforms for animation.
   useFrame(() => {
+    // The state entry can be deleted before our unmount commits: subtree
+    // removal and reconnect clearing both run in the message handler's
+    // useFrame (priority -100000) earlier in the same rAF tick, while this
+    // subscriber is still registered. R3F's subscriber loop has no try/catch,
+    // so throwing here would skip the remaining subscribers and gl.render.
     const state = viewerMutable.skinnedMeshState[message.name];
+    if (state === undefined) return;
     const bones = bonesRef.current;
     if (skeleton !== undefined && bones !== undefined) {
       if (!state.initialized) {

--- a/src/viser/client/src/mesh/SkinnedMesh.tsx
+++ b/src/viser/client/src/mesh/SkinnedMesh.tsx
@@ -136,6 +136,12 @@ export const SkinnedMesh = React.forwardRef<
     const state = viewerMutable.skinnedMeshState[message.name];
     if (state === undefined) return;
     const bones = bonesRef.current;
+    // A same-tick delete + re-add (subtree removal or reconnect replay, then a
+    // SkinnedMeshMessage for the same name) can swap in an entry for a REBUILT
+    // skeleton with a different bone count while this instance's unmount is
+    // still pending. Initializing or posing OUR bones against that entry would
+    // index poses out of bounds -- the remounted instance owns the new entry.
+    if (state.poses.length !== (bones?.length ?? 0)) return;
     if (skeleton !== undefined && bones !== undefined) {
       if (!state.initialized) {
         const parentNode = viewerMutable.nodeRefFromName[message.name];

--- a/src/viser/client/src/mesh/SkinnedMesh.tsx
+++ b/src/viser/client/src/mesh/SkinnedMesh.tsx
@@ -146,10 +146,8 @@ export const SkinnedMesh = React.forwardRef<
     // so throwing here would skip the remaining subscribers and gl.render.
     const state = viewerMutable.skinnedMeshState[message.name];
     if (state === undefined) return;
-    // Identity guard for same-tick delete + re-add of the same name: only the
-    // instance whose init effect claimed THIS entry may touch it (see
-    // ownedEntryRef). A pending-unmount instance fails this check even when
-    // the replacement skeleton's bone count matches its own.
+    // Only the instance whose init effect claimed THIS entry may touch it
+    // (see ownedEntryRef above for the same-name delete + re-add race).
     if (state !== ownedEntryRef.current) return;
     const bones = bonesRef.current;
     // Belt over the identity guard: never index poses beyond our bones (a

--- a/src/viser/client/src/utils/outlineGeometry.test.ts
+++ b/src/viser/client/src/utils/outlineGeometry.test.ts
@@ -1,0 +1,73 @@
+// Pins the ownership contract of buildOutlineGeometry against three-stdlib's
+// toCreasedNormals, whose subtle behavior caused a real dispose-of-shared-
+// geometry bug: it returns its INPUT object unchanged (and rewrites its
+// normal attribute in place) when the input is already non-indexed, so
+// "angle != 0 => we own a fresh clone" is false without the clone step.
+
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import { toCreasedNormals } from "three-stdlib";
+import { buildOutlineGeometry } from "./outlineGeometry";
+
+/** A unit quad as two indexed triangles. */
+function indexedGeometry(): THREE.BufferGeometry {
+  const g = new THREE.BufferGeometry();
+  g.setAttribute(
+    "position",
+    new THREE.BufferAttribute(
+      new Float32Array([0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0]),
+      3,
+    ),
+  );
+  g.setIndex([0, 1, 2, 0, 2, 3]);
+  g.computeVertexNormals();
+  return g;
+}
+
+function nonIndexedGeometry(): THREE.BufferGeometry {
+  const g = indexedGeometry().toNonIndexed();
+  g.computeVertexNormals();
+  return g;
+}
+
+describe("buildOutlineGeometry ownership", () => {
+  it("angle 0: shares the parent's geometry, not owned", () => {
+    const parent = indexedGeometry();
+    const built = buildOutlineGeometry(parent, 0);
+    expect(built.geometry).toBe(parent);
+    expect(built.owned).toBe(false);
+  });
+
+  it("indexed parent: creased result is a fresh owned object", () => {
+    const parent = indexedGeometry();
+    const built = buildOutlineGeometry(parent, Math.PI);
+    expect(built.geometry).not.toBe(parent);
+    expect(built.owned).toBe(true);
+  });
+
+  it("NON-indexed parent: still owned, and the parent is untouched", () => {
+    // The library premise this module exists to fence: toCreasedNormals
+    // returns a non-indexed input as-is. If a three-stdlib upgrade changes
+    // this, the clone in buildOutlineGeometry becomes redundant but stays
+    // correct; if this test starts failing here, re-derive the ownership
+    // rules before touching the clone.
+    const raw = nonIndexedGeometry();
+    expect(toCreasedNormals(raw, Math.PI)).toBe(raw);
+
+    const parent = nonIndexedGeometry();
+    const normalsBefore = Array.from(
+      (parent.getAttribute("normal") as THREE.BufferAttribute).array,
+    );
+    const built = buildOutlineGeometry(parent, Math.PI);
+    expect(built.geometry).not.toBe(parent);
+    expect(built.owned).toBe(true);
+    // Creasing mutates normals in place on its input; the clone must have
+    // absorbed that so the parent's live normals are unchanged.
+    expect(
+      Array.from(
+        (parent.getAttribute("normal") as THREE.BufferAttribute).array,
+      ),
+    ).toEqual(normalsBefore);
+    built.geometry.dispose();
+  });
+});

--- a/src/viser/client/src/utils/outlineGeometry.ts
+++ b/src/viser/client/src/utils/outlineGeometry.ts
@@ -1,0 +1,20 @@
+import * as THREE from "three";
+import { toCreasedNormals } from "three-stdlib";
+
+/** Build the geometry for an outline mesh: the parent's geometry as-is when
+ * `angle` is 0, else a creased-normals copy the CALLER owns (and must
+ * dispose). Owned is derived from identity, never inferred from `angle`:
+ * three-stdlib's toCreasedNormals returns its input object unchanged -- and
+ * mutates its normal attribute in place -- when the input is already
+ * non-indexed, so a non-indexed parent is cloned first to keep the result
+ * privately owned and the parent's normals untouched. */
+export function buildOutlineGeometry(
+  parentGeometry: THREE.BufferGeometry,
+  angle: number,
+): { geometry: THREE.BufferGeometry; owned: boolean } {
+  if (angle === 0) return { geometry: parentGeometry, owned: false };
+  const source =
+    parentGeometry.index === null ? parentGeometry.clone() : parentGeometry;
+  const geometry = toCreasedNormals(source, angle);
+  return { geometry, owned: geometry !== parentGeometry };
+}

--- a/src/viser/client/src/utils/pointCloudGeometry.test.ts
+++ b/src/viser/client/src/utils/pointCloudGeometry.test.ts
@@ -58,66 +58,25 @@ describe("syncPointCloudGeometry", () => {
   // leftover attribute costs bandwidth every render and serves stale data if
   // per-point colors come back at a matching length.
   describe("per-point -> uniform color transition", () => {
-    // Minimal model of three's WebGLAttributes + WebGLGeometries.onGeometryDispose
-    // (same shape as the one in bufferGeometrySync.test.ts): buffers are freed
-    // ONLY via the geometry 'dispose' event, and only for attributes still
-    // present on the geometry when it fires.
-    function makeFakeRenderer(geometry: THREE.BufferGeometry) {
-      const uploaded = new Map<object, { size: number; version: number }>();
-      let deleteBufferCalls = 0;
-      geometry.addEventListener("dispose", () => {
-        for (const name in geometry.attributes) {
-          const attr = geometry.attributes[name];
-          if (uploaded.has(attr)) {
-            uploaded.delete(attr);
-            deleteBufferCalls++;
-          }
-        }
-      });
-      return {
-        render() {
-          for (const name in geometry.attributes) {
-            const attr = geometry.attributes[name] as THREE.BufferAttribute;
-            const cached = uploaded.get(attr);
-            if (cached === undefined) {
-              uploaded.set(attr, {
-                size: attr.array.byteLength,
-                version: attr.version,
-              });
-            } else if (cached.version < attr.version) {
-              if (cached.size !== attr.array.byteLength) {
-                throw new Error(
-                  "THREE.WebGLAttributes: Resizing buffer attributes is not supported.",
-                );
-              }
-              cached.version = attr.version;
-            }
-          }
-        },
-        liveBufferCount: () => uploaded.size,
-        deleteBufferCalls: () => deleteBufferCalls,
-      };
-    }
-
     it("removes the stale color attribute (same point count)", () => {
       const geom = new THREE.BufferGeometry();
-      const gpu = makeFakeRenderer(geom);
-
-      // Per-point colors: both attributes registered and uploaded.
       syncPointCloudGeometry(geom, new Float32Array(6), new Uint8Array(6));
-      gpu.render();
-      expect(geom.hasAttribute("color")).toBe(true);
-      expect(gpu.liveBufferCount()).toBe(2);
+      const staleColor = geom.getAttribute("color");
+      expect(staleColor).toBeDefined();
 
-      // Uniform color, same point count.
+      // three frees GL buffers only via the geometry 'dispose' event, and
+      // only for attributes still registered when it fires -- so dispose must
+      // run BEFORE deleteAttribute or the color buffer is stranded until GC.
+      // A listener pins both facts: it must fire (false if not), and the
+      // stale attribute must still be present when it does.
+      let colorPresentAtDispose = false;
+      geom.addEventListener("dispose", () => {
+        colorPresentAtDispose = geom.getAttribute("color") === staleColor;
+      });
+
       syncPointCloudGeometry(geom, new Float32Array(6), new Uint8Array(3));
+      expect(colorPresentAtDispose).toBe(true);
       expect(geom.hasAttribute("color")).toBe(false);
-      expect(() => gpu.render()).not.toThrow();
-      // Dispose fired BEFORE deleteAttribute, so the color GL buffer was
-      // deterministically freed (not stranded until GC); position was then
-      // re-uploaded into a fresh buffer.
-      expect(gpu.deleteBufferCalls()).toBe(2);
-      expect(gpu.liveBufferCount()).toBe(1); // position only
     });
 
     it("removes the stale color attribute (point count also changed)", () => {

--- a/src/viser/client/src/utils/pointCloudGeometry.test.ts
+++ b/src/viser/client/src/utils/pointCloudGeometry.test.ts
@@ -51,4 +51,94 @@ describe("syncPointCloudGeometry", () => {
     syncPointCloudGeometry(geom, new Uint16Array(6), new Uint8Array(6)); // float16
     expect(geom.getAttribute("position")).not.toBe(pos1);
   });
+
+  // Regression: switching per-point colors -> uniform (3-length) colors must
+  // remove the stale N-length 'color' attribute. three.js re-uploads every
+  // registered attribute regardless of whether the material samples it, so a
+  // leftover attribute costs bandwidth every render and serves stale data if
+  // per-point colors come back at a matching length.
+  describe("per-point -> uniform color transition", () => {
+    // Minimal model of three's WebGLAttributes + WebGLGeometries.onGeometryDispose
+    // (same shape as the one in bufferGeometrySync.test.ts): buffers are freed
+    // ONLY via the geometry 'dispose' event, and only for attributes still
+    // present on the geometry when it fires.
+    function makeFakeRenderer(geometry: THREE.BufferGeometry) {
+      const uploaded = new Map<object, { size: number; version: number }>();
+      let deleteBufferCalls = 0;
+      geometry.addEventListener("dispose", () => {
+        for (const name in geometry.attributes) {
+          const attr = geometry.attributes[name];
+          if (uploaded.has(attr)) {
+            uploaded.delete(attr);
+            deleteBufferCalls++;
+          }
+        }
+      });
+      return {
+        render() {
+          for (const name in geometry.attributes) {
+            const attr = geometry.attributes[name] as THREE.BufferAttribute;
+            const cached = uploaded.get(attr);
+            if (cached === undefined) {
+              uploaded.set(attr, {
+                size: attr.array.byteLength,
+                version: attr.version,
+              });
+            } else if (cached.version < attr.version) {
+              if (cached.size !== attr.array.byteLength) {
+                throw new Error(
+                  "THREE.WebGLAttributes: Resizing buffer attributes is not supported.",
+                );
+              }
+              cached.version = attr.version;
+            }
+          }
+        },
+        liveBufferCount: () => uploaded.size,
+        deleteBufferCalls: () => deleteBufferCalls,
+      };
+    }
+
+    it("removes the stale color attribute (same point count)", () => {
+      const geom = new THREE.BufferGeometry();
+      const gpu = makeFakeRenderer(geom);
+
+      // Per-point colors: both attributes registered and uploaded.
+      syncPointCloudGeometry(geom, new Float32Array(6), new Uint8Array(6));
+      gpu.render();
+      expect(geom.hasAttribute("color")).toBe(true);
+      expect(gpu.liveBufferCount()).toBe(2);
+
+      // Uniform color, same point count.
+      syncPointCloudGeometry(geom, new Float32Array(6), new Uint8Array(3));
+      expect(geom.hasAttribute("color")).toBe(false);
+      expect(() => gpu.render()).not.toThrow();
+      // Dispose fired BEFORE deleteAttribute, so the color GL buffer was
+      // deterministically freed (not stranded until GC); position was then
+      // re-uploaded into a fresh buffer.
+      expect(gpu.deleteBufferCalls()).toBe(2);
+      expect(gpu.liveBufferCount()).toBe(1); // position only
+    });
+
+    it("removes the stale color attribute (point count also changed)", () => {
+      const geom = new THREE.BufferGeometry();
+      syncPointCloudGeometry(
+        geom,
+        new Float32Array(3000),
+        new Uint8Array(3000),
+      );
+      syncPointCloudGeometry(geom, new Float32Array(900), new Uint8Array(3));
+      expect(geom.hasAttribute("color")).toBe(false);
+      expect(geom.getAttribute("position").count).toBe(300);
+    });
+
+    it("re-adds the color attribute when per-point colors return", () => {
+      const geom = new THREE.BufferGeometry();
+      syncPointCloudGeometry(geom, new Float32Array(6), new Uint8Array(3));
+      expect(geom.hasAttribute("color")).toBe(false);
+      syncPointCloudGeometry(geom, new Float32Array(6), new Uint8Array(6));
+      expect(geom.hasAttribute("color")).toBe(true);
+      expect(geom.getAttribute("color").count).toBe(2);
+    });
+  });
 });

--- a/src/viser/client/src/utils/pointCloudGeometry.ts
+++ b/src/viser/client/src/utils/pointCloudGeometry.ts
@@ -25,5 +25,20 @@ export function syncPointCloudGeometry(
     console.error(`Invalid color buffer length, got ${colors.length}`);
   }
 
+  // Per-point -> uniform color transition: drop the stale per-point 'color'
+  // attribute. three.js re-uploads every registered attribute regardless of
+  // whether the material samples it, so leaving it registered costs bandwidth
+  // every render (and serves stale data if per-point colors come back at a
+  // matching length). Dispose BEFORE deleting: three only frees an
+  // attribute's GL buffer via the geometry 'dispose' event, which walks the
+  // attributes still present on the geometry -- deleteAttribute alone would
+  // strand the GL buffer until the JS GC happens to reclaim the wrapper. The
+  // surviving position attribute is re-uploaded into a fresh buffer on the
+  // next render (same one-time cost as any realloc; this transition is rare).
+  if (attributes.color === undefined && geometry.hasAttribute("color")) {
+    geometry.dispose();
+    geometry.deleteAttribute("color");
+  }
+
   syncBufferGeometry(geometry, attributes);
 }

--- a/src/viser/infra/_infra.py
+++ b/src/viser/infra/_infra.py
@@ -343,7 +343,14 @@ class WebsockServer(WebsockMessageHandler):
     ):
         """`backlog_done_message`, when given, is sent to each (re)connecting
         client exactly once, immediately after the broadcast buffer's replay
-        backlog -- an explicit end-of-replay marker (never buffered)."""
+        backlog -- an explicit end-of-replay marker (never buffered).
+
+        Servers serving viser's stock client build MUST pass viser's
+        ``ReplayDoneMessage`` here: the client enters a reconnect/replay phase
+        on every (re)connect and leaves it only when this marker arrives, so
+        with the ``None`` default it never exits that phase (degraded panel
+        behavior). ``ViserServer`` does this automatically; it only needs
+        attention when building directly on ``viser.infra.WebsockServer``."""
         super().__init__()
 
         # Track connected clients.

--- a/tests/e2e/test_panel_layout_persistence.py
+++ b/tests/e2e/test_panel_layout_persistence.py
@@ -196,12 +196,22 @@ def test_set_width_after_user_move_does_not_redock(
         f"set_width re-docked a user-moved panel (stale position re-applied): {after}"
     )
     # The width itself DID apply (to the floating window) -- the gate lets the
-    # fresh axis through while blocking the stale one.
-    width = viser_page.eval_on_selector(
-        "[data-floating-window]",
-        "e => Math.round(e.getBoundingClientRect().width)",
+    # fresh axis through while blocking the stale one. Measure THIS panel's
+    # window via its tab label: a bare [data-floating-window] first-match is
+    # order-fragile (windows render sorted by id, ids are lexicographic
+    # "window-<n>", and the control panel's float is also in the DOM), so it
+    # can silently measure the control panel instead.
+    width = viser_page.evaluate(
+        """() => {
+            const t = [...document.querySelectorAll('[data-dock-tab]')]
+                .find((e) => e.textContent.includes('Persisty'));
+            const w = t && t.closest('[data-floating-window]');
+            return w ? Math.round(w.getBoundingClientRect().width) : null;
+        }"""
     )
-    assert abs(width - 444) <= 2, f"width axis was not applied: {width}"
+    assert width is not None and abs(width - 444) <= 2, (
+        f"width axis was not applied: {width}"
+    )
 
 
 def test_removed_then_readded_panel_does_not_inherit_touched_state(

--- a/tests/test_handle_lifecycle_bugs.py
+++ b/tests/test_handle_lifecycle_bugs.py
@@ -321,10 +321,16 @@ def test_rgb_value_normalizes_floats() -> None:
         # wild value (e.g. a float 255.0 must not become 65025) -- AND float
         # channels > 1.0 warn: pre-1.1.0 float [0, 255] inputs passed through
         # unchanged, so old code silently clamping to white needs a signpost.
-        with pytest.warns(UserWarning, match=r"\[0, 1\]"):
+        with pytest.warns(UserWarning, match=r"\[0, 1\]") as record:
             assert server.gui.add_rgb("e", (255.0, 1.2, -0.1)).value == (255, 255, 0)  # type: ignore[arg-type]
-        with pytest.warns(UserWarning, match=r"\[0, 1\]"):
+        # The warning must point at USER code (this file), not at viser
+        # internals or the deprecated_positional_shim wrapper -- each call
+        # path threads its own warn_stacklevel and a wrong depth silently
+        # blames the wrong frame.
+        assert record[0].filename == __file__
+        with pytest.warns(UserWarning, match=r"\[0, 1\]") as record:
             rgb.value = np.array([2.0, -5.0, 0.5])
+        assert record[0].filename == __file__
         assert rgb.value == (255, 0, 127)
         # In-range floats stay silent.
         with warnings.catch_warnings():

--- a/tests/test_handle_lifecycle_bugs.py
+++ b/tests/test_handle_lifecycle_bugs.py
@@ -318,10 +318,32 @@ def test_rgb_value_normalizes_floats() -> None:
         assert rgb.value == (1, 2, 3)
 
         # Out-of-range channels are clamped to [0, 255] rather than producing a
-        # wild value (e.g. a float 255.0 must not become 65025).
-        assert server.gui.add_rgb("e", (255.0, 1.2, -0.1)).value == (255, 255, 0)  # type: ignore[arg-type]
-        rgb.value = np.array([2.0, -5.0, 0.5])
+        # wild value (e.g. a float 255.0 must not become 65025) -- AND float
+        # channels > 1.0 warn: pre-1.1.0 float [0, 255] inputs passed through
+        # unchanged, so old code silently clamping to white needs a signpost.
+        with pytest.warns(UserWarning, match=r"\[0, 1\]"):
+            assert server.gui.add_rgb("e", (255.0, 1.2, -0.1)).value == (255, 255, 0)  # type: ignore[arg-type]
+        with pytest.warns(UserWarning, match=r"\[0, 1\]"):
+            rgb.value = np.array([2.0, -5.0, 0.5])
         assert rgb.value == (255, 0, 127)
+        # In-range floats stay silent.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            rgb.value = np.array([0.25, 1.0, 0.0])
+        assert rgb.value == (63, 255, 0)
+
+
+def test_numpy_assignment_to_int_tuple_rounds_not_truncates() -> None:
+    """Assigning float numpy values to an int-typed tuple handle must round to
+    the nearest integer, not truncate toward zero (int(2.9) == 2). Rounding
+    uses the round() builtin, i.e. round-half-even."""
+    with _server() as server:
+        ms = server.gui.add_multi_slider(
+            "m", min=0, max=20, step=1, initial_value=(0, 1)
+        )
+        ms.value = np.array([2.9, 9.999])
+        assert ms.value == (3, 10)
+        assert all(type(x) is int for x in ms.value)
 
 
 def test_gui_container_target_is_per_instance() -> None:
@@ -405,6 +427,61 @@ def test_gaussian_splat_subprop_update_does_not_alias_buffer() -> None:
         # already-queued message must stay untouched.
         s.centers = np.full((n, 3), 7.0, np.float32)
         assert np.array_equal(queued, before)
+
+
+def test_upload_part_after_button_removal_still_acks_and_completes() -> None:
+    """A FileTransferPart arriving after button.remove() mid-upload must not
+    assert (the handle is legitimately gone from the registry): parts keep
+    being buffered and acked, and completion pops the transfer state (no leak)
+    while _finish_file_upload no-ops on the removed handle."""
+    with _server() as server:
+        btn = server.gui.add_upload_button("up")
+        uuid = btn._impl.uuid
+
+        server.gui._handle_file_transfer_start(
+            ClientId(0),
+            _messages.FileTransferStartUpload(
+                source_component_uuid=uuid,
+                transfer_uuid="t1",
+                filename="a.bin",
+                mime_type="application/octet-stream",
+                part_count=2,
+                size_bytes=8,
+            ),
+        )
+        server.gui._handle_file_transfer_part(
+            ClientId(0),
+            _messages.FileTransferPart(
+                source_component_uuid=uuid,
+                transfer_uuid="t1",
+                part_index=0,
+                content=b"1234",
+            ),
+        )
+        btn.remove()  # Mid-upload removal.
+        # The next part must not raise; it is still acked and completes the
+        # transfer.
+        server.gui._handle_file_transfer_part(
+            ClientId(0),
+            _messages.FileTransferPart(
+                source_component_uuid=uuid,
+                transfer_uuid="t1",
+                part_index=1,
+                content=b"5678",
+            ),
+        )
+
+        # Transfer state was popped by completion -> no permanent leak.
+        assert "t1" not in server.gui._current_file_upload_states
+        # The final ack (all bytes) was queued despite the removed handle.
+        buf = server._websock_server._broadcast_buffer.message_from_id
+        acks = [
+            msg
+            for msg in buf.values()
+            if isinstance(msg, _messages.FileTransferPartAck)
+            and msg.transfer_uuid == "t1"
+        ]
+        assert acks and acks[-1].transferred_bytes == 8
 
 
 def test_zero_byte_upload_completes() -> None:

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -9,9 +9,12 @@ raises as specified.
 
 from __future__ import annotations
 
+import threading
 import warnings
 from typing import Any
 from unittest.mock import patch
+
+import pytest
 
 import viser
 import viser._client_autobuild
@@ -369,6 +372,144 @@ def test_reset_clears_main_panel_collapsed() -> None:
         assert (
             _latest(server, CONTROL_PANEL_ID, m.GuiSetPanelCollapsedMessage).collapsed
             is False
+        )
+    finally:
+        server.stop()
+
+
+def test_client_scoped_reset_does_not_touch_main_panel_placement() -> None:
+    """client.gui.reset() resets the GUI elements it owns but must NOT reset
+    the main panel's placement: a client-scoped GuiApi mints its own run_id,
+    which the client's placement gate treats as a fresh deliberate command --
+    so the default CONTROL_PANEL_ID messages would clobber server-authored
+    placement (e.g. undock a dock_left control panel) for that one client."""
+    from viser._viser import ClientHandle
+    from viser.infra._async_message_buffer import AsyncMessageBuffer
+    from viser.infra._infra import WebsockClientConnection, _ClientHandleState
+
+    server = _make_server()
+    try:
+        server.gui.main_panel.dock_left()
+
+        # Synthetic in-process client connection: no websocket needed, we only
+        # inspect the outgoing per-client message buffer (mirrors how
+        # WebsockServer constructs the per-client state).
+        buffer = AsyncMessageBuffer(server._event_loop, persistent_messages=False)
+        conn = WebsockClientConnection(
+            0, _ClientHandleState(buffer, server._event_loop)
+        )
+        client = ClientHandle(conn, server)
+
+        client.gui.add_button("local")
+        client.gui.reset()
+
+        # The client-scoped reset drained its own GUI elements...
+        root = client.gui._container_handle_from_uuid["root"]
+        assert root._children == {}
+        # ...but queued NO main-panel placement messages on the per-client
+        # connection.
+        placement_types = (
+            m.GuiSetPanelPositionMessage,
+            m.GuiSetPanelWidthMessage,
+            m.GuiSetPanelHeightMessage,
+            m.GuiSetPanelCollapsedMessage,
+        )
+        assert not any(
+            isinstance(msg, placement_types) for msg in buffer.message_from_id.values()
+        )
+        # The server-authored broadcast placement is untouched by the
+        # client-scoped reset...
+        assert _latest(
+            server, CONTROL_PANEL_ID, m.GuiSetPanelPositionMessage
+        ).position == {"kind": "edge", "edge": "left"}
+        # ...while a server-scoped reset still resets it to the default.
+        server.gui.reset()
+        assert _latest(
+            server, CONTROL_PANEL_ID, m.GuiSetPanelPositionMessage
+        ).position == {"kind": "float", "x": None, "y": None}
+    finally:
+        server.stop()
+
+
+@pytest.mark.filterwarnings("ignore:Attempted to remove an already removed")
+def test_concurrent_panel_remove_single_winner() -> None:
+    """Two concurrent remove() calls must resolve to exactly one winner: the
+    loser warns (filtered above; warnings state is global, so per-thread
+    catch_warnings would race) and returns. Regression: the tombstone check ran
+    before the lifecycle lock was taken and was never re-checked inside, so
+    both racers could pass and the loser's registry pop raised KeyError (which
+    would also abort a gui.reset() mid-drain)."""
+    server = _make_server()
+    try:
+        for _ in range(20):
+            panel = server.gui.add_panel()
+            uuid = panel._impl.uuid
+            barrier = threading.Barrier(2)
+            errors: list[BaseException] = []
+
+            def racer(p: viser.PanelHandle = panel) -> None:
+                try:
+                    barrier.wait()
+                    p.remove()
+                except BaseException as e:  # pragma: no cover - failure path
+                    errors.append(e)
+
+            threads = [threading.Thread(target=racer) for _ in range(2)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            assert errors == [], errors
+            assert uuid not in server.gui._panel_handle_from_uuid
+            # Exactly the remove tombstone remains buffered for the panel.
+            assert _buffered_types(server, uuid) == {m.GuiPanelRemoveMessage}
+    finally:
+        server.stop()
+
+
+def test_panel_double_remove_warns_and_noops() -> None:
+    """A second remove() on the same handle warns and returns (no KeyError,
+    no duplicate remove message)."""
+    server = _make_server()
+    try:
+        panel = server.gui.add_panel()
+        panel.remove()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            panel.remove()
+        assert any("already removed" in str(w.message) for w in caught)
+    finally:
+        server.stop()
+
+
+def test_queue_placement_rechecks_anchor_under_lock() -> None:
+    """dock_above/dock_below validate the anchor in _resolve_anchor_uuid BEFORE
+    the lifecycle lock is taken; _queue_placement must re-check `removed` under
+    the lock, or an anchor.remove() in between persists a split placement
+    referencing a dead anchor uuid in the replay buffer. Simulate the
+    interleaving by running the two stages with the removal in between."""
+    server = _make_server()
+    try:
+        anchor = server.gui.add_panel()
+        panel = server.gui.add_panel()
+        # Stage 1: the pre-lock check passes while the anchor is alive.
+        anchor_uuid = panel._resolve_anchor_uuid(anchor)
+        # The anchor is removed between the check and the enqueue.
+        anchor.remove()
+        # Stage 2: the locked enqueue must reject with the same ValueError the
+        # sequential path promises.
+        try:
+            panel._set_position(
+                {"kind": "split", "anchor_uuid": anchor_uuid, "side": "below"},
+                anchor=anchor,
+            )
+            assert False, "expected ValueError"
+        except ValueError as e:
+            assert "removed" in str(e)
+        # No split placement referencing the dead anchor was buffered.
+        assert m.GuiSetPanelPositionMessage not in _buffered_types(
+            server, panel._impl.uuid
         )
     finally:
         server.stop()

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -9,6 +9,7 @@ raises as specified.
 
 from __future__ import annotations
 
+import asyncio
 import threading
 import warnings
 from typing import Any
@@ -393,8 +394,17 @@ def test_client_scoped_reset_does_not_touch_main_panel_placement() -> None:
 
         # Synthetic in-process client connection: no websocket needed, we only
         # inspect the outgoing per-client message buffer (mirrors how
-        # WebsockServer constructs the per-client state).
-        buffer = AsyncMessageBuffer(server._event_loop, persistent_messages=False)
+        # WebsockServer constructs the per-client state). Constructed ON the
+        # server's loop thread: AsyncMessageBuffer's asyncio.Event fields bind
+        # to the current event loop at construction on Python <= 3.9, and this
+        # test thread has none (production buffers are always built inside the
+        # loop, so only the test needs the hop).
+        async def _make_buffer() -> AsyncMessageBuffer:
+            return AsyncMessageBuffer(server._event_loop, persistent_messages=False)
+
+        buffer = asyncio.run_coroutine_threadsafe(
+            _make_buffer(), server._event_loop
+        ).result(timeout=5.0)
         conn = WebsockClientConnection(
             0, _ClientHandleState(buffer, server._event_loop)
         )


### PR DESCRIPTION
This PR includes fixes from auditing `v1.0.30..main`:
* `float(x, y)` now always applies. Removed the `userOwnsPosition` guard, which could swallow new repositioning commands (spec §8/D52).
* Width and height can now be cleared back to their defaults through `gui.reset()`. Bundle axes are now tri-state: absent, clear, or set. Pinned windows correctly return to automatic sizing.
* Floating stack divider push-through budgets are now calculated in rendered pixels. Scale-free weights were previously interpreted as pixels, causing the window to grow instead of shrinking its cells.
* Added a guard and entry-identity check for `SkinnedMesh` to prevent render-loop crashes when a subtree is removed, re-added, or reconnected within the same tick.
* `GaussianSplats` now waits for the sorter module before construction, preventing a double-`Sorter` WASM heap leak during rapid buffer updates.
* Outline geometry ownership is now tracked by identity because `toCreasedNormals` can alias non-indexed input. Also fixed unmount disposal, which was previously dead code because React clears refs before passive cleanup.
* Point clouds now dispose of stale per-point color attributes when switching to a uniform color.
* Fixed races in `PanelHandle.remove()` using an atomic tombstone, as well as the dead-anchor split race.
* Client-scoped `reset()` no longer overwrites the main panel’s placement.
* Removed an upload-part assertion that could stall the client and leak transfer state if the upload button was removed mid-transfer.
* Float color channels above `1` now emit a warning. Previously, applying `[0,1]` scaling to legacy `[0,255]` float values silently produced white.
* NumPy-to-integer-tuple assignments now round values instead of truncating them.
* Regenerated the example documentation. The panels example was missing its page and gallery entry, and stale RST documentation still referenced `control_layout`.
* Fixed the script name in the documentation README.
* Cleaned up a stale counter docstring, deduplicated index clamping, removed unused exports, made registry removal strict, and simplified tests.