### PR TITLE
Wait longer for the server thread on shutdown to avoid nanobind leak warnings

### DIFF
--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
 import dataclasses
 import io
 import mimetypes
@@ -1058,6 +1059,16 @@ class ViserServer(DeprecatedAttributeShim if not TYPE_CHECKING else object):
 
         # Start the server.
         server.start()
+        # server.start() registered the infra-level WebsockServer.stop with
+        # atexit; also register the full ViserServer.stop, which runs first
+        # (LIFO) and supersedes it (WebsockServer.stop unregisters itself).
+        # This matters for scripts that exit without calling stop(): the
+        # ViserServer-level stop waits longer for the loop thread to wind
+        # down, and a loop thread that outlives interpreter shutdown pins
+        # user callbacks from its frozen frames (seen as nanobind leak
+        # warnings in https://github.com/viser-project/viser/issues/518 and
+        # https://github.com/viser-project/viser/issues/744).
+        atexit.register(self.stop)
         self._event_loop = server._broadcast_buffer.event_loop
 
         self.scene: SceneApi = SceneApi(
@@ -1363,13 +1374,16 @@ class ViserServer(DeprecatedAttributeShim if not TYPE_CHECKING else object):
 
     def stop(self) -> None:
         """Stop the Viser server and associated threads and tunnels."""
+        # stop() is also registered via atexit; unregister so a manual stop
+        # isn't followed by a redundant second one at interpreter exit.
+        atexit.unregister(self.stop)
         self._websock_server.stop()
         if self._share_tunnel is not None:
             self._share_tunnel.close()
         # Let the background event loop finish its connection teardown before
         # shutting the pool: that teardown submits disconnect/camera callbacks
         # to the pool, and websock_server.stop() only join()s the loop thread
-        # for 0.1s -- so shutting the pool right after would make those late
+        # for 1s -- so shutting the pool right after would make those late
         # submits raise "cannot schedule new futures after shutdown" and drop
         # the user's callbacks silently. Bounded so a hung callback can't
         # block stop() forever (in that pathological case the pool still

--- a/src/viser/infra/_infra.py
+++ b/src/viser/infra/_infra.py
@@ -453,8 +453,16 @@ class WebsockServer(WebsockMessageHandler):
         for client in list(self._client_state_from_id.values()):
             client.message_buffer.set_done()
 
-        # Wait for the server thread to finish.
-        self._server_thread.join(timeout=0.1)
+        # Wait for the server thread to finish. The thread is daemonic, so an
+        # expired timeout never blocks interpreter exit -- but a thread that's
+        # still winding down at interpreter shutdown keeps server state and
+        # user callbacks referenced from its frozen frames, which surfaces as
+        # spurious leak reports from binding frameworks like nanobind. 1s is
+        # generous for the wind-down (~0.5s observed under heavy GIL
+        # contention) and costs nothing when teardown is fast: join() returns
+        # as soon as the thread exits.
+        # https://github.com/viser-project/viser/issues/744
+        self._server_thread.join(timeout=1.0)
 
     def on_client_connect(
         self, cb: Callable[[WebsockClientConnection], None | Coroutine]

--- a/tests/e2e/test_server_shutdown.py
+++ b/tests/e2e/test_server_shutdown.py
@@ -3,12 +3,12 @@
 ViserServer.stop() shuts the callback thread pool so its worker threads don't
 linger after the server is gone. But the background event loop's connection
 teardown fires on_client_disconnect and submits the (sync) user callbacks to
-that same pool -- and the infra server only join()s the loop thread for 0.1s.
-Shutting the pool right after that short join races those late submits: a
-submit that lands after shutdown() raises "cannot schedule new futures after
-shutdown" and the user's disconnect callback is silently dropped. stop() now
-joins the loop thread (bounded) before shutting the pool, so the teardown's
-submits are all in the queue first.
+that same pool -- historically the infra server only join()ed the loop thread
+for 0.1s. Shutting the pool right after such a short join races those late
+submits: a submit that lands after shutdown() raises "cannot schedule new
+futures after shutdown" and the user's disconnect callback is silently
+dropped. stop() now joins the loop thread (bounded) before shutting the pool,
+so the teardown's submits are all in the queue first.
 """
 
 from __future__ import annotations
@@ -54,12 +54,13 @@ def test_stop_runs_disconnect_callback_queued_during_teardown(
 ) -> None:
     disconnect_ran = threading.Event()
 
-    # A slow ASYNC disconnect callback runs first, inline on the event loop. It
-    # holds the loop thread's teardown past websock_server.stop()'s short 0.1s
-    # join, so the SYNC callback's pool submit below lands only after stop()
-    # has moved on -- the exact window where a premature pool shutdown drops
-    # it. Without this delay the submit finishes inside the 0.1s join and the
-    # race never surfaces locally.
+    # A slow ASYNC disconnect callback runs first, inline on the event loop.
+    # It holds the loop thread's teardown well past the historical 0.1s
+    # websock_server.stop() join, so with a short join the SYNC callback's
+    # pool submit below would land only after stop() had moved on -- the
+    # exact window where a premature pool shutdown drops it. Without this
+    # delay the submit finishes inside even a short join and the race never
+    # surfaces locally.
     @own_server.on_client_disconnect
     async def _(client: viser.ClientHandle) -> None:
         await asyncio.sleep(0.5)

--- a/tests/test_server_stop.py
+++ b/tests/test_server_stop.py
@@ -1,4 +1,6 @@
 import socket
+import subprocess
+import sys
 import time
 from unittest.mock import patch
 
@@ -24,3 +26,63 @@ def test_server_port_is_freed():
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     result = sock.connect_ex(("localhost", original_port))
     assert result != 0
+
+
+_GIL_CONTENTION_EXIT_SCRIPT = """
+import atexit, threading, time
+import viser, viser._client_autobuild
+
+viser._client_autobuild.ensure_client_is_built = lambda: None
+
+
+# Registered BEFORE the server is constructed, so it runs AFTER viser's own
+# atexit cleanup (atexit is LIFO): observes whether the loop thread actually
+# exited within the cleanup's join, with no extra waiting of its own.
+def check() -> None:
+    thread = server._websock_server._server_thread
+    print("SERVER_THREAD_ALIVE:", thread.is_alive(), flush=True)
+
+
+atexit.register(check)
+
+server = viser.ViserServer(port=0, verbose=False)
+
+
+def burn():
+    while True:
+        sum(i * i for i in range(10000))
+
+
+for _ in range(8):
+    threading.Thread(target=burn, daemon=True).start()
+time.sleep(0.3)
+# Exit WITHOUT calling stop(): cleanup runs through atexit. The registered
+# ViserServer.stop must wait for the loop thread to wind down even though the
+# burner threads are contending the GIL.
+"""
+
+
+def test_atexit_stop_outwaits_gil_contention():
+    """Regression test for https://github.com/viser-project/viser/issues/744.
+
+    A process that exits without calling stop() relies on the atexit hook. If
+    the atexit-side join gives up while the loop thread is still winding down
+    (which CPU-loaded processes routinely hit with a short timeout), the
+    daemonic thread is frozen mid-teardown at interpreter shutdown, and its
+    frames pin server state and user callbacks -- binding frameworks like
+    nanobind report those as leaked objects. The property that keeps the leak
+    away is the loop thread being DEAD by the time viser's atexit cleanup
+    returns.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", _GIL_CONTENTION_EXIT_SCRIPT],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "SERVER_THREAD_ALIVE: False" in result.stdout, (
+        "The background loop thread was still alive after viser's atexit "
+        f"cleanup.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )


### PR DESCRIPTION
Fixes #744.

The leak warnings from #518 come back whenever the server thread is still alive at interpreter exit: the atexit handler from #519 only joins it for 0.1s, and a CPU-loaded process routinely needs longer than that to wind down. The frozen thread's frames then keep user callbacks referenced, which nanobind reports as leaks.

This PR raises the join bound to 1s and registers `ViserServer.stop()` with atexit, so scripts that exit via Ctrl-C get the full wait too. I verified the fix with a small nanobind extension: before the change it leaked in about a third of runs, and after it doesn't leak at all. Also added a regression test.