### PR TITLE
Ignore PLR0917: ruff 0.16 stabilized it, breaking the unpinned CI formatting job

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ lint.ignore = [
     "PLR2004",  # Magic value used in comparison.
     "PLR0915",  # Too many statements.
     "PLR0913",  # Too many arguments.
+    "PLR0917",  # Too many positional arguments. (stabilized in newer ruff; same intent as PLR0913 above)
     "PLC0414",  # Import alias does not rename variable. (this is used for exporting names)
     "PLC0415",  # Import should be at the top-level of a file.
     "PLC1901",  # Use falsey strings.


### PR DESCRIPTION
Unbreaks the formatting job on main; same intent as the existing PLR0913 ignore.