### PR TITLE
Speed up get_render()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ lint.ignore = [
     "PLR0915",  # Too many statements.
     "PLR0913",  # Too many arguments.
     "PLR0917",  # Too many positional arguments. (stabilized in newer ruff; same intent as PLR0913 above)
+    "PLW0108",  # Lambda may be unnecessary. (stabilized in newer ruff; flags pre-existing callback-style lambdas)
     "PLC0414",  # Import alias does not rename variable. (this is used for exporting names)
     "PLC0415",  # Import should be at the top-level of a file.
     "PLC1901",  # Use falsey strings.

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -2356,6 +2356,14 @@ class GetRenderRequestMessage(Message, include_in_scene_serialization=False):
     # calls on the same client can be matched to their responses.
     render_uuid: str
 
+    @override
+    def redundancy_key(self) -> str:
+        # Every in-flight request must survive independently in the outgoing
+        # buffer. Under the class-name default key, a second concurrent
+        # get_render() on the same client evicted the first caller's
+        # still-unsent request, hanging that caller until timeout.
+        return type(self).__name__ + "-" + self.render_uuid
+
 
 @dataclasses.dataclass
 class GetRenderResponseMessage(Message, include_in_scene_serialization=False):

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -2343,10 +2343,13 @@ class GetRenderRequestMessage(Message, include_in_scene_serialization=False):
     """Message from server->client requesting a render from a specified camera
     pose."""
 
-    # "raw" is unencoded RGBA bytes (height * width * 4, row-major): no
-    # browser-side image encode and no server-side decode, at the cost of
-    # bandwidth. Fastest for local / LAN connections.
-    format: Literal["image/jpeg", "image/png", "raw"]
+    # The raw formats are unencoded RGBA bytes (height * width * 4,
+    # row-major): no browser-side image encode and no server-side decode, at
+    # the cost of bandwidth. Fastest for local / LAN connections. Both carry
+    # RGBA on the wire; they differ in background (raw_rgb renders on opaque
+    # white like JPEG, raw_rgba on transparent like PNG), and the server
+    # drops the alpha channel for raw_rgb.
+    format: Literal["image/jpeg", "image/png", "raw_rgb", "raw_rgba"]
     height: int
     width: int
     quality: int

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -2351,7 +2351,14 @@ class GetRenderRequestMessage(Message, include_in_scene_serialization=False):
     # in background (raw_rgb renders on opaque white like JPEG, raw_rgba on
     # transparent like PNG), and the server drops the alpha channel for
     # raw_rgb.
-    format: Literal["image/jpeg", "image/png", "raw_rgb", "raw_rgba"]
+    #
+    # "auto" renders on opaque white like JPEG and picks its wire encoding
+    # by content, tagged by the same 1-byte flag: deflate-compressed RGBA
+    # (flag 1) when the frame compresses losslessly at JPEG-competitive
+    # rates -- typical 3D scenes, where this is also much cheaper to encode
+    # and decode than JPEG -- and JPEG bytes (flag 2) otherwise, bounding
+    # the payload size on arbitrary content.
+    format: Literal["image/jpeg", "image/png", "raw_rgb", "raw_rgba", "auto"]
     height: int
     width: int
     quality: int

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -2343,7 +2343,10 @@ class GetRenderRequestMessage(Message, include_in_scene_serialization=False):
     """Message from server->client requesting a render from a specified camera
     pose."""
 
-    format: Literal["image/jpeg", "image/png"]
+    # "raw" is unencoded RGBA bytes (height * width * 4, row-major): no
+    # browser-side image encode and no server-side decode, at the cost of
+    # bandwidth. Fastest for local / LAN connections.
+    format: Literal["image/jpeg", "image/png", "raw"]
     height: int
     width: int
     quality: int

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -2350,7 +2350,17 @@ class GetRenderRequestMessage(Message, include_in_scene_serialization=False):
     # connections. They differ in background (deflate_rgb renders on opaque
     # white like JPEG, deflate_rgba on transparent like PNG), and the server
     # drops the alpha channel for deflate_rgb.
-    format: Literal["image/jpeg", "image/png", "deflate_rgb", "deflate_rgba"]
+    #
+    # "auto" renders on opaque white like JPEG and picks its wire encoding
+    # per frame, tagged by the same 1-byte flag: deflate-compressed RGBA
+    # (flag 1) when the frame compresses well losslessly -- typical 3D
+    # scenes, where deflate is also much cheaper than JPEG on both ends --
+    # and JPEG bytes (flag 2) otherwise, so high-entropy content (dense
+    # colored point clouds, splats, photo textures) never hits deflate's
+    # slow path or ships uncompressed.
+    format: Literal[
+        "image/jpeg", "image/png", "deflate_rgb", "deflate_rgba", "auto"
+    ]
     height: int
     width: int
     quality: int

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -2344,11 +2344,13 @@ class GetRenderRequestMessage(Message, include_in_scene_serialization=False):
     pose."""
 
     # The raw formats are unencoded RGBA bytes (height * width * 4,
-    # row-major): no browser-side image encode and no server-side decode, at
-    # the cost of bandwidth. Fastest for local / LAN connections. Both carry
-    # RGBA on the wire; they differ in background (raw_rgb renders on opaque
-    # white like JPEG, raw_rgba on transparent like PNG), and the server
-    # drops the alpha channel for raw_rgb.
+    # row-major): no browser-side image encode and no server-side decode.
+    # Fastest for local / LAN connections. Both carry RGBA on the wire
+    # behind a 1-byte flag (0 = as-is, 1 = deflate-raw compressed; the
+    # client compresses adaptively based on a content sample); they differ
+    # in background (raw_rgb renders on opaque white like JPEG, raw_rgba on
+    # transparent like PNG), and the server drops the alpha channel for
+    # raw_rgb.
     format: Literal["image/jpeg", "image/png", "raw_rgb", "raw_rgba"]
     height: int
     width: int

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -2351,14 +2351,7 @@ class GetRenderRequestMessage(Message, include_in_scene_serialization=False):
     # in background (raw_rgb renders on opaque white like JPEG, raw_rgba on
     # transparent like PNG), and the server drops the alpha channel for
     # raw_rgb.
-    #
-    # "auto" renders on opaque white like JPEG and picks its wire encoding
-    # by content, tagged by the same 1-byte flag: deflate-compressed RGBA
-    # (flag 1) when the frame compresses losslessly at JPEG-competitive
-    # rates -- typical 3D scenes, where this is also much cheaper to encode
-    # and decode than JPEG -- and JPEG bytes (flag 2) otherwise, bounding
-    # the payload size on arbitrary content.
-    format: Literal["image/jpeg", "image/png", "raw_rgb", "raw_rgba", "auto"]
+    format: Literal["image/jpeg", "image/png", "raw_rgb", "raw_rgba"]
     height: int
     width: int
     quality: int

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -2343,24 +2343,7 @@ class GetRenderRequestMessage(Message, include_in_scene_serialization=False):
     """Message from server->client requesting a render from a specified camera
     pose."""
 
-    # The deflate formats carry RGBA bytes (height * width * 4, row-major)
-    # behind a 1-byte flag: deflate-raw compressed (flag 1) when the content
-    # compresses -- decided from a cheap sample -- and as-is (flag 0)
-    # otherwise. No image codec on either side; fastest for local / LAN
-    # connections. They differ in background (deflate_rgb renders on opaque
-    # white like JPEG, deflate_rgba on transparent like PNG), and the server
-    # drops the alpha channel for deflate_rgb.
-    #
-    # "auto" renders on opaque white like JPEG and picks its wire encoding
-    # per frame, tagged by the same 1-byte flag: deflate-compressed RGBA
-    # (flag 1) when the frame compresses well losslessly -- typical 3D
-    # scenes, where deflate is also much cheaper than JPEG on both ends --
-    # and JPEG bytes (flag 2) otherwise, so high-entropy content (dense
-    # colored point clouds, splats, photo textures) never hits deflate's
-    # slow path or ships uncompressed.
-    format: Literal[
-        "image/jpeg", "image/png", "deflate_rgb", "deflate_rgba", "auto"
-    ]
+    format: Literal["image/jpeg", "image/png"]
     height: int
     width: int
     quality: int

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -2343,15 +2343,14 @@ class GetRenderRequestMessage(Message, include_in_scene_serialization=False):
     """Message from server->client requesting a render from a specified camera
     pose."""
 
-    # The raw formats are unencoded RGBA bytes (height * width * 4,
-    # row-major): no browser-side image encode and no server-side decode.
-    # Fastest for local / LAN connections. Both carry RGBA on the wire
-    # behind a 1-byte flag (0 = as-is, 1 = deflate-raw compressed; the
-    # client compresses adaptively based on a content sample); they differ
-    # in background (raw_rgb renders on opaque white like JPEG, raw_rgba on
-    # transparent like PNG), and the server drops the alpha channel for
-    # raw_rgb.
-    format: Literal["image/jpeg", "image/png", "raw_rgb", "raw_rgba"]
+    # The deflate formats carry RGBA bytes (height * width * 4, row-major)
+    # behind a 1-byte flag: deflate-raw compressed (flag 1) when the content
+    # compresses -- decided from a cheap sample -- and as-is (flag 0)
+    # otherwise. No image codec on either side; fastest for local / LAN
+    # connections. They differ in background (deflate_rgb renders on opaque
+    # white like JPEG, deflate_rgba on transparent like PNG), and the server
+    # drops the alpha channel for deflate_rgb.
+    format: Literal["image/jpeg", "image/png", "deflate_rgb", "deflate_rgba"]
     height: int
     width: int
     quality: int

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -501,7 +501,7 @@ class CameraHandle:
         self,
         height: int,
         width: int,
-        transport_format: Literal["png", "jpeg", "raw"] = "jpeg",
+        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "raw_rgb",
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -510,11 +510,20 @@ class CameraHandle:
         Args:
             height: Height of rendered image. Should be <= the browser height.
             width: Width of rendered image. Should be <= the browser width.
-            transport_format: Image transport format. JPEG will return a lossy (H, W, 3) RGB array. PNG will
-                return a lossless (H, W, 4) RGBA array, but can cause memory issues on the frontend if called
-                too quickly for higher-resolution images. RAW returns a lossless (H, W, 4) RGBA array with no
-                image encoding or decoding at all; it is the fastest option for local or LAN connections, at
-                the cost of transferring uncompressed pixels.
+            transport_format: Image transport format. The raw formats skip image encoding and decoding
+                entirely; they are the fastest option for local or LAN connections, at the cost of
+                transferring uncompressed pixels. RAW_RGB (default) returns a lossless (H, W, 3) RGB array
+                rendered on an opaque white background, like JPEG but without compression artifacts.
+                RAW_RGBA returns a lossless (H, W, 4) RGBA array with a transparent background, like PNG.
+                JPEG returns a lossy (H, W, 3) RGB array with the smallest payload; prefer it when clients
+                connect over slow or remote links (e.g. share URLs). PNG returns a lossless (H, W, 4) RGBA
+                array with a compressed payload, but can cause memory issues on the frontend if called too
+                quickly for higher-resolution images.
+
+                .. versionchanged::
+                    The default changed from ``"jpeg"`` to ``"raw_rgb"``: same (H, W, 3) RGB shape and
+                    white background as before, but now lossless and substantially faster. Pass
+                    ``transport_format="jpeg"`` explicitly to recover the previous behavior.
             timeout: Optional maximum seconds to wait for the frame. ``None``
                 (default) waits indefinitely; a disconnect still raises promptly
                 either way. Set this to bound a client that stays connected but
@@ -723,7 +732,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         wxyz: tuple[float, float, float, float] | np.ndarray,
         position: tuple[float, float, float] | np.ndarray,
         fov: float,
-        transport_format: Literal["png", "jpeg", "raw"] = "jpeg",
+        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "raw_rgb",
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -733,7 +742,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         height: int,
         width: int,
         *,
-        transport_format: Literal["png", "jpeg", "raw"] = "jpeg",
+        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "raw_rgb",
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -745,7 +754,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         wxyz: tuple[float, float, float, float] | np.ndarray | None = None,
         position: tuple[float, float, float] | np.ndarray | None = None,
         fov: float | None = None,
-        transport_format: Literal["png", "jpeg", "raw"] = "jpeg",
+        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "raw_rgb",
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -761,11 +770,20 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 be used.
             fov: Vertical field of view of the camera, in radians. If not provided, the
                 current camera position will be used.
-            transport_format: Image transport format. JPEG will return a lossy (H, W, 3) RGB array. PNG will
-                return a lossless (H, W, 4) RGBA array, but can cause memory issues on the frontend if called
-                too quickly for higher-resolution images. RAW returns a lossless (H, W, 4) RGBA array with no
-                image encoding or decoding at all; it is the fastest option for local or LAN connections, at
-                the cost of transferring uncompressed pixels.
+            transport_format: Image transport format. The raw formats skip image encoding and decoding
+                entirely; they are the fastest option for local or LAN connections, at the cost of
+                transferring uncompressed pixels. RAW_RGB (default) returns a lossless (H, W, 3) RGB array
+                rendered on an opaque white background, like JPEG but without compression artifacts.
+                RAW_RGBA returns a lossless (H, W, 4) RGBA array with a transparent background, like PNG.
+                JPEG returns a lossy (H, W, 3) RGB array with the smallest payload; prefer it when clients
+                connect over slow or remote links (e.g. share URLs). PNG returns a lossless (H, W, 4) RGBA
+                array with a compressed payload, but can cause memory issues on the frontend if called too
+                quickly for higher-resolution images.
+
+                .. versionchanged::
+                    The default changed from ``"jpeg"`` to ``"raw_rgb"``: same (H, W, 3) RGB shape and
+                    white background as before, but now lossless and substantially faster. Pass
+                    ``transport_format="jpeg"`` explicitly to recover the previous behavior.
             timeout: Optional maximum seconds to wait for the frame. ``None``
                 (default) waits indefinitely; a disconnect still raises promptly
                 either way. Set this to bound a client that stays connected but
@@ -832,7 +850,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
             _messages.GetRenderRequestMessage(
                 "image/jpeg"
                 if transport_format == "jpeg"
-                else ("image/png" if transport_format == "png" else "raw"),
+                else ("image/png" if transport_format == "png" else transport_format),
                 height=height,
                 width=width,
                 # Only used for JPEG. The main reason to use a lower quality version
@@ -855,8 +873,8 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         # Import the decoder while the client is busy rendering: on first use
         # this import is slow, and doing it here (request already in flight)
         # overlaps it with the round trip instead of adding to it. The raw
-        # transport needs no decoder at all.
-        if transport_format != "raw":
+        # transports need no decoder at all.
+        if transport_format in ("jpeg", "png"):
             import imageio.v3 as iio
 
         # Poll rather than wait unbounded: a client that DISCONNECTS (tab
@@ -895,16 +913,21 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
             raise RuntimeError(
                 "Render request failed: the client could not capture a frame."
             )
-        if transport_format == "raw":
-            # Unencoded RGBA bytes; just reshape. Copy so the caller gets a
-            # writable array (np.frombuffer views of bytes are read-only).
+        if transport_format in ("raw_rgb", "raw_rgba"):
+            # Unencoded bytes, always RGBA on the wire; just reshape (and
+            # drop the -- all-255, opaque-background -- alpha channel for
+            # raw_rgb). The slice/copy also makes the returned array writable
+            # (np.frombuffer views of bytes are read-only).
             if len(payload) != height * width * 4:
                 raise RuntimeError(
                     "Render request failed: the client returned "
                     f"{len(payload)} bytes, expected {height * width * 4} "
                     f"for a raw {height}x{width} RGBA frame."
                 )
-            return np.frombuffer(payload, np.uint8).reshape(height, width, 4).copy()
+            rgba = np.frombuffer(payload, np.uint8).reshape(height, width, 4)
+            return (
+                rgba[:, :, :3].copy() if transport_format == "raw_rgb" else rgba.copy()
+            )
         try:
             return iio.imread(
                 io.BytesIO(payload),

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -828,9 +828,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         self._viser_server.flush()
         self._websock_connection.queue_message(
             _messages.GetRenderRequestMessage(
-                "image/jpeg"
-                if transport_format == "jpeg"
-                else ("image/png" if transport_format == "png" else transport_format),
+                "image/jpeg" if transport_format == "jpeg" else "image/png",
                 height=height,
                 width=width,
                 # Only used for JPEG. Measured: JPEG speed and size move

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -823,8 +823,12 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         connection.register_handler(_messages.GetRenderResponseMessage, got_render_cb)
         # Kick any windowed BROADCAST messages (server.scene updates, which
         # ride a different buffer than this request) toward the wire before
-        # the request: a capture should reflect scene updates made before the
-        # get_render() call, and the request must not overtake them.
+        # queueing the request: a capture should reflect scene updates made
+        # before the get_render() call. Best-effort, not a guarantee -- the
+        # two buffers are drained by independent producer tasks, so a
+        # backlogged broadcast producer can still lose the race -- but
+        # flushing first makes the request overtaking a scene update rare
+        # instead of routine (~one windowing delay of exposure).
         self._viser_server.flush()
         self._websock_connection.queue_message(
             _messages.GetRenderRequestMessage(

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -9,7 +9,6 @@ import os
 import threading
 import time
 import warnings
-import zlib
 from collections.abc import Coroutine
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -502,9 +501,7 @@ class CameraHandle:
         self,
         height: int,
         width: int,
-        transport_format: Literal[
-            "auto", "png", "jpeg", "deflate_rgb", "deflate_rgba"
-        ] = "auto",
+        transport_format: Literal["png", "jpeg"] = "jpeg",
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -513,24 +510,10 @@ class CameraHandle:
         Args:
             height: Height of rendered image. Should be <= the browser height.
             width: Width of rendered image. Should be <= the browser width.
-            transport_format: Image transport format. AUTO (default) returns an (H, W, 3) RGB array
-                rendered on an opaque white background and picks its wire encoding per frame: frames
-                that compress well losslessly (typical 3D scenes) are sent as losslessly compressed
-                pixels -- pixel-exact and much cheaper than JPEG on both ends -- while high-entropy
-                frames (dense colored point clouds, splats, photo textures, where lossless compression
-                is slow AND ineffective) fall back to JPEG. JPEG always returns a lossy (H, W, 3) RGB
-                array with a small payload on any content. The DEFLATE formats skip image codecs
-                unconditionally: DEFLATE_RGB returns a lossless (H, W, 3) RGB array on white and
-                DEFLATE_RGBA a lossless (H, W, 4) RGBA array on a transparent background, deflate-
-                compressed on the wire when the content compresses, shipped uncompressed (width *
-                height * 4 bytes) otherwise. PNG returns a lossless (H, W, 4) RGBA array with a
-                compressed payload, but can cause memory issues on the frontend if called too quickly
-                for higher-resolution images.
-
-                .. versionchanged::
-                    The default changed from ``"jpeg"`` to ``"auto"``: same (H, W, 3) shape and white
-                    background, never meaningfully slower, and frames are pixel-exact whenever the
-                    content compresses well losslessly. Pass ``transport_format="jpeg"`` to force JPEG.
+            transport_format: Image transport format. JPEG (default) returns a lossy (H, W, 3) RGB
+                array with a small payload on any content. PNG returns a lossless (H, W, 4) RGBA array
+                with a transparent background, but can cause memory issues on the frontend if called
+                too quickly for higher-resolution images.
             timeout: Optional maximum seconds to wait for the frame. ``None``
                 (default) waits indefinitely; a disconnect still raises promptly
                 either way. Set this to bound a client that stays connected but
@@ -739,9 +722,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         wxyz: tuple[float, float, float, float] | np.ndarray,
         position: tuple[float, float, float] | np.ndarray,
         fov: float,
-        transport_format: Literal[
-            "auto", "png", "jpeg", "deflate_rgb", "deflate_rgba"
-        ] = "auto",
+        transport_format: Literal["png", "jpeg"] = "jpeg",
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -751,9 +732,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         height: int,
         width: int,
         *,
-        transport_format: Literal[
-            "auto", "png", "jpeg", "deflate_rgb", "deflate_rgba"
-        ] = "auto",
+        transport_format: Literal["png", "jpeg"] = "jpeg",
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -765,9 +744,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         wxyz: tuple[float, float, float, float] | np.ndarray | None = None,
         position: tuple[float, float, float] | np.ndarray | None = None,
         fov: float | None = None,
-        transport_format: Literal[
-            "auto", "png", "jpeg", "deflate_rgb", "deflate_rgba"
-        ] = "auto",
+        transport_format: Literal["png", "jpeg"] = "jpeg",
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -783,24 +760,10 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 be used.
             fov: Vertical field of view of the camera, in radians. If not provided, the
                 current camera position will be used.
-            transport_format: Image transport format. AUTO (default) returns an (H, W, 3) RGB array
-                rendered on an opaque white background and picks its wire encoding per frame: frames
-                that compress well losslessly (typical 3D scenes) are sent as losslessly compressed
-                pixels -- pixel-exact and much cheaper than JPEG on both ends -- while high-entropy
-                frames (dense colored point clouds, splats, photo textures, where lossless compression
-                is slow AND ineffective) fall back to JPEG. JPEG always returns a lossy (H, W, 3) RGB
-                array with a small payload on any content. The DEFLATE formats skip image codecs
-                unconditionally: DEFLATE_RGB returns a lossless (H, W, 3) RGB array on white and
-                DEFLATE_RGBA a lossless (H, W, 4) RGBA array on a transparent background, deflate-
-                compressed on the wire when the content compresses, shipped uncompressed (width *
-                height * 4 bytes) otherwise. PNG returns a lossless (H, W, 4) RGBA array with a
-                compressed payload, but can cause memory issues on the frontend if called too quickly
-                for higher-resolution images.
-
-                .. versionchanged::
-                    The default changed from ``"jpeg"`` to ``"auto"``: same (H, W, 3) shape and white
-                    background, never meaningfully slower, and frames are pixel-exact whenever the
-                    content compresses well losslessly. Pass ``transport_format="jpeg"`` to force JPEG.
+            transport_format: Image transport format. JPEG (default) returns a lossy (H, W, 3) RGB
+                array with a small payload on any content. PNG returns a lossless (H, W, 4) RGBA array
+                with a transparent background, but can cause memory issues on the frontend if called
+                too quickly for higher-resolution images.
             timeout: Optional maximum seconds to wait for the frame. ``None``
                 (default) waits indefinitely; a disconnect still raises promptly
                 either way. Set this to bound a client that stays connected but
@@ -891,10 +854,8 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
 
         # Import the decoder while the client is busy rendering: on first use
         # this import is slow, and doing it here (request already in flight)
-        # overlaps it with the round trip instead of adding to it. The
-        # deflate transports need no decoder at all.
-        if transport_format in ("auto", "jpeg", "png"):
-            import imageio.v3 as iio
+        # overlaps it with the round trip instead of adding to it.
+        import imageio.v3 as iio
 
         # Poll rather than wait unbounded: a client that DISCONNECTS (tab
         # closed, network drop) never sends a response, so this raises as soon
@@ -931,73 +892,6 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         if payload is None or len(payload) == 0:
             raise RuntimeError(
                 "Render request failed: the client could not capture a frame."
-            )
-        if transport_format == "auto":
-            # 1-byte flag chosen by the client per frame: 1 = deflate-raw
-            # compressed RGBA (content compressed well losslessly), 2 = JPEG
-            # bytes (fallback for high-entropy content). Both decode to
-            # (H, W, 3) RGB on the white background the client rendered with.
-            flag = payload[0]
-            if flag == 1:
-                try:
-                    inflated = zlib.decompress(memoryview(payload)[1:], wbits=-15)
-                except zlib.error as e:
-                    raise RuntimeError(
-                        "Render request failed: the client returned a "
-                        "corrupt compressed frame."
-                    ) from e
-                if len(inflated) != height * width * 4:
-                    raise RuntimeError(
-                        "Render request failed: the client returned "
-                        f"{len(inflated)} bytes, expected {height * width * 4} "
-                        f"for a raw {height}x{width} RGBA frame."
-                    )
-                rgba = np.frombuffer(inflated, np.uint8).reshape(height, width, 4)
-                return rgba[:, :, :3].copy()
-            elif flag == 2:
-                try:
-                    return iio.imread(
-                        io.BytesIO(memoryview(payload)[1:]), extension=".jpeg"
-                    )
-                except Exception as e:
-                    raise RuntimeError(
-                        "Render request failed: the client could not capture a frame."
-                    ) from e
-            raise RuntimeError(f"Render request failed: unknown payload flag {flag}.")
-        if transport_format in ("deflate_rgb", "deflate_rgba"):
-            # RGBA bytes behind a 1-byte flag: 1 means the client
-            # deflate-compressed the pixels (typical renders compress
-            # 100-1000x for a few ms; the client sends flag 0, uncompressed,
-            # when a content sample shows compression isn't worth its CPU --
-            # see maybeDeflateRenderPayload in MessageHandler.tsx). Then just
-            # reshape, dropping the -- all-255, opaque-background -- alpha
-            # channel for deflate_rgb. The slice/copy also makes the returned
-            # array writable (np.frombuffer views of bytes are read-only).
-            flag = payload[0]
-            data: bytes | memoryview = memoryview(payload)[1:]
-            if flag == 1:
-                try:
-                    data = zlib.decompress(data, wbits=-15)
-                except zlib.error as e:
-                    raise RuntimeError(
-                        "Render request failed: the client returned a "
-                        "corrupt compressed frame."
-                    ) from e
-            elif flag != 0:
-                raise RuntimeError(
-                    f"Render request failed: unknown payload flag {flag}."
-                )
-            if len(data) != height * width * 4:
-                raise RuntimeError(
-                    "Render request failed: the client returned "
-                    f"{len(data)} bytes, expected {height * width * 4} "
-                    f"for a raw {height}x{width} RGBA frame."
-                )
-            rgba = np.frombuffer(data, np.uint8).reshape(height, width, 4)
-            return (
-                rgba[:, :, :3].copy()
-                if transport_format == "deflate_rgb"
-                else rgba.copy()
             )
         try:
             return iio.imread(

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -502,7 +502,9 @@ class CameraHandle:
         self,
         height: int,
         width: int,
-        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "raw_rgb",
+        transport_format: Literal[
+            "png", "jpeg", "deflate_rgb", "deflate_rgba"
+        ] = "deflate_rgb",
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -511,12 +513,12 @@ class CameraHandle:
         Args:
             height: Height of rendered image. Should be <= the browser height.
             width: Width of rendered image. Should be <= the browser width.
-            transport_format: Image transport format. The raw formats skip image encoding and decoding
+            transport_format: Image transport format. The deflate formats skip image encoding and decoding
                 entirely; frames are losslessly deflate-compressed on the wire whenever the content
                 compresses (typical 3D scenes: 100x or more, at a few milliseconds), with a worst case
                 of the full width * height * 4 bytes per frame (~8 MB at 1080p) for incompressible
-                content. RAW_RGB (default) returns a lossless (H, W, 3) RGB array on an opaque white
-                background; RAW_RGBA a lossless (H, W, 4) RGBA array on a transparent background. JPEG
+                content. DEFLATE_RGB (default) returns a lossless (H, W, 3) RGB array on an opaque white
+                background; DEFLATE_RGBA a lossless (H, W, 4) RGBA array on a transparent background. JPEG
                 returns a lossy (H, W, 3) RGB array whose payload stays small on ANY content; prefer it
                 when clients connect over slow or remote links (e.g. share URLs) and scenes may not
                 compress (photo textures, dense splats). PNG returns a lossless (H, W, 4) RGBA array
@@ -524,7 +526,7 @@ class CameraHandle:
                 quickly for higher-resolution images.
 
                 .. versionchanged::
-                    The default changed from ``"jpeg"`` to ``"raw_rgb"``: same (H, W, 3) shape and
+                    The default changed from ``"jpeg"`` to ``"deflate_rgb"``: same (H, W, 3) shape and
                     white background, but frames are now lossless and typically faster. Pass
                     ``transport_format="jpeg"`` to recover the previous behavior.
             timeout: Optional maximum seconds to wait for the frame. ``None``
@@ -735,7 +737,9 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         wxyz: tuple[float, float, float, float] | np.ndarray,
         position: tuple[float, float, float] | np.ndarray,
         fov: float,
-        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "raw_rgb",
+        transport_format: Literal[
+            "png", "jpeg", "deflate_rgb", "deflate_rgba"
+        ] = "deflate_rgb",
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -745,7 +749,9 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         height: int,
         width: int,
         *,
-        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "raw_rgb",
+        transport_format: Literal[
+            "png", "jpeg", "deflate_rgb", "deflate_rgba"
+        ] = "deflate_rgb",
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -757,7 +763,9 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         wxyz: tuple[float, float, float, float] | np.ndarray | None = None,
         position: tuple[float, float, float] | np.ndarray | None = None,
         fov: float | None = None,
-        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "raw_rgb",
+        transport_format: Literal[
+            "png", "jpeg", "deflate_rgb", "deflate_rgba"
+        ] = "deflate_rgb",
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -773,12 +781,12 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 be used.
             fov: Vertical field of view of the camera, in radians. If not provided, the
                 current camera position will be used.
-            transport_format: Image transport format. The raw formats skip image encoding and decoding
+            transport_format: Image transport format. The deflate formats skip image encoding and decoding
                 entirely; frames are losslessly deflate-compressed on the wire whenever the content
                 compresses (typical 3D scenes: 100x or more, at a few milliseconds), with a worst case
                 of the full width * height * 4 bytes per frame (~8 MB at 1080p) for incompressible
-                content. RAW_RGB (default) returns a lossless (H, W, 3) RGB array on an opaque white
-                background; RAW_RGBA a lossless (H, W, 4) RGBA array on a transparent background. JPEG
+                content. DEFLATE_RGB (default) returns a lossless (H, W, 3) RGB array on an opaque white
+                background; DEFLATE_RGBA a lossless (H, W, 4) RGBA array on a transparent background. JPEG
                 returns a lossy (H, W, 3) RGB array whose payload stays small on ANY content; prefer it
                 when clients connect over slow or remote links (e.g. share URLs) and scenes may not
                 compress (photo textures, dense splats). PNG returns a lossless (H, W, 4) RGBA array
@@ -786,7 +794,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 quickly for higher-resolution images.
 
                 .. versionchanged::
-                    The default changed from ``"jpeg"`` to ``"raw_rgb"``: same (H, W, 3) shape and
+                    The default changed from ``"jpeg"`` to ``"deflate_rgb"``: same (H, W, 3) shape and
                     white background, but frames are now lossless and typically faster. Pass
                     ``transport_format="jpeg"`` to recover the previous behavior.
             timeout: Optional maximum seconds to wait for the frame. ``None``
@@ -877,8 +885,8 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
 
         # Import the decoder while the client is busy rendering: on first use
         # this import is slow, and doing it here (request already in flight)
-        # overlaps it with the round trip instead of adding to it. The raw
-        # transports need no decoder at all.
+        # overlaps it with the round trip instead of adding to it. The
+        # deflate transports need no decoder at all.
         if transport_format in ("jpeg", "png"):
             import imageio.v3 as iio
 
@@ -918,14 +926,14 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
             raise RuntimeError(
                 "Render request failed: the client could not capture a frame."
             )
-        if transport_format in ("raw_rgb", "raw_rgba"):
+        if transport_format in ("deflate_rgb", "deflate_rgba"):
             # RGBA bytes behind a 1-byte flag: 1 means the client
             # deflate-compressed the pixels (typical renders compress
             # 100-1000x for a few ms; the client sends flag 0, uncompressed,
             # when a content sample shows compression isn't worth its CPU --
             # see maybeDeflateRenderPayload in MessageHandler.tsx). Then just
             # reshape, dropping the -- all-255, opaque-background -- alpha
-            # channel for raw_rgb. The slice/copy also makes the returned
+            # channel for deflate_rgb. The slice/copy also makes the returned
             # array writable (np.frombuffer views of bytes are read-only).
             flag = payload[0]
             data: bytes | memoryview = memoryview(payload)[1:]
@@ -939,7 +947,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                     ) from e
             elif flag != 0:
                 raise RuntimeError(
-                    f"Render request failed: unknown raw payload flag {flag}."
+                    f"Render request failed: unknown payload flag {flag}."
                 )
             if len(data) != height * width * 4:
                 raise RuntimeError(
@@ -949,7 +957,9 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 )
             rgba = np.frombuffer(data, np.uint8).reshape(height, width, 4)
             return (
-                rgba[:, :, :3].copy() if transport_format == "raw_rgb" else rgba.copy()
+                rgba[:, :, :3].copy()
+                if transport_format == "deflate_rgb"
+                else rgba.copy()
             )
         try:
             return iio.imread(

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -501,7 +501,7 @@ class CameraHandle:
         self,
         height: int,
         width: int,
-        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "raw_rgb",
+        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "jpeg",
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -510,20 +510,15 @@ class CameraHandle:
         Args:
             height: Height of rendered image. Should be <= the browser height.
             width: Width of rendered image. Should be <= the browser width.
-            transport_format: Image transport format. The raw formats skip image encoding and decoding
-                entirely; they are the fastest option for local or LAN connections, at the cost of
-                transferring uncompressed pixels. RAW_RGB (default) returns a lossless (H, W, 3) RGB array
-                rendered on an opaque white background, like JPEG but without compression artifacts.
-                RAW_RGBA returns a lossless (H, W, 4) RGBA array with a transparent background, like PNG.
-                JPEG returns a lossy (H, W, 3) RGB array with the smallest payload; prefer it when clients
-                connect over slow or remote links (e.g. share URLs). PNG returns a lossless (H, W, 4) RGBA
-                array with a compressed payload, but can cause memory issues on the frontend if called too
-                quickly for higher-resolution images.
-
-                .. versionchanged::
-                    The default changed from ``"jpeg"`` to ``"raw_rgb"``: same (H, W, 3) RGB shape and
-                    white background as before, but now lossless and substantially faster. Pass
-                    ``transport_format="jpeg"`` explicitly to recover the previous behavior.
+            transport_format: Image transport format. JPEG (default) returns a lossy (H, W, 3) RGB
+                array with the smallest payload; it is a safe choice for any connection, including slow
+                or remote links (e.g. share URLs). The raw formats skip image encoding and decoding
+                entirely and are substantially faster over local or LAN connections, at the cost of
+                transferring uncompressed pixels (width * height * 4 bytes per frame, ~8 MB at 1080p):
+                RAW_RGB returns a lossless (H, W, 3) RGB array on the same opaque white background as
+                JPEG, and RAW_RGBA a lossless (H, W, 4) RGBA array on a transparent background. PNG
+                returns a lossless (H, W, 4) RGBA array with a compressed payload, but can cause memory
+                issues on the frontend if called too quickly for higher-resolution images.
             timeout: Optional maximum seconds to wait for the frame. ``None``
                 (default) waits indefinitely; a disconnect still raises promptly
                 either way. Set this to bound a client that stays connected but
@@ -732,7 +727,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         wxyz: tuple[float, float, float, float] | np.ndarray,
         position: tuple[float, float, float] | np.ndarray,
         fov: float,
-        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "raw_rgb",
+        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "jpeg",
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -742,7 +737,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         height: int,
         width: int,
         *,
-        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "raw_rgb",
+        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "jpeg",
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -754,7 +749,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         wxyz: tuple[float, float, float, float] | np.ndarray | None = None,
         position: tuple[float, float, float] | np.ndarray | None = None,
         fov: float | None = None,
-        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "raw_rgb",
+        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "jpeg",
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -770,20 +765,15 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 be used.
             fov: Vertical field of view of the camera, in radians. If not provided, the
                 current camera position will be used.
-            transport_format: Image transport format. The raw formats skip image encoding and decoding
-                entirely; they are the fastest option for local or LAN connections, at the cost of
-                transferring uncompressed pixels. RAW_RGB (default) returns a lossless (H, W, 3) RGB array
-                rendered on an opaque white background, like JPEG but without compression artifacts.
-                RAW_RGBA returns a lossless (H, W, 4) RGBA array with a transparent background, like PNG.
-                JPEG returns a lossy (H, W, 3) RGB array with the smallest payload; prefer it when clients
-                connect over slow or remote links (e.g. share URLs). PNG returns a lossless (H, W, 4) RGBA
-                array with a compressed payload, but can cause memory issues on the frontend if called too
-                quickly for higher-resolution images.
-
-                .. versionchanged::
-                    The default changed from ``"jpeg"`` to ``"raw_rgb"``: same (H, W, 3) RGB shape and
-                    white background as before, but now lossless and substantially faster. Pass
-                    ``transport_format="jpeg"`` explicitly to recover the previous behavior.
+            transport_format: Image transport format. JPEG (default) returns a lossy (H, W, 3) RGB
+                array with the smallest payload; it is a safe choice for any connection, including slow
+                or remote links (e.g. share URLs). The raw formats skip image encoding and decoding
+                entirely and are substantially faster over local or LAN connections, at the cost of
+                transferring uncompressed pixels (width * height * 4 bytes per frame, ~8 MB at 1080p):
+                RAW_RGB returns a lossless (H, W, 3) RGB array on the same opaque white background as
+                JPEG, and RAW_RGBA a lossless (H, W, 4) RGBA array on a transparent background. PNG
+                returns a lossless (H, W, 4) RGBA array with a compressed payload, but can cause memory
+                issues on the frontend if called too quickly for higher-resolution images.
             timeout: Optional maximum seconds to wait for the frame. ``None``
                 (default) waits indefinitely; a disconnect still raises promptly
                 either way. Set this to bound a client that stays connected but

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -771,7 +771,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         # Listen for a render reseponse message, which should contain the rendered
         # image.
         render_ready_event = threading.Event()
-        out: np.ndarray | None = None
+        payload: bytes | None = None
 
         connection = self._websock_connection
 
@@ -810,21 +810,12 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 # dispatch loop snapshotted the handler list before the
                 # removal. The caller is gone -- drop the frame.
                 return
-            nonlocal out
-            # An empty payload is the client's failure sentinel (capture threw,
-            # or toBlob() returned null). Leave `out` as None and let the
-            # waiter raise, rather than crashing the decode here (which would
-            # never set the event and hang get_render() forever).
-            if len(message.payload) > 0:
-                import imageio.v3 as iio
-
-                try:
-                    out = iio.imread(
-                        io.BytesIO(message.payload),
-                        extension=f".{transport_format}",
-                    )
-                except Exception:
-                    out = None
+            nonlocal payload
+            # Store the raw payload only; decoding happens on the caller's
+            # thread below. This callback runs on the server's event loop,
+            # where a large PNG/JPEG decode (or imageio's slow first import)
+            # would block message handling for EVERY client.
+            payload = message.payload
             render_ready_event.set()
 
         connection.register_handler(_messages.GetRenderResponseMessage, got_render_cb)
@@ -845,6 +836,16 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 render_uuid=render_uuid,
             )
         )
+        # Outgoing messages are windowed by default (up to ~1/60s of batching
+        # delay before they hit the wire). For a blocking round trip that
+        # delay is pure added latency, so flush the request out immediately.
+        self.flush()
+
+        # Import the decoder while the client is busy rendering: on first use
+        # this import is slow, and doing it here (request already in flight)
+        # overlaps it with the round trip instead of adding to it.
+        import imageio.v3 as iio
+
         # Poll rather than wait unbounded: a client that DISCONNECTS (tab
         # closed, network drop) never sends a response, so this raises as soon
         # as it leaves _connected_clients instead of hanging the caller (and,
@@ -875,11 +876,21 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                     f"Render request timed out after {timeout}s: the client "
                     "did not return a frame."
                 )
-        if out is None:
+        # An empty payload is the client's failure sentinel (capture threw, or
+        # toBlob() returned null).
+        if payload is None or len(payload) == 0:
             raise RuntimeError(
                 "Render request failed: the client could not capture a frame."
             )
-        return out
+        try:
+            return iio.imread(
+                io.BytesIO(payload),
+                extension=f".{transport_format}",
+            )
+        except Exception as e:
+            raise RuntimeError(
+                "Render request failed: the client could not capture a frame."
+            ) from e
 
 
 class ViserServer(DeprecatedAttributeShim if not TYPE_CHECKING else object):

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -9,6 +9,7 @@ import os
 import threading
 import time
 import warnings
+import zlib
 from collections.abc import Coroutine
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -513,8 +514,10 @@ class CameraHandle:
             transport_format: Image transport format. JPEG (default) returns a lossy (H, W, 3) RGB
                 array with the smallest payload; it is a safe choice for any connection, including slow
                 or remote links (e.g. share URLs). The raw formats skip image encoding and decoding
-                entirely and are substantially faster over local or LAN connections, at the cost of
-                transferring uncompressed pixels (width * height * 4 bytes per frame, ~8 MB at 1080p):
+                entirely and are substantially faster over local or LAN connections. Raw frames are
+                losslessly deflate-compressed on the wire when the content compresses (typical 3D scenes:
+                100x or more); the worst case for incompressible content is the full width * height * 4
+                bytes per frame (~8 MB at 1080p):
                 RAW_RGB returns a lossless (H, W, 3) RGB array on the same opaque white background as
                 JPEG, and RAW_RGBA a lossless (H, W, 4) RGBA array on a transparent background. PNG
                 returns a lossless (H, W, 4) RGBA array with a compressed payload, but can cause memory
@@ -768,8 +771,10 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
             transport_format: Image transport format. JPEG (default) returns a lossy (H, W, 3) RGB
                 array with the smallest payload; it is a safe choice for any connection, including slow
                 or remote links (e.g. share URLs). The raw formats skip image encoding and decoding
-                entirely and are substantially faster over local or LAN connections, at the cost of
-                transferring uncompressed pixels (width * height * 4 bytes per frame, ~8 MB at 1080p):
+                entirely and are substantially faster over local or LAN connections. Raw frames are
+                losslessly deflate-compressed on the wire when the content compresses (typical 3D scenes:
+                100x or more); the worst case for incompressible content is the full width * height * 4
+                bytes per frame (~8 MB at 1080p):
                 RAW_RGB returns a lossless (H, W, 3) RGB array on the same opaque white background as
                 JPEG, and RAW_RGBA a lossless (H, W, 4) RGBA array on a transparent background. PNG
                 returns a lossless (H, W, 4) RGBA array with a compressed payload, but can cause memory
@@ -904,17 +909,35 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 "Render request failed: the client could not capture a frame."
             )
         if transport_format in ("raw_rgb", "raw_rgba"):
-            # Unencoded bytes, always RGBA on the wire; just reshape (and
-            # drop the -- all-255, opaque-background -- alpha channel for
-            # raw_rgb). The slice/copy also makes the returned array writable
-            # (np.frombuffer views of bytes are read-only).
-            if len(payload) != height * width * 4:
+            # RGBA bytes behind a 1-byte flag: 1 means the client
+            # deflate-compressed the pixels (typical renders compress
+            # 100-1000x for a few ms; the client sends flag 0, uncompressed,
+            # when a content sample shows compression isn't worth its CPU --
+            # see maybeDeflateRenderPayload in MessageHandler.tsx). Then just
+            # reshape, dropping the -- all-255, opaque-background -- alpha
+            # channel for raw_rgb. The slice/copy also makes the returned
+            # array writable (np.frombuffer views of bytes are read-only).
+            flag = payload[0]
+            data: bytes | memoryview = memoryview(payload)[1:]
+            if flag == 1:
+                try:
+                    data = zlib.decompress(data, wbits=-15)
+                except zlib.error as e:
+                    raise RuntimeError(
+                        "Render request failed: the client returned a "
+                        "corrupt compressed frame."
+                    ) from e
+            elif flag != 0:
+                raise RuntimeError(
+                    f"Render request failed: unknown raw payload flag {flag}."
+                )
+            if len(data) != height * width * 4:
                 raise RuntimeError(
                     "Render request failed: the client returned "
-                    f"{len(payload)} bytes, expected {height * width * 4} "
+                    f"{len(data)} bytes, expected {height * width * 4} "
                     f"for a raw {height}x{width} RGBA frame."
                 )
-            rgba = np.frombuffer(payload, np.uint8).reshape(height, width, 4)
+            rgba = np.frombuffer(data, np.uint8).reshape(height, width, 4)
             return (
                 rgba[:, :, :3].copy() if transport_format == "raw_rgb" else rgba.copy()
             )

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -502,7 +502,9 @@ class CameraHandle:
         self,
         height: int,
         width: int,
-        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "jpeg",
+        transport_format: Literal[
+            "auto", "png", "jpeg", "raw_rgb", "raw_rgba"
+        ] = "auto",
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -511,17 +513,24 @@ class CameraHandle:
         Args:
             height: Height of rendered image. Should be <= the browser height.
             width: Width of rendered image. Should be <= the browser width.
-            transport_format: Image transport format. JPEG (default) returns a lossy (H, W, 3) RGB
-                array with the smallest payload; it is a safe choice for any connection, including slow
-                or remote links (e.g. share URLs). The raw formats skip image encoding and decoding
-                entirely and are substantially faster over local or LAN connections. Raw frames are
-                losslessly deflate-compressed on the wire when the content compresses (typical 3D scenes:
-                100x or more); the worst case for incompressible content is the full width * height * 4
-                bytes per frame (~8 MB at 1080p):
+            transport_format: Image transport format. AUTO (default) returns an (H, W, 3) RGB array
+                rendered on an opaque white background, choosing its wire encoding by content: frames
+                that compress well losslessly (typical 3D scenes) are sent as losslessly compressed
+                pixels -- much faster to encode/decode than JPEG, and pixel-exact -- while anything else
+                falls back to JPEG, so the payload stays small on arbitrary content and connections.
+                JPEG always returns a lossy (H, W, 3) RGB array with a small payload. The raw formats
+                skip image encoding entirely and are the fastest option over local or LAN connections;
+                their frames are losslessly deflate-compressed on the wire when the content compresses,
+                with a worst case of the full width * height * 4 bytes per frame (~8 MB at 1080p):
                 RAW_RGB returns a lossless (H, W, 3) RGB array on the same opaque white background as
                 JPEG, and RAW_RGBA a lossless (H, W, 4) RGBA array on a transparent background. PNG
                 returns a lossless (H, W, 4) RGBA array with a compressed payload, but can cause memory
                 issues on the frontend if called too quickly for higher-resolution images.
+
+                .. versionchanged::
+                    The default changed from ``"jpeg"`` to ``"auto"``: same (H, W, 3) shape and white
+                    background, but frames are now pixel-exact (and faster) whenever the content
+                    compresses well losslessly. Pass ``transport_format="jpeg"`` to force JPEG.
             timeout: Optional maximum seconds to wait for the frame. ``None``
                 (default) waits indefinitely; a disconnect still raises promptly
                 either way. Set this to bound a client that stays connected but
@@ -730,7 +739,9 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         wxyz: tuple[float, float, float, float] | np.ndarray,
         position: tuple[float, float, float] | np.ndarray,
         fov: float,
-        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "jpeg",
+        transport_format: Literal[
+            "auto", "png", "jpeg", "raw_rgb", "raw_rgba"
+        ] = "auto",
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -740,7 +751,9 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         height: int,
         width: int,
         *,
-        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "jpeg",
+        transport_format: Literal[
+            "auto", "png", "jpeg", "raw_rgb", "raw_rgba"
+        ] = "auto",
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -752,7 +765,9 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         wxyz: tuple[float, float, float, float] | np.ndarray | None = None,
         position: tuple[float, float, float] | np.ndarray | None = None,
         fov: float | None = None,
-        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "jpeg",
+        transport_format: Literal[
+            "auto", "png", "jpeg", "raw_rgb", "raw_rgba"
+        ] = "auto",
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -768,17 +783,24 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 be used.
             fov: Vertical field of view of the camera, in radians. If not provided, the
                 current camera position will be used.
-            transport_format: Image transport format. JPEG (default) returns a lossy (H, W, 3) RGB
-                array with the smallest payload; it is a safe choice for any connection, including slow
-                or remote links (e.g. share URLs). The raw formats skip image encoding and decoding
-                entirely and are substantially faster over local or LAN connections. Raw frames are
-                losslessly deflate-compressed on the wire when the content compresses (typical 3D scenes:
-                100x or more); the worst case for incompressible content is the full width * height * 4
-                bytes per frame (~8 MB at 1080p):
+            transport_format: Image transport format. AUTO (default) returns an (H, W, 3) RGB array
+                rendered on an opaque white background, choosing its wire encoding by content: frames
+                that compress well losslessly (typical 3D scenes) are sent as losslessly compressed
+                pixels -- much faster to encode/decode than JPEG, and pixel-exact -- while anything else
+                falls back to JPEG, so the payload stays small on arbitrary content and connections.
+                JPEG always returns a lossy (H, W, 3) RGB array with a small payload. The raw formats
+                skip image encoding entirely and are the fastest option over local or LAN connections;
+                their frames are losslessly deflate-compressed on the wire when the content compresses,
+                with a worst case of the full width * height * 4 bytes per frame (~8 MB at 1080p):
                 RAW_RGB returns a lossless (H, W, 3) RGB array on the same opaque white background as
                 JPEG, and RAW_RGBA a lossless (H, W, 4) RGBA array on a transparent background. PNG
                 returns a lossless (H, W, 4) RGBA array with a compressed payload, but can cause memory
                 issues on the frontend if called too quickly for higher-resolution images.
+
+                .. versionchanged::
+                    The default changed from ``"jpeg"`` to ``"auto"``: same (H, W, 3) shape and white
+                    background, but frames are now pixel-exact (and faster) whenever the content
+                    compresses well losslessly. Pass ``transport_format="jpeg"`` to force JPEG.
             timeout: Optional maximum seconds to wait for the frame. ``None``
                 (default) waits indefinitely; a disconnect still raises promptly
                 either way. Set this to bound a client that stays connected but
@@ -846,6 +868,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 "image/jpeg"
                 if transport_format == "jpeg"
                 else ("image/png" if transport_format == "png" else transport_format),
+                # ^"auto", "raw_rgb", and "raw_rgba" pass through unchanged.
                 height=height,
                 width=width,
                 # Only used for JPEG. The main reason to use a lower quality version
@@ -869,7 +892,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         # this import is slow, and doing it here (request already in flight)
         # overlaps it with the round trip instead of adding to it. The raw
         # transports need no decoder at all.
-        if transport_format in ("jpeg", "png"):
+        if transport_format in ("auto", "jpeg", "png"):
             import imageio.v3 as iio
 
         # Poll rather than wait unbounded: a client that DISCONNECTS (tab
@@ -907,6 +930,41 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         if payload is None or len(payload) == 0:
             raise RuntimeError(
                 "Render request failed: the client could not capture a frame."
+            )
+        if transport_format == "auto":
+            # 1-byte flag chosen by the client per frame: 1 = deflate-raw
+            # compressed RGBA (content compressed losslessly at
+            # JPEG-competitive rates), 2 = JPEG bytes (fallback for
+            # incompressible content). Both decode to (H, W, 3) RGB on the
+            # white background the client rendered with.
+            flag = payload[0]
+            if flag == 1:
+                try:
+                    inflated = zlib.decompress(memoryview(payload)[1:], wbits=-15)
+                except zlib.error as e:
+                    raise RuntimeError(
+                        "Render request failed: the client returned a "
+                        "corrupt compressed frame."
+                    ) from e
+                if len(inflated) != height * width * 4:
+                    raise RuntimeError(
+                        "Render request failed: the client returned "
+                        f"{len(inflated)} bytes, expected {height * width * 4} "
+                        f"for a raw {height}x{width} RGBA frame."
+                    )
+                rgba = np.frombuffer(inflated, np.uint8).reshape(height, width, 4)
+                return rgba[:, :, :3].copy()
+            elif flag == 2:
+                try:
+                    return iio.imread(
+                        io.BytesIO(memoryview(payload)[1:]), extension=".jpeg"
+                    )
+                except Exception as e:
+                    raise RuntimeError(
+                        "Render request failed: the client could not capture a frame."
+                    ) from e
+            raise RuntimeError(
+                f"Render request failed: unknown auto payload flag {flag}."
             )
         if transport_format in ("raw_rgb", "raw_rgba"):
             # RGBA bytes behind a 1-byte flag: 1 means the client

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -505,7 +505,6 @@ class CameraHandle:
         transport_format: Literal[
             "png", "jpeg", "deflate_rgb", "deflate_rgba"
         ] = "deflate_rgb",
-        jpeg_quality: int = 80,
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -525,10 +524,6 @@ class CameraHandle:
                 compress (photo textures, dense splats). PNG returns a lossless (H, W, 4) RGBA array
                 with a compressed payload, but can cause memory issues on the frontend if called too
                 quickly for higher-resolution images.
-            jpeg_quality: JPEG encoding quality in [1, 100]; only used when
-                ``transport_format="jpeg"``. Lower values shrink the payload substantially (roughly
-                2x from 80 to 40) and speed up encoding somewhat; PNG and the deflate formats have no
-                equivalent knob (the browser exposes none for PNG).
 
                 .. versionchanged::
                     The default changed from ``"jpeg"`` to ``"deflate_rgb"``: same (H, W, 3) shape and
@@ -540,11 +535,7 @@ class CameraHandle:
                 never returns a frame.
         """
         return self._state.client.get_render(
-            height,
-            width,
-            transport_format=transport_format,
-            jpeg_quality=jpeg_quality,
-            timeout=timeout,
+            height, width, transport_format=transport_format, timeout=timeout
         )
 
 
@@ -749,7 +740,6 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         transport_format: Literal[
             "png", "jpeg", "deflate_rgb", "deflate_rgba"
         ] = "deflate_rgb",
-        jpeg_quality: int = 80,
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -762,7 +752,6 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         transport_format: Literal[
             "png", "jpeg", "deflate_rgb", "deflate_rgba"
         ] = "deflate_rgb",
-        jpeg_quality: int = 80,
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -777,7 +766,6 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         transport_format: Literal[
             "png", "jpeg", "deflate_rgb", "deflate_rgba"
         ] = "deflate_rgb",
-        jpeg_quality: int = 80,
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -804,10 +792,6 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 compress (photo textures, dense splats). PNG returns a lossless (H, W, 4) RGBA array
                 with a compressed payload, but can cause memory issues on the frontend if called too
                 quickly for higher-resolution images.
-            jpeg_quality: JPEG encoding quality in [1, 100]; only used when
-                ``transport_format="jpeg"``. Lower values shrink the payload substantially (roughly
-                2x from 80 to 40) and speed up encoding somewhat; PNG and the deflate formats have no
-                equivalent knob (the browser exposes none for PNG).
 
                 .. versionchanged::
                     The default changed from ``"jpeg"`` to ``"deflate_rgb"``: same (H, W, 3) shape and
@@ -818,9 +802,6 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 either way. Set this to bound a client that stays connected but
                 never returns a frame (raises ``TimeoutError``).
         """
-
-        if not 1 <= jpeg_quality <= 100:
-            raise ValueError(f"jpeg_quality must be in [1, 100], got {jpeg_quality}.")
 
         # Listen for a render reseponse message, which should contain the rendered
         # image.
@@ -885,8 +866,12 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 else ("image/png" if transport_format == "png" else transport_format),
                 height=height,
                 width=width,
-                # Only used for JPEG.
-                quality=jpeg_quality,
+                # Only used for JPEG. Measured: JPEG speed and size move
+                # together (lower quality = fewer surviving DCT coefficients
+                # = less entropy-coding work on both ends), and 80 sits near
+                # the speed plateau while staying fidelity-safe. Chrome's
+                # 0.92 toBlob default is strictly slower and larger.
+                quality=80,
                 position=cast_vector(
                     position if position is not None else self.camera.position, 3
                 ),

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -502,9 +502,7 @@ class CameraHandle:
         self,
         height: int,
         width: int,
-        transport_format: Literal[
-            "auto", "png", "jpeg", "raw_rgb", "raw_rgba"
-        ] = "auto",
+        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "raw_rgb",
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -513,24 +511,22 @@ class CameraHandle:
         Args:
             height: Height of rendered image. Should be <= the browser height.
             width: Width of rendered image. Should be <= the browser width.
-            transport_format: Image transport format. AUTO (default) returns an (H, W, 3) RGB array
-                rendered on an opaque white background, choosing its wire encoding by content: frames
-                that compress well losslessly (typical 3D scenes) are sent as losslessly compressed
-                pixels -- much faster to encode/decode than JPEG, and pixel-exact -- while anything else
-                falls back to JPEG, so the payload stays small on arbitrary content and connections.
-                JPEG always returns a lossy (H, W, 3) RGB array with a small payload. The raw formats
-                skip image encoding entirely and are the fastest option over local or LAN connections;
-                their frames are losslessly deflate-compressed on the wire when the content compresses,
-                with a worst case of the full width * height * 4 bytes per frame (~8 MB at 1080p):
-                RAW_RGB returns a lossless (H, W, 3) RGB array on the same opaque white background as
-                JPEG, and RAW_RGBA a lossless (H, W, 4) RGBA array on a transparent background. PNG
-                returns a lossless (H, W, 4) RGBA array with a compressed payload, but can cause memory
-                issues on the frontend if called too quickly for higher-resolution images.
+            transport_format: Image transport format. The raw formats skip image encoding and decoding
+                entirely; frames are losslessly deflate-compressed on the wire whenever the content
+                compresses (typical 3D scenes: 100x or more, at a few milliseconds), with a worst case
+                of the full width * height * 4 bytes per frame (~8 MB at 1080p) for incompressible
+                content. RAW_RGB (default) returns a lossless (H, W, 3) RGB array on an opaque white
+                background; RAW_RGBA a lossless (H, W, 4) RGBA array on a transparent background. JPEG
+                returns a lossy (H, W, 3) RGB array whose payload stays small on ANY content; prefer it
+                when clients connect over slow or remote links (e.g. share URLs) and scenes may not
+                compress (photo textures, dense splats). PNG returns a lossless (H, W, 4) RGBA array
+                with a compressed payload, but can cause memory issues on the frontend if called too
+                quickly for higher-resolution images.
 
                 .. versionchanged::
-                    The default changed from ``"jpeg"`` to ``"auto"``: same (H, W, 3) shape and white
-                    background, but frames are now pixel-exact (and faster) whenever the content
-                    compresses well losslessly. Pass ``transport_format="jpeg"`` to force JPEG.
+                    The default changed from ``"jpeg"`` to ``"raw_rgb"``: same (H, W, 3) shape and
+                    white background, but frames are now lossless and typically faster. Pass
+                    ``transport_format="jpeg"`` to recover the previous behavior.
             timeout: Optional maximum seconds to wait for the frame. ``None``
                 (default) waits indefinitely; a disconnect still raises promptly
                 either way. Set this to bound a client that stays connected but
@@ -739,9 +735,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         wxyz: tuple[float, float, float, float] | np.ndarray,
         position: tuple[float, float, float] | np.ndarray,
         fov: float,
-        transport_format: Literal[
-            "auto", "png", "jpeg", "raw_rgb", "raw_rgba"
-        ] = "auto",
+        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "raw_rgb",
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -751,9 +745,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         height: int,
         width: int,
         *,
-        transport_format: Literal[
-            "auto", "png", "jpeg", "raw_rgb", "raw_rgba"
-        ] = "auto",
+        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "raw_rgb",
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -765,9 +757,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         wxyz: tuple[float, float, float, float] | np.ndarray | None = None,
         position: tuple[float, float, float] | np.ndarray | None = None,
         fov: float | None = None,
-        transport_format: Literal[
-            "auto", "png", "jpeg", "raw_rgb", "raw_rgba"
-        ] = "auto",
+        transport_format: Literal["png", "jpeg", "raw_rgb", "raw_rgba"] = "raw_rgb",
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -783,24 +773,22 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 be used.
             fov: Vertical field of view of the camera, in radians. If not provided, the
                 current camera position will be used.
-            transport_format: Image transport format. AUTO (default) returns an (H, W, 3) RGB array
-                rendered on an opaque white background, choosing its wire encoding by content: frames
-                that compress well losslessly (typical 3D scenes) are sent as losslessly compressed
-                pixels -- much faster to encode/decode than JPEG, and pixel-exact -- while anything else
-                falls back to JPEG, so the payload stays small on arbitrary content and connections.
-                JPEG always returns a lossy (H, W, 3) RGB array with a small payload. The raw formats
-                skip image encoding entirely and are the fastest option over local or LAN connections;
-                their frames are losslessly deflate-compressed on the wire when the content compresses,
-                with a worst case of the full width * height * 4 bytes per frame (~8 MB at 1080p):
-                RAW_RGB returns a lossless (H, W, 3) RGB array on the same opaque white background as
-                JPEG, and RAW_RGBA a lossless (H, W, 4) RGBA array on a transparent background. PNG
-                returns a lossless (H, W, 4) RGBA array with a compressed payload, but can cause memory
-                issues on the frontend if called too quickly for higher-resolution images.
+            transport_format: Image transport format. The raw formats skip image encoding and decoding
+                entirely; frames are losslessly deflate-compressed on the wire whenever the content
+                compresses (typical 3D scenes: 100x or more, at a few milliseconds), with a worst case
+                of the full width * height * 4 bytes per frame (~8 MB at 1080p) for incompressible
+                content. RAW_RGB (default) returns a lossless (H, W, 3) RGB array on an opaque white
+                background; RAW_RGBA a lossless (H, W, 4) RGBA array on a transparent background. JPEG
+                returns a lossy (H, W, 3) RGB array whose payload stays small on ANY content; prefer it
+                when clients connect over slow or remote links (e.g. share URLs) and scenes may not
+                compress (photo textures, dense splats). PNG returns a lossless (H, W, 4) RGBA array
+                with a compressed payload, but can cause memory issues on the frontend if called too
+                quickly for higher-resolution images.
 
                 .. versionchanged::
-                    The default changed from ``"jpeg"`` to ``"auto"``: same (H, W, 3) shape and white
-                    background, but frames are now pixel-exact (and faster) whenever the content
-                    compresses well losslessly. Pass ``transport_format="jpeg"`` to force JPEG.
+                    The default changed from ``"jpeg"`` to ``"raw_rgb"``: same (H, W, 3) shape and
+                    white background, but frames are now lossless and typically faster. Pass
+                    ``transport_format="jpeg"`` to recover the previous behavior.
             timeout: Optional maximum seconds to wait for the frame. ``None``
                 (default) waits indefinitely; a disconnect still raises promptly
                 either way. Set this to bound a client that stays connected but
@@ -868,7 +856,6 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 "image/jpeg"
                 if transport_format == "jpeg"
                 else ("image/png" if transport_format == "png" else transport_format),
-                # ^"auto", "raw_rgb", and "raw_rgba" pass through unchanged.
                 height=height,
                 width=width,
                 # Only used for JPEG. The main reason to use a lower quality version
@@ -892,7 +879,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         # this import is slow, and doing it here (request already in flight)
         # overlaps it with the round trip instead of adding to it. The raw
         # transports need no decoder at all.
-        if transport_format in ("auto", "jpeg", "png"):
+        if transport_format in ("jpeg", "png"):
             import imageio.v3 as iio
 
         # Poll rather than wait unbounded: a client that DISCONNECTS (tab
@@ -930,41 +917,6 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         if payload is None or len(payload) == 0:
             raise RuntimeError(
                 "Render request failed: the client could not capture a frame."
-            )
-        if transport_format == "auto":
-            # 1-byte flag chosen by the client per frame: 1 = deflate-raw
-            # compressed RGBA (content compressed losslessly at
-            # JPEG-competitive rates), 2 = JPEG bytes (fallback for
-            # incompressible content). Both decode to (H, W, 3) RGB on the
-            # white background the client rendered with.
-            flag = payload[0]
-            if flag == 1:
-                try:
-                    inflated = zlib.decompress(memoryview(payload)[1:], wbits=-15)
-                except zlib.error as e:
-                    raise RuntimeError(
-                        "Render request failed: the client returned a "
-                        "corrupt compressed frame."
-                    ) from e
-                if len(inflated) != height * width * 4:
-                    raise RuntimeError(
-                        "Render request failed: the client returned "
-                        f"{len(inflated)} bytes, expected {height * width * 4} "
-                        f"for a raw {height}x{width} RGBA frame."
-                    )
-                rgba = np.frombuffer(inflated, np.uint8).reshape(height, width, 4)
-                return rgba[:, :, :3].copy()
-            elif flag == 2:
-                try:
-                    return iio.imread(
-                        io.BytesIO(memoryview(payload)[1:]), extension=".jpeg"
-                    )
-                except Exception as e:
-                    raise RuntimeError(
-                        "Render request failed: the client could not capture a frame."
-                    ) from e
-            raise RuntimeError(
-                f"Render request failed: unknown auto payload flag {flag}."
             )
         if transport_format in ("raw_rgb", "raw_rgba"):
             # RGBA bytes behind a 1-byte flag: 1 means the client

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -503,8 +503,8 @@ class CameraHandle:
         height: int,
         width: int,
         transport_format: Literal[
-            "png", "jpeg", "deflate_rgb", "deflate_rgba"
-        ] = "deflate_rgb",
+            "auto", "png", "jpeg", "deflate_rgb", "deflate_rgba"
+        ] = "auto",
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -513,22 +513,24 @@ class CameraHandle:
         Args:
             height: Height of rendered image. Should be <= the browser height.
             width: Width of rendered image. Should be <= the browser width.
-            transport_format: Image transport format. The deflate formats skip image encoding and decoding
-                entirely; frames are losslessly deflate-compressed on the wire whenever the content
-                compresses (typical 3D scenes: 100x or more, at a few milliseconds), with a worst case
-                of the full width * height * 4 bytes per frame (~8 MB at 1080p) for incompressible
-                content. DEFLATE_RGB (default) returns a lossless (H, W, 3) RGB array on an opaque white
-                background; DEFLATE_RGBA a lossless (H, W, 4) RGBA array on a transparent background. JPEG
-                returns a lossy (H, W, 3) RGB array whose payload stays small on ANY content; prefer it
-                when clients connect over slow or remote links (e.g. share URLs) and scenes may not
-                compress (photo textures, dense splats). PNG returns a lossless (H, W, 4) RGBA array
-                with a compressed payload, but can cause memory issues on the frontend if called too
-                quickly for higher-resolution images.
+            transport_format: Image transport format. AUTO (default) returns an (H, W, 3) RGB array
+                rendered on an opaque white background and picks its wire encoding per frame: frames
+                that compress well losslessly (typical 3D scenes) are sent as losslessly compressed
+                pixels -- pixel-exact and much cheaper than JPEG on both ends -- while high-entropy
+                frames (dense colored point clouds, splats, photo textures, where lossless compression
+                is slow AND ineffective) fall back to JPEG. JPEG always returns a lossy (H, W, 3) RGB
+                array with a small payload on any content. The DEFLATE formats skip image codecs
+                unconditionally: DEFLATE_RGB returns a lossless (H, W, 3) RGB array on white and
+                DEFLATE_RGBA a lossless (H, W, 4) RGBA array on a transparent background, deflate-
+                compressed on the wire when the content compresses, shipped uncompressed (width *
+                height * 4 bytes) otherwise. PNG returns a lossless (H, W, 4) RGBA array with a
+                compressed payload, but can cause memory issues on the frontend if called too quickly
+                for higher-resolution images.
 
                 .. versionchanged::
-                    The default changed from ``"jpeg"`` to ``"deflate_rgb"``: same (H, W, 3) shape and
-                    white background, but frames are now lossless and typically faster. Pass
-                    ``transport_format="jpeg"`` to recover the previous behavior.
+                    The default changed from ``"jpeg"`` to ``"auto"``: same (H, W, 3) shape and white
+                    background, never meaningfully slower, and frames are pixel-exact whenever the
+                    content compresses well losslessly. Pass ``transport_format="jpeg"`` to force JPEG.
             timeout: Optional maximum seconds to wait for the frame. ``None``
                 (default) waits indefinitely; a disconnect still raises promptly
                 either way. Set this to bound a client that stays connected but
@@ -738,8 +740,8 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         position: tuple[float, float, float] | np.ndarray,
         fov: float,
         transport_format: Literal[
-            "png", "jpeg", "deflate_rgb", "deflate_rgba"
-        ] = "deflate_rgb",
+            "auto", "png", "jpeg", "deflate_rgb", "deflate_rgba"
+        ] = "auto",
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -750,8 +752,8 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         width: int,
         *,
         transport_format: Literal[
-            "png", "jpeg", "deflate_rgb", "deflate_rgba"
-        ] = "deflate_rgb",
+            "auto", "png", "jpeg", "deflate_rgb", "deflate_rgba"
+        ] = "auto",
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -764,8 +766,8 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         position: tuple[float, float, float] | np.ndarray | None = None,
         fov: float | None = None,
         transport_format: Literal[
-            "png", "jpeg", "deflate_rgb", "deflate_rgba"
-        ] = "deflate_rgb",
+            "auto", "png", "jpeg", "deflate_rgb", "deflate_rgba"
+        ] = "auto",
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -781,22 +783,24 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 be used.
             fov: Vertical field of view of the camera, in radians. If not provided, the
                 current camera position will be used.
-            transport_format: Image transport format. The deflate formats skip image encoding and decoding
-                entirely; frames are losslessly deflate-compressed on the wire whenever the content
-                compresses (typical 3D scenes: 100x or more, at a few milliseconds), with a worst case
-                of the full width * height * 4 bytes per frame (~8 MB at 1080p) for incompressible
-                content. DEFLATE_RGB (default) returns a lossless (H, W, 3) RGB array on an opaque white
-                background; DEFLATE_RGBA a lossless (H, W, 4) RGBA array on a transparent background. JPEG
-                returns a lossy (H, W, 3) RGB array whose payload stays small on ANY content; prefer it
-                when clients connect over slow or remote links (e.g. share URLs) and scenes may not
-                compress (photo textures, dense splats). PNG returns a lossless (H, W, 4) RGBA array
-                with a compressed payload, but can cause memory issues on the frontend if called too
-                quickly for higher-resolution images.
+            transport_format: Image transport format. AUTO (default) returns an (H, W, 3) RGB array
+                rendered on an opaque white background and picks its wire encoding per frame: frames
+                that compress well losslessly (typical 3D scenes) are sent as losslessly compressed
+                pixels -- pixel-exact and much cheaper than JPEG on both ends -- while high-entropy
+                frames (dense colored point clouds, splats, photo textures, where lossless compression
+                is slow AND ineffective) fall back to JPEG. JPEG always returns a lossy (H, W, 3) RGB
+                array with a small payload on any content. The DEFLATE formats skip image codecs
+                unconditionally: DEFLATE_RGB returns a lossless (H, W, 3) RGB array on white and
+                DEFLATE_RGBA a lossless (H, W, 4) RGBA array on a transparent background, deflate-
+                compressed on the wire when the content compresses, shipped uncompressed (width *
+                height * 4 bytes) otherwise. PNG returns a lossless (H, W, 4) RGBA array with a
+                compressed payload, but can cause memory issues on the frontend if called too quickly
+                for higher-resolution images.
 
                 .. versionchanged::
-                    The default changed from ``"jpeg"`` to ``"deflate_rgb"``: same (H, W, 3) shape and
-                    white background, but frames are now lossless and typically faster. Pass
-                    ``transport_format="jpeg"`` to recover the previous behavior.
+                    The default changed from ``"jpeg"`` to ``"auto"``: same (H, W, 3) shape and white
+                    background, never meaningfully slower, and frames are pixel-exact whenever the
+                    content compresses well losslessly. Pass ``transport_format="jpeg"`` to force JPEG.
             timeout: Optional maximum seconds to wait for the frame. ``None``
                 (default) waits indefinitely; a disconnect still raises promptly
                 either way. Set this to bound a client that stays connected but
@@ -889,7 +893,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         # this import is slow, and doing it here (request already in flight)
         # overlaps it with the round trip instead of adding to it. The
         # deflate transports need no decoder at all.
-        if transport_format in ("jpeg", "png"):
+        if transport_format in ("auto", "jpeg", "png"):
             import imageio.v3 as iio
 
         # Poll rather than wait unbounded: a client that DISCONNECTS (tab
@@ -928,6 +932,38 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
             raise RuntimeError(
                 "Render request failed: the client could not capture a frame."
             )
+        if transport_format == "auto":
+            # 1-byte flag chosen by the client per frame: 1 = deflate-raw
+            # compressed RGBA (content compressed well losslessly), 2 = JPEG
+            # bytes (fallback for high-entropy content). Both decode to
+            # (H, W, 3) RGB on the white background the client rendered with.
+            flag = payload[0]
+            if flag == 1:
+                try:
+                    inflated = zlib.decompress(memoryview(payload)[1:], wbits=-15)
+                except zlib.error as e:
+                    raise RuntimeError(
+                        "Render request failed: the client returned a "
+                        "corrupt compressed frame."
+                    ) from e
+                if len(inflated) != height * width * 4:
+                    raise RuntimeError(
+                        "Render request failed: the client returned "
+                        f"{len(inflated)} bytes, expected {height * width * 4} "
+                        f"for a raw {height}x{width} RGBA frame."
+                    )
+                rgba = np.frombuffer(inflated, np.uint8).reshape(height, width, 4)
+                return rgba[:, :, :3].copy()
+            elif flag == 2:
+                try:
+                    return iio.imread(
+                        io.BytesIO(memoryview(payload)[1:]), extension=".jpeg"
+                    )
+                except Exception as e:
+                    raise RuntimeError(
+                        "Render request failed: the client could not capture a frame."
+                    ) from e
+            raise RuntimeError(f"Render request failed: unknown payload flag {flag}.")
         if transport_format in ("deflate_rgb", "deflate_rgba"):
             # RGBA bytes behind a 1-byte flag: 1 means the client
             # deflate-compressed the pixels (typical renders compress

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -768,6 +768,16 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 (default) waits indefinitely; a disconnect still raises promptly
                 either way. Set this to bound a client that stays connected but
                 never returns a frame (raises ``TimeoutError``).
+
+        Note:
+            Captures reflect all scene *state* updates (poses, colors, visibility,
+            geometry props) made before the call. Content that the browser decodes
+            or loads asynchronously -- large background/image textures, GLB assets,
+            environment maps -- is not awaited: a capture issued immediately after
+            such an update may still show the previous content if the decode hasn't
+            finished (more likely on fast displays, where frames are short relative
+            to decode time). When that matters, capture after the asset has had a
+            moment to load.
         """
 
         # Listen for a render reseponse message, which should contain the rendered

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -501,7 +501,7 @@ class CameraHandle:
         self,
         height: int,
         width: int,
-        transport_format: Literal["png", "jpeg"] = "jpeg",
+        transport_format: Literal["png", "jpeg", "raw"] = "jpeg",
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -512,7 +512,9 @@ class CameraHandle:
             width: Width of rendered image. Should be <= the browser width.
             transport_format: Image transport format. JPEG will return a lossy (H, W, 3) RGB array. PNG will
                 return a lossless (H, W, 4) RGBA array, but can cause memory issues on the frontend if called
-                too quickly for higher-resolution images.
+                too quickly for higher-resolution images. RAW returns a lossless (H, W, 4) RGBA array with no
+                image encoding or decoding at all; it is the fastest option for local or LAN connections, at
+                the cost of transferring uncompressed pixels.
             timeout: Optional maximum seconds to wait for the frame. ``None``
                 (default) waits indefinitely; a disconnect still raises promptly
                 either way. Set this to bound a client that stays connected but
@@ -721,7 +723,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         wxyz: tuple[float, float, float, float] | np.ndarray,
         position: tuple[float, float, float] | np.ndarray,
         fov: float,
-        transport_format: Literal["png", "jpeg"] = "jpeg",
+        transport_format: Literal["png", "jpeg", "raw"] = "jpeg",
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -731,7 +733,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         height: int,
         width: int,
         *,
-        transport_format: Literal["png", "jpeg"] = "jpeg",
+        transport_format: Literal["png", "jpeg", "raw"] = "jpeg",
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -743,7 +745,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         wxyz: tuple[float, float, float, float] | np.ndarray | None = None,
         position: tuple[float, float, float] | np.ndarray | None = None,
         fov: float | None = None,
-        transport_format: Literal["png", "jpeg"] = "jpeg",
+        transport_format: Literal["png", "jpeg", "raw"] = "jpeg",
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -761,7 +763,9 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 current camera position will be used.
             transport_format: Image transport format. JPEG will return a lossy (H, W, 3) RGB array. PNG will
                 return a lossless (H, W, 4) RGBA array, but can cause memory issues on the frontend if called
-                too quickly for higher-resolution images.
+                too quickly for higher-resolution images. RAW returns a lossless (H, W, 4) RGBA array with no
+                image encoding or decoding at all; it is the fastest option for local or LAN connections, at
+                the cost of transferring uncompressed pixels.
             timeout: Optional maximum seconds to wait for the frame. ``None``
                 (default) waits indefinitely; a disconnect still raises promptly
                 either way. Set this to bound a client that stays connected but
@@ -819,9 +823,16 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
             render_ready_event.set()
 
         connection.register_handler(_messages.GetRenderResponseMessage, got_render_cb)
+        # Kick any windowed BROADCAST messages (server.scene updates, which
+        # ride a different buffer than this request) toward the wire before
+        # the request: a capture should reflect scene updates made before the
+        # get_render() call, and the request must not overtake them.
+        self._viser_server.flush()
         self._websock_connection.queue_message(
             _messages.GetRenderRequestMessage(
-                "image/jpeg" if transport_format == "jpeg" else "image/png",
+                "image/jpeg"
+                if transport_format == "jpeg"
+                else ("image/png" if transport_format == "png" else "raw"),
                 height=height,
                 width=width,
                 # Only used for JPEG. The main reason to use a lower quality version
@@ -843,8 +854,10 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
 
         # Import the decoder while the client is busy rendering: on first use
         # this import is slow, and doing it here (request already in flight)
-        # overlaps it with the round trip instead of adding to it.
-        import imageio.v3 as iio
+        # overlaps it with the round trip instead of adding to it. The raw
+        # transport needs no decoder at all.
+        if transport_format != "raw":
+            import imageio.v3 as iio
 
         # Poll rather than wait unbounded: a client that DISCONNECTS (tab
         # closed, network drop) never sends a response, so this raises as soon
@@ -882,6 +895,16 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
             raise RuntimeError(
                 "Render request failed: the client could not capture a frame."
             )
+        if transport_format == "raw":
+            # Unencoded RGBA bytes; just reshape. Copy so the caller gets a
+            # writable array (np.frombuffer views of bytes are read-only).
+            if len(payload) != height * width * 4:
+                raise RuntimeError(
+                    "Render request failed: the client returned "
+                    f"{len(payload)} bytes, expected {height * width * 4} "
+                    f"for a raw {height}x{width} RGBA frame."
+                )
+            return np.frombuffer(payload, np.uint8).reshape(height, width, 4).copy()
         try:
             return iio.imread(
                 io.BytesIO(payload),

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -505,6 +505,7 @@ class CameraHandle:
         transport_format: Literal[
             "png", "jpeg", "deflate_rgb", "deflate_rgba"
         ] = "deflate_rgb",
+        jpeg_quality: int = 80,
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -524,6 +525,10 @@ class CameraHandle:
                 compress (photo textures, dense splats). PNG returns a lossless (H, W, 4) RGBA array
                 with a compressed payload, but can cause memory issues on the frontend if called too
                 quickly for higher-resolution images.
+            jpeg_quality: JPEG encoding quality in [1, 100]; only used when
+                ``transport_format="jpeg"``. Lower values shrink the payload substantially (roughly
+                2x from 80 to 40) and speed up encoding somewhat; PNG and the deflate formats have no
+                equivalent knob (the browser exposes none for PNG).
 
                 .. versionchanged::
                     The default changed from ``"jpeg"`` to ``"deflate_rgb"``: same (H, W, 3) shape and
@@ -535,7 +540,11 @@ class CameraHandle:
                 never returns a frame.
         """
         return self._state.client.get_render(
-            height, width, transport_format=transport_format, timeout=timeout
+            height,
+            width,
+            transport_format=transport_format,
+            jpeg_quality=jpeg_quality,
+            timeout=timeout,
         )
 
 
@@ -740,6 +749,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         transport_format: Literal[
             "png", "jpeg", "deflate_rgb", "deflate_rgba"
         ] = "deflate_rgb",
+        jpeg_quality: int = 80,
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -752,6 +762,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         transport_format: Literal[
             "png", "jpeg", "deflate_rgb", "deflate_rgba"
         ] = "deflate_rgb",
+        jpeg_quality: int = 80,
         timeout: float | None = None,
     ) -> np.ndarray: ...
 
@@ -766,6 +777,7 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         transport_format: Literal[
             "png", "jpeg", "deflate_rgb", "deflate_rgba"
         ] = "deflate_rgb",
+        jpeg_quality: int = 80,
         timeout: float | None = None,
     ) -> np.ndarray:
         """Request a render from a client, block until it's done and received, then
@@ -792,6 +804,10 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 compress (photo textures, dense splats). PNG returns a lossless (H, W, 4) RGBA array
                 with a compressed payload, but can cause memory issues on the frontend if called too
                 quickly for higher-resolution images.
+            jpeg_quality: JPEG encoding quality in [1, 100]; only used when
+                ``transport_format="jpeg"``. Lower values shrink the payload substantially (roughly
+                2x from 80 to 40) and speed up encoding somewhat; PNG and the deflate formats have no
+                equivalent knob (the browser exposes none for PNG).
 
                 .. versionchanged::
                     The default changed from ``"jpeg"`` to ``"deflate_rgb"``: same (H, W, 3) shape and
@@ -802,6 +818,9 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 either way. Set this to bound a client that stays connected but
                 never returns a frame (raises ``TimeoutError``).
         """
+
+        if not 1 <= jpeg_quality <= 100:
+            raise ValueError(f"jpeg_quality must be in [1, 100], got {jpeg_quality}.")
 
         # Listen for a render reseponse message, which should contain the rendered
         # image.
@@ -866,10 +885,8 @@ class ClientHandle(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                 else ("image/png" if transport_format == "png" else transport_format),
                 height=height,
                 width=width,
-                # Only used for JPEG. The main reason to use a lower quality version
-                # value is (unfortunately) to make life easier for the Javascript
-                # garbage collector.
-                quality=80,
+                # Only used for JPEG.
+                quality=jpeg_quality,
                 position=cast_vector(
                     position if position is not None else self.camera.position, 3
                 ),

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -1319,13 +1319,13 @@ export function FrameSynchronizedMessageHandler() {
             true,
           );
 
-        // Configure for capture. JPEG and raw_rgb are RGB results, rendered
-        // on an opaque white background; PNG and raw_rgba are RGBA with a
+        // Configure for capture. JPEG and deflate_rgb are RGB results, rendered
+        // on an opaque white background; PNG and deflate_rgba are RGBA with a
         // transparent background.
         gl.setSize(targetWidth, targetHeight);
         gl.setClearColor(0xffffff);
         gl.setClearAlpha(
-          format === "image/jpeg" || format === "raw_rgb" ? 1.0 : 0.0,
+          format === "image/jpeg" || format === "deflate_rgb" ? 1.0 : 0.0,
         );
 
         // Render the scene.
@@ -1341,11 +1341,11 @@ export function FrameSynchronizedMessageHandler() {
         const ctx = bufferCanvas.getContext("2d")!;
         ctx.drawImage(canvas, 0, 0, targetWidth, targetHeight);
 
-        if (format === "raw_rgb" || format === "raw_rgba") {
-          // RGBA readback. The raw formats send pixels either as-is or
-          // deflate-compressed, decided from a content sample (see
+        if (format === "deflate_rgb" || format === "deflate_rgba") {
+          // RGBA readback. The deflate formats send pixels either
+          // deflate-compressed or as-is, decided from a content sample (see
           // deflateIfCompressible / flagPrefixed). The server drops the
-          // (uniformly opaque) alpha channel for raw_rgb.
+          // (uniformly opaque) alpha channel for deflate_rgb.
           const imageData = ctx.getImageData(0, 0, targetWidth, targetHeight);
           viewerMutable.getRenderRequestState = "ready";
           const pixels = new Uint8Array(

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -928,35 +928,34 @@ function useFileDownloadHandler(): (
   };
 }
 
-/** Pack a raw RGBA render payload, deflate-compressing it when that's worth
- * it. The result carries a 1-byte prefix read by the server's get_render():
- * 0 = uncompressed RGBA follows, 1 = deflate-raw compressed RGBA follows.
+/** Prefix a render payload with its 1-byte encoding flag, read by the
+ * server's get_render(): 0 = uncompressed RGBA, 1 = deflate-raw compressed
+ * RGBA, 2 = JPEG bytes (the "auto" format's fallback). */
+function flagPrefixed(flag: number, data: Uint8Array): Uint8Array<ArrayBuffer> {
+  const out = new Uint8Array(data.length + 1);
+  out[0] = flag;
+  out.set(data, 1);
+  return out;
+}
+
+/** Deflate-compress raw RGBA render pixels when the content compresses at
+ * least `minRatio`; return null when it doesn't (or CompressionStream is
+ * unavailable).
  *
  * Typical 3D renders (flat backgrounds, smooth shading) deflate 100-1000x
- * at a few milliseconds per megapixel, which removes most of the raw
- * formats' bandwidth cost. Incompressible content (photo textures, dense
- * splats) is the exception: deflate then costs tens of milliseconds and
- * saves nothing, so a small strided sample of the frame decides first --
- * CompressionStream exposes no compression-level knob, making a sample the
- * only cheap way to bail out. */
-async function maybeDeflateRenderPayload(
+ * at a few milliseconds per megapixel. Incompressible content (photo
+ * textures, dense splats) is the exception: deflate then costs tens of
+ * milliseconds and saves nothing, so a small strided sample of the frame
+ * decides first -- CompressionStream exposes no compression-level knob,
+ * making a sample the only cheap way to bail out. Callers pick the
+ * threshold: ~1.5x when the alternative is sending uncompressed pixels
+ * (raw formats), ~32x when the alternative is JPEG ("auto": 32x on 32
+ * bits/pixel RGBA is ~1 bit/pixel, competitive with JPEG's rate). */
+async function deflateIfCompressible(
   pixels: Uint8Array<ArrayBuffer>,
-): Promise<Uint8Array<ArrayBuffer>> {
-  const withFlag = (flag: number, data: Uint8Array) => {
-    const out = new Uint8Array(data.length + 1);
-    out[0] = flag;
-    out.set(data, 1);
-    return out;
-  };
-  if (typeof CompressionStream === "undefined") return withFlag(0, pixels);
-
-  const deflate = async (data: Uint8Array<ArrayBuffer>) => {
-    const stream = new CompressionStream("deflate-raw");
-    const writer = stream.writable.getWriter();
-    void writer.write(data);
-    void writer.close();
-    return new Uint8Array(await new Response(stream.readable).arrayBuffer());
-  };
+  minRatio: number,
+): Promise<Uint8Array<ArrayBuffer> | null> {
+  if (typeof CompressionStream === "undefined") return null;
 
   // Small frames: compressing outright costs about as much as sampling.
   const sampleChunk = 4096;
@@ -970,15 +969,77 @@ async function maybeDeflateRenderPayload(
         i * sampleChunk,
       );
     }
-    const sampleCompressed = await deflate(sample);
-    // Under ~1.5x on the sample, full-frame deflate isn't worth its CPU:
-    // send uncompressed (the raw formats' worst case, exactly as before
-    // compression existed).
-    if (sampleCompressed.length * 1.5 > sample.length) {
-      return withFlag(0, pixels);
-    }
+    const sampleCompressed = await deflateRaw(sample);
+    if (sampleCompressed.length * minRatio > sample.length) return null;
   }
-  return withFlag(1, await deflate(pixels));
+  const compressed = await deflateRaw(pixels);
+  // Small frames skip the sample; still honor the caller's threshold.
+  if (compressed.length * minRatio > pixels.length) return null;
+  return compressed;
+}
+
+async function deflateRaw(
+  data: Uint8Array<ArrayBuffer>,
+): Promise<Uint8Array<ArrayBuffer>> {
+  const stream = new CompressionStream("deflate-raw");
+  const writer = stream.writable.getWriter();
+  void writer.write(data);
+  void writer.close();
+  return new Uint8Array(await new Response(stream.readable).arrayBuffer());
+}
+
+/** The "auto" format's lossless path: decide from a few sampled rows whether
+ * the frame deflates at JPEG-competitive rates (~32x on RGBA is ~1
+ * bit/pixel), and return the deflated full frame if so; null means "encode a
+ * JPEG instead". The sample strips are read BEFORE paying for the full-frame
+ * getImageData, so when the answer is JPEG -- the only case where a real
+ * JPEG encode follows -- the readback overhead vs. plain JPEG stays tiny. */
+async function deflateAutoFrame(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+): Promise<Uint8Array<ArrayBuffer> | null> {
+  if (typeof CompressionStream === "undefined") return null;
+
+  // Small frames: deflate outright (bounded at ~10ms even on
+  // incompressible content) -- a tiny sample would be dominated by
+  // deflate's fixed overhead and systematically underestimate the frame's
+  // compressibility.
+  if (width * height * 4 > 512 * 1024) {
+    const sampleRows = Math.min(16, height);
+    const rowBytes = width * 4;
+    const sample = new Uint8Array(sampleRows * rowBytes);
+    for (let i = 0; i < sampleRows; i++) {
+      const y = Math.floor((i * (height - 1)) / Math.max(1, sampleRows - 1));
+      const strip = ctx.getImageData(0, y, width, 1);
+      sample.set(
+        new Uint8Array(
+          strip.data.buffer as ArrayBuffer,
+          strip.data.byteOffset,
+          strip.data.byteLength,
+        ),
+        i * rowBytes,
+      );
+    }
+    // The strip sample underestimates the full frame's ratio (no vertical
+    // redundancy, per-stream overhead), so gate at 16x as a biased-down
+    // proxy for "JPEG-competitive"; the final guard below bounds the cases
+    // where even that was too optimistic.
+    const sampleCompressed = await deflateRaw(sample);
+    if (sampleCompressed.length * 16.0 > sample.length) return null;
+  }
+
+  const img = ctx.getImageData(0, 0, width, height);
+  const pixels = new Uint8Array(
+    img.data.buffer as ArrayBuffer,
+    img.data.byteOffset,
+    img.data.byteLength,
+  );
+  const compressed = await deflateRaw(pixels);
+  // Final guard: never ship a payload outlandishly larger than the JPEG
+  // would have been.
+  if (compressed.length * 8 > pixels.length) return null;
+  return compressed;
 }
 
 export function FrameSynchronizedMessageHandler() {
@@ -1315,13 +1376,15 @@ export function FrameSynchronizedMessageHandler() {
             true,
           );
 
-        // Configure for capture. JPEG and raw_rgb are RGB results, rendered
-        // on an opaque white background; PNG and raw_rgba are RGBA with a
-        // transparent background.
+        // Configure for capture. JPEG, raw_rgb, and auto are RGB results,
+        // rendered on an opaque white background; PNG and raw_rgba are RGBA
+        // with a transparent background.
         gl.setSize(targetWidth, targetHeight);
         gl.setClearColor(0xffffff);
         gl.setClearAlpha(
-          format === "image/jpeg" || format === "raw_rgb" ? 1.0 : 0.0,
+          format === "image/jpeg" || format === "raw_rgb" || format === "auto"
+            ? 1.0
+            : 0.0,
         );
 
         // Render the scene.
@@ -1338,10 +1401,10 @@ export function FrameSynchronizedMessageHandler() {
         ctx.drawImage(canvas, 0, 0, targetWidth, targetHeight);
 
         if (format === "raw_rgb" || format === "raw_rgba") {
-          // Unencoded RGBA readback: no image encode here, no image decode
-          // on the server. Both raw formats send RGBA bytes (adaptively
-          // deflate-compressed, see maybeDeflateRenderPayload); the server
-          // drops the (uniformly opaque) alpha channel for raw_rgb.
+          // RGBA readback. The raw formats send pixels either as-is or
+          // deflate-compressed, decided from a content sample (see
+          // deflateIfCompressible / flagPrefixed). The server drops the
+          // (uniformly opaque) alpha channel for raw_rgb.
           const imageData = ctx.getImageData(0, 0, targetWidth, targetHeight);
           viewerMutable.getRenderRequestState = "ready";
           const pixels = new Uint8Array(
@@ -1351,7 +1414,57 @@ export function FrameSynchronizedMessageHandler() {
           );
           void (async () => {
             try {
-              sendRenderResponse(await maybeDeflateRenderPayload(pixels));
+              const deflated = await deflateIfCompressible(pixels, 1.5);
+              sendRenderResponse(
+                deflated === null
+                  ? flagPrefixed(0, pixels)
+                  : flagPrefixed(1, deflated),
+              );
+            } catch (e) {
+              console.error("Failed to pack rendered image:", e);
+              sendRenderResponse(new Uint8Array(0));
+            }
+          })();
+        } else if (format === "auto") {
+          // Content-adaptive: losslessly deflate-compressed pixels when the
+          // frame compresses at JPEG-competitive rates, an actual JPEG
+          // otherwise (see deflateAutoFrame). bufferCanvas is captured by
+          // the closure and immutable, so all readbacks can happen after
+          // message handling resumes.
+          const quality = viewerMutable.getRenderRequest!.quality;
+          viewerMutable.getRenderRequestState = "ready";
+          void (async () => {
+            try {
+              const deflated = await deflateAutoFrame(
+                ctx,
+                targetWidth,
+                targetHeight,
+              );
+              if (deflated !== null) {
+                sendRenderResponse(flagPrefixed(1, deflated));
+                return;
+              }
+              bufferCanvas.toBlob(
+                (blob) => {
+                  void (async () => {
+                    try {
+                      sendRenderResponse(
+                        blob === null
+                          ? new Uint8Array(0)
+                          : flagPrefixed(
+                              2,
+                              new Uint8Array(await blob.arrayBuffer()),
+                            ),
+                      );
+                    } catch (e) {
+                      console.error("Failed to read rendered image:", e);
+                      sendRenderResponse(new Uint8Array(0));
+                    }
+                  })();
+                },
+                "image/jpeg",
+                quality / 100.0,
+              );
             } catch (e) {
               console.error("Failed to pack rendered image:", e);
               sendRenderResponse(new Uint8Array(0));

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -930,7 +930,7 @@ function useFileDownloadHandler(): (
 
 /** Prefix a render payload with its 1-byte encoding flag, read by the
  * server's get_render(): 0 = uncompressed RGBA, 1 = deflate-raw compressed
- * RGBA. */
+ * RGBA, 2 = JPEG bytes (the "auto" format's fallback). */
 function flagPrefixed(flag: number, data: Uint8Array): Uint8Array<ArrayBuffer> {
   const out = new Uint8Array(data.length + 1);
   out[0] = flag;
@@ -987,6 +987,63 @@ async function deflateRaw(
   void writer.write(data);
   void writer.close();
   return new Uint8Array(await new Response(stream.readable).arrayBuffer());
+}
+
+/** The "auto" format's lossless path: decide from a few sampled rows whether
+ * the frame deflates well, and return the deflated full frame if so; null
+ * means "encode a JPEG instead". High-entropy content (dense colored point
+ * clouds, splats, photo textures) is exactly where deflate is slowest AND
+ * least effective (measured ~2x at 100-270ms per 720p frame), so it must
+ * take the JPEG branch. The sample strips are read BEFORE paying for the
+ * full-frame getImageData, so when the answer is JPEG -- the only case
+ * where a real JPEG encode follows -- the readback overhead vs. plain JPEG
+ * stays tiny. */
+async function deflateAutoFrame(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+): Promise<Uint8Array<ArrayBuffer> | null> {
+  if (typeof CompressionStream === "undefined") return null;
+
+  // Small frames: deflate outright (bounded at ~10ms even on
+  // incompressible content) -- a tiny sample would be dominated by
+  // deflate's fixed overhead and systematically underestimate the frame's
+  // compressibility.
+  if (width * height * 4 > 512 * 1024) {
+    const sampleRows = Math.min(16, height);
+    const rowBytes = width * 4;
+    const sample = new Uint8Array(sampleRows * rowBytes);
+    for (let i = 0; i < sampleRows; i++) {
+      const y = Math.floor((i * (height - 1)) / Math.max(1, sampleRows - 1));
+      const strip = ctx.getImageData(0, y, width, 1);
+      sample.set(
+        new Uint8Array(
+          strip.data.buffer as ArrayBuffer,
+          strip.data.byteOffset,
+          strip.data.byteLength,
+        ),
+        i * rowBytes,
+      );
+    }
+    // The strip sample underestimates the full frame's ratio (no vertical
+    // redundancy, per-stream overhead), so gate at 16x as a biased-down
+    // proxy for "compresses well"; the final guard below bounds the cases
+    // where even that was too optimistic.
+    const sampleCompressed = await deflateRaw(sample);
+    if (sampleCompressed.length * 16.0 > sample.length) return null;
+  }
+
+  const img = ctx.getImageData(0, 0, width, height);
+  const pixels = new Uint8Array(
+    img.data.buffer as ArrayBuffer,
+    img.data.byteOffset,
+    img.data.byteLength,
+  );
+  const compressed = await deflateRaw(pixels);
+  // Final guard: never ship a payload outlandishly larger than the JPEG
+  // would have been.
+  if (compressed.length * 8 > pixels.length) return null;
+  return compressed;
 }
 
 export function FrameSynchronizedMessageHandler() {
@@ -1324,13 +1381,17 @@ export function FrameSynchronizedMessageHandler() {
             true,
           );
 
-        // Configure for capture. JPEG and deflate_rgb are RGB results, rendered
-        // on an opaque white background; PNG and deflate_rgba are RGBA with a
-        // transparent background.
+        // Configure for capture. JPEG, deflate_rgb, and auto are RGB
+        // results, rendered on an opaque white background; PNG and
+        // deflate_rgba are RGBA with a transparent background.
         gl.setSize(targetWidth, targetHeight);
         gl.setClearColor(0xffffff);
         gl.setClearAlpha(
-          format === "image/jpeg" || format === "deflate_rgb" ? 1.0 : 0.0,
+          format === "image/jpeg" ||
+            format === "deflate_rgb" ||
+            format === "auto"
+            ? 1.0
+            : 0.0,
         );
 
         // Render the scene.
@@ -1365,6 +1426,50 @@ export function FrameSynchronizedMessageHandler() {
                 deflated === null
                   ? flagPrefixed(0, pixels)
                   : flagPrefixed(1, deflated),
+              );
+            } catch (e) {
+              console.error("Failed to pack rendered image:", e);
+              sendRenderResponse(new Uint8Array(0));
+            }
+          })();
+        } else if (format === "auto") {
+          // Content-adaptive: losslessly deflate-compressed pixels when the
+          // frame compresses well, an actual JPEG otherwise (see
+          // deflateAutoFrame). bufferCanvas is captured by the closure and
+          // immutable, so all readbacks can happen after message handling
+          // resumes.
+          viewerMutable.getRenderRequestState = "ready";
+          void (async () => {
+            try {
+              const deflated = await deflateAutoFrame(
+                ctx,
+                targetWidth,
+                targetHeight,
+              );
+              if (deflated !== null) {
+                sendRenderResponse(flagPrefixed(1, deflated));
+                return;
+              }
+              bufferCanvas.toBlob(
+                (blob) => {
+                  void (async () => {
+                    try {
+                      sendRenderResponse(
+                        blob === null
+                          ? new Uint8Array(0)
+                          : flagPrefixed(
+                              2,
+                              new Uint8Array(await blob.arrayBuffer()),
+                            ),
+                      );
+                    } catch (e) {
+                      console.error("Failed to read rendered image:", e);
+                      sendRenderResponse(new Uint8Array(0));
+                    }
+                  })();
+                },
+                "image/jpeg",
+                quality / 100.0,
               );
             } catch (e) {
               console.error("Failed to pack rendered image:", e);

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -1221,6 +1221,7 @@ export function FrameSynchronizedMessageHandler() {
       const targetWidth = viewerMutable.getRenderRequest!.width;
       const targetHeight = viewerMutable.getRenderRequest!.height;
       const format = viewerMutable.getRenderRequest!.format;
+      const quality = viewerMutable.getRenderRequest!.quality;
       // Captured now so the response can be correlated to its request even
       // after the async toBlob below.
       const renderUuid = viewerMutable.getRenderRequest!.render_uuid;
@@ -1375,23 +1376,30 @@ export function FrameSynchronizedMessageHandler() {
           // message handling can resume NOW: the async encode below overlaps
           // with whatever comes next, including the next capture.
           viewerMutable.getRenderRequestState = "ready";
-          bufferCanvas.toBlob((blob) => {
-            void (async () => {
-              try {
-                // `toBlob` can hand back null (e.g. canvas too large / OOM);
-                // fall back to an empty payload so the server's pending
-                // request resolves instead of hanging forever.
-                sendRenderResponse(
-                  blob === null
-                    ? new Uint8Array(0)
-                    : new Uint8Array(await blob.arrayBuffer()),
-                );
-              } catch (e) {
-                console.error("Failed to read rendered image:", e);
-                sendRenderResponse(new Uint8Array(0));
-              }
-            })();
-          }, format);
+          bufferCanvas.toBlob(
+            (blob) => {
+              void (async () => {
+                try {
+                  // `toBlob` can hand back null (e.g. canvas too large / OOM);
+                  // fall back to an empty payload so the server's pending
+                  // request resolves instead of hanging forever.
+                  sendRenderResponse(
+                    blob === null
+                      ? new Uint8Array(0)
+                      : new Uint8Array(await blob.arrayBuffer()),
+                  );
+                } catch (e) {
+                  console.error("Failed to read rendered image:", e);
+                  sendRenderResponse(new Uint8Array(0));
+                }
+              })();
+              // The quality argument applies to JPEG only (PNG's encoder has
+              // no knobs in the web API); omitting it would silently encode
+              // at Chrome's 0.92 default -- larger and no faster.
+            },
+            format,
+            format === "image/jpeg" ? quality / 100.0 : undefined,
+          );
         }
       } catch (e) {
         console.error("Render request failed:", e);

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -1330,9 +1330,15 @@ export function FrameSynchronizedMessageHandler() {
         }
       }
     },
-    // After SceneTree's pose appliers (-1000), before the frame's regular
-    // render (0).
-    -1,
+    // Between SceneTree's pose appliers (-1000) and the Gaussian splat
+    // per-frame hook (-100): capture must see this frame's poses, and the
+    // splat hook must run AFTER capture so it re-applies interactive-camera
+    // splat state (uniforms, group transforms, async sort) that the
+    // capture's virtual-camera updateCamera(..., blockingSort=true) call
+    // mutates -- capture only restores the sorted-index attribute itself.
+    // At a later priority, the frame's visible render would draw the
+    // interactive viewport with the virtual camera's splat state.
+    -500,
   );
 
   return null;

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -1262,12 +1262,14 @@ export function FrameSynchronizedMessageHandler() {
             true,
           );
 
-        // Configure for capture. JPEG has no alpha channel, so it gets an
-        // opaque white background; PNG and raw are RGBA with a transparent
-        // background.
+        // Configure for capture. JPEG and raw_rgb are RGB results, rendered
+        // on an opaque white background; PNG and raw_rgba are RGBA with a
+        // transparent background.
         gl.setSize(targetWidth, targetHeight);
         gl.setClearColor(0xffffff);
-        gl.setClearAlpha(format === "image/jpeg" ? 1.0 : 0.0);
+        gl.setClearAlpha(
+          format === "image/jpeg" || format === "raw_rgb" ? 1.0 : 0.0,
+        );
 
         // Render the scene.
         gl.render(viewerMutable.scene!, camera);
@@ -1282,9 +1284,10 @@ export function FrameSynchronizedMessageHandler() {
         const ctx = bufferCanvas.getContext("2d")!;
         ctx.drawImage(canvas, 0, 0, targetWidth, targetHeight);
 
-        if (format === "raw") {
+        if (format === "raw_rgb" || format === "raw_rgba") {
           // Unencoded RGBA readback: no image encode here, no image decode
-          // on the server.
+          // on the server. Both raw formats send RGBA bytes; the server
+          // drops the (uniformly opaque) alpha channel for raw_rgb.
           const imageData = ctx.getImageData(0, 0, targetWidth, targetHeight);
           viewerMutable.getRenderRequestState = "ready";
           sendRenderResponse(

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -253,10 +253,13 @@ function useMessageHandler() {
         setShareUrl(message.share_url);
         return;
       }
-      // Request a render.
+      // Request a render. "commit_wait" gives React one frame to commit any
+      // scene updates processed in the same batch; the message-processing
+      // loop upgrades this to "capture" directly when the request arrived
+      // with no preceding messages (nothing pending a commit).
       case "GetRenderRequestMessage": {
         viewerMutable.getRenderRequest = message;
-        viewerMutable.getRenderRequestState = "triggered";
+        viewerMutable.getRenderRequestState = "commit_wait";
         return;
       }
       // Set the GUI panel label.
@@ -935,153 +938,9 @@ export function FrameSynchronizedMessageHandler() {
 
   useFrame(
     () => {
-      // Send a render along if it was requested!
-      if (viewerMutable.getRenderRequestState === "triggered") {
-        viewerMutable.getRenderRequestState = "pause";
-      } else if (viewerMutable.getRenderRequestState === "pause") {
-        const targetWidth = viewerMutable.getRenderRequest!.width;
-        const targetHeight = viewerMutable.getRenderRequest!.height;
-        const format = viewerMutable.getRenderRequest!.format;
-        // Captured now so the response can be correlated to its request even
-        // after the async toBlob below.
-        const renderUuid = viewerMutable.getRenderRequest!.render_uuid;
-
-        // Snapshot renderer state up front so the `finally` below can always
-        // restore it, even if rendering throws partway through.
-        const originalSize = gl.getSize(new THREE.Vector2());
-        const originalClearColor = gl.getClearColor(new THREE.Color());
-        const originalClearAlpha = gl.getClearAlpha();
-
-        // Splat sorted-index backup, restored in `finally`.
-        const splatMeshProps = splatContext.meshPropsRef.current;
-        const sortedIndicesOrig =
-          splatMeshProps !== null
-            ? splatMeshProps.sortedIndexAttribute.array.slice()
-            : null;
-
-        // An empty payload is the failure sentinel: it lets the server's
-        // pending get_render() resolve instead of blocking forever.
-        const sendRenderResponse = (payload: Uint8Array<ArrayBuffer>) =>
-          viewerMutable.sendMessage({
-            type: "GetRenderResponseMessage",
-            payload,
-            render_uuid: renderUuid,
-          });
-
-        // Once we enter capture we must always return to "ready" -- otherwise
-        // an exception (or a null toBlob) would wedge the render state machine
-        // and block all further message handling, which is gated on "ready".
-        try {
-          const cameraPosition = viewerMutable.getRenderRequest!.position;
-          const cameraWxyz = viewerMutable.getRenderRequest!.wxyz;
-          const cameraFov = viewerMutable.getRenderRequest!.fov;
-
-          // Render the scene using the virtual camera.
-          const T_threeworld_world = computeT_threeworld_world(viewer);
-
-          // Create a new perspective camera.
-          const camera = new THREE.PerspectiveCamera(
-            THREE.MathUtils.radToDeg(cameraFov),
-            targetWidth / targetHeight,
-            0.01, // Near.
-            1000.0, // Far.
-          );
-
-          // Set camera pose.
-          camera.position
-            .set(...cameraPosition)
-            .applyMatrix4(T_threeworld_world);
-          camera.setRotationFromQuaternion(
-            new THREE.Quaternion(
-              cameraWxyz[1],
-              cameraWxyz[2],
-              cameraWxyz[3],
-              cameraWxyz[0],
-            )
-              .premultiply(
-                new THREE.Quaternion().setFromRotationMatrix(
-                  T_threeworld_world,
-                ),
-              )
-              .multiply(
-                // OpenCV => OpenGL coordinate system conversion.
-                new THREE.Quaternion().setFromAxisAngle(
-                  new THREE.Vector3(1, 0, 0),
-                  Math.PI,
-                ),
-              ),
-          );
-
-          // Update splatting camera if needed.
-          if (splatContext.updateCamera.current !== null)
-            splatContext.updateCamera.current!(
-              camera,
-              targetWidth,
-              targetHeight,
-              true,
-            );
-
-          // Configure for capture.
-          gl.setSize(targetWidth, targetHeight);
-          gl.setClearColor(0xffffff);
-          gl.setClearAlpha(format == "image/png" ? 0.0 : 1.0);
-
-          // Render the scene.
-          gl.render(viewerMutable.scene!, camera);
-
-          // Temporary canvas for saving the rendered image. This is needed to
-          // prevent flickers: we need context from the original canvas for
-          // rendering, but we want to revert the renderer state immediately.
-          const canvas = gl.domElement;
-          const bufferCanvas = document.createElement("canvas");
-          bufferCanvas.width = targetWidth;
-          bufferCanvas.height = targetHeight;
-          const ctx = bufferCanvas.getContext("2d")!;
-          ctx.drawImage(canvas, 0, 0, targetWidth, targetHeight);
-
-          // Get the rendered image from our temp canvas.
-          viewerMutable.getRenderRequestState = "in_progress";
-          bufferCanvas.toBlob((blob) => {
-            void (async () => {
-              try {
-                // `toBlob` can hand back null (e.g. canvas too large / OOM);
-                // fall back to an empty payload so the server's pending
-                // request resolves instead of hanging forever.
-                sendRenderResponse(
-                  blob === null
-                    ? new Uint8Array(0)
-                    : new Uint8Array(await blob.arrayBuffer()),
-                );
-              } catch (e) {
-                console.error("Failed to read rendered image:", e);
-                sendRenderResponse(new Uint8Array(0));
-              } finally {
-                viewerMutable.getRenderRequestState = "ready";
-              }
-            })();
-          }, format);
-        } catch (e) {
-          console.error("Render request failed:", e);
-          // The toBlob callback won't run, so send the failure sentinel now --
-          // otherwise the server's get_render() blocks forever waiting for a
-          // response. Then resume message handling.
-          sendRenderResponse(new Uint8Array(0));
-          viewerMutable.getRenderRequestState = "ready";
-        } finally {
-          // Restore the original renderer state.
-          gl.setSize(originalSize.x, originalSize.y);
-          gl.setClearColor(originalClearColor);
-          gl.setClearAlpha(originalClearAlpha);
-
-          // Restore splatting indices.
-          if (sortedIndicesOrig !== null && splatMeshProps !== null) {
-            splatMeshProps.sortedIndexAttribute.array = sortedIndicesOrig;
-            splatMeshProps.sortedIndexAttribute.needsUpdate = true;
-          }
-        }
-      }
-
       // Handle messages, but only if we're not trying to render something.
+      // (Render capture itself lives in the second useFrame below, which runs
+      // later in the same frame -- after SceneTree's pose appliers.)
       if (
         viewerMutable.getRenderRequestState === "ready" &&
         messageQueue.length > 0
@@ -1262,6 +1121,16 @@ export function FrameSynchronizedMessageHandler() {
             viewer.sceneTreeActions.computeEffectiveVisibility(nodeName);
           }
         }
+
+        // A render request that arrived with no messages in front of it has
+        // nothing waiting on a React commit: skip "commit_wait" so the
+        // capture hook below fires this same frame, after the SceneTree pose
+        // appliers. This is the common case for tight get_render() loops.
+        // (requestRenderIndex === 0 means the processed batch was exactly the
+        // request, whose handler just set the state to "commit_wait".)
+        if (requestRenderIndex === 0) {
+          viewerMutable.getRenderRequestState = "capture";
+        }
       }
     },
     // We should handle messages before doing anything else!!
@@ -1269,6 +1138,208 @@ export function FrameSynchronizedMessageHandler() {
     // Importantly, this priority should be *lower* than the useFrame priority
     // used to update scene node transforms in SceneTree.tsx.
     -100000,
+  );
+
+  // Render capture for get_render() requests, in its own hook so it can run
+  // at a priority AFTER SceneTree's per-node pose appliers (-1000) and the
+  // message handler above (-100000). Captures therefore see the poses applied
+  // earlier in the SAME frame, which is what lets a request skip idle frames:
+  // an implementation that captures before pose application (the old one ran
+  // at -100000) has to idle extra frames to compensate.
+  useFrame(
+    () => {
+      if (viewerMutable.getRenderRequestState === "commit_wait") {
+        // The batch that carried this request also carried scene updates.
+        // React flushes those commits (sync lane) before the next frame;
+        // capture on the next pass.
+        viewerMutable.getRenderRequestState = "capture";
+        return;
+      }
+      if (viewerMutable.getRenderRequestState !== "capture") return;
+
+      const targetWidth = viewerMutable.getRenderRequest!.width;
+      const targetHeight = viewerMutable.getRenderRequest!.height;
+      const format = viewerMutable.getRenderRequest!.format;
+      // Captured now so the response can be correlated to its request even
+      // after the async toBlob below.
+      const renderUuid = viewerMutable.getRenderRequest!.render_uuid;
+
+      // Snapshot renderer state up front so the `finally` below can always
+      // restore it, even if rendering throws partway through.
+      const originalSize = gl.getSize(new THREE.Vector2());
+      const originalClearColor = gl.getClearColor(new THREE.Color());
+      const originalClearAlpha = gl.getClearAlpha();
+
+      // Splat sorted-index backup, restored in `finally`.
+      const splatMeshProps = splatContext.meshPropsRef.current;
+      const sortedIndicesOrig =
+        splatMeshProps !== null
+          ? splatMeshProps.sortedIndexAttribute.array.slice()
+          : null;
+
+      // An empty payload is the failure sentinel: it lets the server's
+      // pending get_render() resolve instead of blocking forever.
+      const sendRenderResponse = (payload: Uint8Array<ArrayBuffer>) =>
+        viewerMutable.sendMessage({
+          type: "GetRenderResponseMessage",
+          payload,
+          render_uuid: renderUuid,
+        });
+
+      // Once we enter capture we must always return to "ready" -- otherwise
+      // an exception (or a null toBlob) would wedge the render state machine
+      // and block all further message handling, which is gated on "ready".
+      try {
+        // Defensively apply node poses still marked "needsUpdate": a pose
+        // marked by a React effect that ran after this frame's SceneTree
+        // applier pass (e.g. a node that just [re]mounted) would otherwise
+        // be captured stale.
+        for (const [name, pose] of Object.entries(viewerMutable.nodePoseData)) {
+          if (pose === undefined || pose.poseUpdateState !== "needsUpdate")
+            continue;
+          const obj = viewerMutable.nodeRefFromName[name];
+          if (obj === undefined) continue;
+          pose.poseUpdateState = "updated";
+          if (viewer.useSceneTree.get(name)?.message.type !== "LabelMessage") {
+            obj.quaternion.set(
+              pose.wxyz[1],
+              pose.wxyz[2],
+              pose.wxyz[3],
+              pose.wxyz[0],
+            );
+          }
+          obj.position.set(
+            pose.position[0],
+            pose.position[1],
+            pose.position[2],
+          );
+          if (!obj.matrixAutoUpdate) obj.updateMatrix();
+          if (!obj.matrixWorldAutoUpdate) obj.updateMatrixWorld();
+        }
+
+        const cameraPosition = viewerMutable.getRenderRequest!.position;
+        const cameraWxyz = viewerMutable.getRenderRequest!.wxyz;
+        const cameraFov = viewerMutable.getRenderRequest!.fov;
+
+        // Render the scene using the virtual camera.
+        const T_threeworld_world = computeT_threeworld_world(viewer);
+
+        // Create a new perspective camera.
+        const camera = new THREE.PerspectiveCamera(
+          THREE.MathUtils.radToDeg(cameraFov),
+          targetWidth / targetHeight,
+          0.01, // Near.
+          1000.0, // Far.
+        );
+
+        // Set camera pose.
+        camera.position.set(...cameraPosition).applyMatrix4(T_threeworld_world);
+        camera.setRotationFromQuaternion(
+          new THREE.Quaternion(
+            cameraWxyz[1],
+            cameraWxyz[2],
+            cameraWxyz[3],
+            cameraWxyz[0],
+          )
+            .premultiply(
+              new THREE.Quaternion().setFromRotationMatrix(T_threeworld_world),
+            )
+            .multiply(
+              // OpenCV => OpenGL coordinate system conversion.
+              new THREE.Quaternion().setFromAxisAngle(
+                new THREE.Vector3(1, 0, 0),
+                Math.PI,
+              ),
+            ),
+        );
+
+        // Update splatting camera if needed.
+        if (splatContext.updateCamera.current !== null)
+          splatContext.updateCamera.current!(
+            camera,
+            targetWidth,
+            targetHeight,
+            true,
+          );
+
+        // Configure for capture. JPEG has no alpha channel, so it gets an
+        // opaque white background; PNG and raw are RGBA with a transparent
+        // background.
+        gl.setSize(targetWidth, targetHeight);
+        gl.setClearColor(0xffffff);
+        gl.setClearAlpha(format === "image/jpeg" ? 1.0 : 0.0);
+
+        // Render the scene.
+        gl.render(viewerMutable.scene!, camera);
+
+        // Temporary canvas for saving the rendered image. This is needed to
+        // prevent flickers: we need context from the original canvas for
+        // rendering, but we want to revert the renderer state immediately.
+        const canvas = gl.domElement;
+        const bufferCanvas = document.createElement("canvas");
+        bufferCanvas.width = targetWidth;
+        bufferCanvas.height = targetHeight;
+        const ctx = bufferCanvas.getContext("2d")!;
+        ctx.drawImage(canvas, 0, 0, targetWidth, targetHeight);
+
+        if (format === "raw") {
+          // Unencoded RGBA readback: no image encode here, no image decode
+          // on the server.
+          const imageData = ctx.getImageData(0, 0, targetWidth, targetHeight);
+          viewerMutable.getRenderRequestState = "ready";
+          sendRenderResponse(
+            new Uint8Array(
+              imageData.data.buffer as ArrayBuffer,
+              imageData.data.byteOffset,
+              imageData.data.byteLength,
+            ),
+          );
+        } else {
+          // The pixels are copied out of the renderer at this point, so
+          // message handling can resume NOW: the async encode below overlaps
+          // with whatever comes next, including the next capture.
+          viewerMutable.getRenderRequestState = "ready";
+          bufferCanvas.toBlob((blob) => {
+            void (async () => {
+              try {
+                // `toBlob` can hand back null (e.g. canvas too large / OOM);
+                // fall back to an empty payload so the server's pending
+                // request resolves instead of hanging forever.
+                sendRenderResponse(
+                  blob === null
+                    ? new Uint8Array(0)
+                    : new Uint8Array(await blob.arrayBuffer()),
+                );
+              } catch (e) {
+                console.error("Failed to read rendered image:", e);
+                sendRenderResponse(new Uint8Array(0));
+              }
+            })();
+          }, format);
+        }
+      } catch (e) {
+        console.error("Render request failed:", e);
+        // The response wasn't sent above, so send the failure sentinel now --
+        // otherwise the server's get_render() blocks forever waiting for a
+        // response. Then resume message handling.
+        sendRenderResponse(new Uint8Array(0));
+        viewerMutable.getRenderRequestState = "ready";
+      } finally {
+        // Restore the original renderer state.
+        gl.setSize(originalSize.x, originalSize.y);
+        gl.setClearColor(originalClearColor);
+        gl.setClearAlpha(originalClearAlpha);
+
+        // Restore splatting indices.
+        if (sortedIndicesOrig !== null && splatMeshProps !== null) {
+          splatMeshProps.sortedIndexAttribute.array = sortedIndicesOrig;
+          splatMeshProps.sortedIndexAttribute.needsUpdate = true;
+        }
+      }
+    },
+    // After SceneTree's pose appliers (-1000), before the frame's regular
+    // render (0).
+    -1,
   );
 
   return null;

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -928,124 +928,6 @@ function useFileDownloadHandler(): (
   };
 }
 
-/** Prefix a render payload with its 1-byte encoding flag, read by the
- * server's get_render(): 0 = uncompressed RGBA, 1 = deflate-raw compressed
- * RGBA, 2 = JPEG bytes (the "auto" format's fallback). */
-function flagPrefixed(flag: number, data: Uint8Array): Uint8Array<ArrayBuffer> {
-  const out = new Uint8Array(data.length + 1);
-  out[0] = flag;
-  out.set(data, 1);
-  return out;
-}
-
-/** Deflate-compress raw RGBA render pixels when the content compresses at
- * least `minRatio`; return null when it doesn't (or CompressionStream is
- * unavailable).
- *
- * Measured on captured 720p frames: geometric scenes deflate 77-530x at
- * 12-18ms, while high-entropy content (random-colored dense point clouds
- * ~2.1x, photo/noise textures ~1.7x) costs 100-270ms -- deflate is slowest
- * exactly where it saves least, and CompressionStream exposes no
- * compression-level knob to cheapen it. A small strided sample therefore
- * decides first, and the threshold below is deliberately well above
- * break-even-on-bytes: in the low-ratio regime the CPU cost dwarfs the
- * bandwidth saved on the local/LAN links these formats target. (A PNG-style
- * per-row delta filter was also measured and does NOT improve any of these
- * ratios; don't bother.) */
-async function deflateIfCompressible(
-  pixels: Uint8Array<ArrayBuffer>,
-  minRatio: number,
-): Promise<Uint8Array<ArrayBuffer> | null> {
-  if (typeof CompressionStream === "undefined") return null;
-
-  // Small frames: compressing outright costs about as much as sampling.
-  const sampleChunk = 4096;
-  const sampleCount = 64;
-  if (pixels.length > 2 * sampleChunk * sampleCount) {
-    const stride = Math.floor(pixels.length / sampleCount);
-    const sample = new Uint8Array(sampleChunk * sampleCount);
-    for (let i = 0; i < sampleCount; i++) {
-      sample.set(
-        pixels.subarray(i * stride, i * stride + sampleChunk),
-        i * sampleChunk,
-      );
-    }
-    const sampleCompressed = await deflateRaw(sample);
-    if (sampleCompressed.length * minRatio > sample.length) return null;
-  }
-  const compressed = await deflateRaw(pixels);
-  // Small frames skip the sample; still honor the caller's threshold.
-  if (compressed.length * minRatio > pixels.length) return null;
-  return compressed;
-}
-
-async function deflateRaw(
-  data: Uint8Array<ArrayBuffer>,
-): Promise<Uint8Array<ArrayBuffer>> {
-  const stream = new CompressionStream("deflate-raw");
-  const writer = stream.writable.getWriter();
-  void writer.write(data);
-  void writer.close();
-  return new Uint8Array(await new Response(stream.readable).arrayBuffer());
-}
-
-/** The "auto" format's lossless path: decide from a few sampled rows whether
- * the frame deflates well, and return the deflated full frame if so; null
- * means "encode a JPEG instead". High-entropy content (dense colored point
- * clouds, splats, photo textures) is exactly where deflate is slowest AND
- * least effective (measured ~2x at 100-270ms per 720p frame), so it must
- * take the JPEG branch. The sample strips are read BEFORE paying for the
- * full-frame getImageData, so when the answer is JPEG -- the only case
- * where a real JPEG encode follows -- the readback overhead vs. plain JPEG
- * stays tiny. */
-async function deflateAutoFrame(
-  ctx: CanvasRenderingContext2D,
-  width: number,
-  height: number,
-): Promise<Uint8Array<ArrayBuffer> | null> {
-  if (typeof CompressionStream === "undefined") return null;
-
-  // Small frames: deflate outright (bounded at ~10ms even on
-  // incompressible content) -- a tiny sample would be dominated by
-  // deflate's fixed overhead and systematically underestimate the frame's
-  // compressibility.
-  if (width * height * 4 > 512 * 1024) {
-    const sampleRows = Math.min(16, height);
-    const rowBytes = width * 4;
-    const sample = new Uint8Array(sampleRows * rowBytes);
-    for (let i = 0; i < sampleRows; i++) {
-      const y = Math.floor((i * (height - 1)) / Math.max(1, sampleRows - 1));
-      const strip = ctx.getImageData(0, y, width, 1);
-      sample.set(
-        new Uint8Array(
-          strip.data.buffer as ArrayBuffer,
-          strip.data.byteOffset,
-          strip.data.byteLength,
-        ),
-        i * rowBytes,
-      );
-    }
-    // The strip sample underestimates the full frame's ratio (no vertical
-    // redundancy, per-stream overhead), so gate at 16x as a biased-down
-    // proxy for "compresses well"; the final guard below bounds the cases
-    // where even that was too optimistic.
-    const sampleCompressed = await deflateRaw(sample);
-    if (sampleCompressed.length * 16.0 > sample.length) return null;
-  }
-
-  const img = ctx.getImageData(0, 0, width, height);
-  const pixels = new Uint8Array(
-    img.data.buffer as ArrayBuffer,
-    img.data.byteOffset,
-    img.data.byteLength,
-  );
-  const compressed = await deflateRaw(pixels);
-  // Final guard: never ship a payload outlandishly larger than the JPEG
-  // would have been.
-  if (compressed.length * 8 > pixels.length) return null;
-  return compressed;
-}
-
 export function FrameSynchronizedMessageHandler() {
   const handleMessage = useMessageHandler();
   const viewer = useContext(ViewerContext)!;
@@ -1381,18 +1263,11 @@ export function FrameSynchronizedMessageHandler() {
             true,
           );
 
-        // Configure for capture. JPEG, deflate_rgb, and auto are RGB
-        // results, rendered on an opaque white background; PNG and
-        // deflate_rgba are RGBA with a transparent background.
+        // Configure for capture. JPEG is an RGB result rendered on an opaque
+        // white background; PNG is RGBA with a transparent background.
         gl.setSize(targetWidth, targetHeight);
         gl.setClearColor(0xffffff);
-        gl.setClearAlpha(
-          format === "image/jpeg" ||
-            format === "deflate_rgb" ||
-            format === "auto"
-            ? 1.0
-            : 0.0,
-        );
+        gl.setClearAlpha(format === "image/jpeg" ? 1.0 : 0.0);
 
         // Render the scene.
         gl.render(viewerMutable.scene!, camera);
@@ -1407,105 +1282,34 @@ export function FrameSynchronizedMessageHandler() {
         const ctx = bufferCanvas.getContext("2d")!;
         ctx.drawImage(canvas, 0, 0, targetWidth, targetHeight);
 
-        if (format === "deflate_rgb" || format === "deflate_rgba") {
-          // RGBA readback. The deflate formats send pixels either
-          // deflate-compressed or as-is, decided from a content sample (see
-          // deflateIfCompressible / flagPrefixed). The server drops the
-          // (uniformly opaque) alpha channel for deflate_rgb.
-          const imageData = ctx.getImageData(0, 0, targetWidth, targetHeight);
-          viewerMutable.getRenderRequestState = "ready";
-          const pixels = new Uint8Array(
-            imageData.data.buffer as ArrayBuffer,
-            imageData.data.byteOffset,
-            imageData.data.byteLength,
-          );
-          void (async () => {
-            try {
-              const deflated = await deflateIfCompressible(pixels, 4.0);
-              sendRenderResponse(
-                deflated === null
-                  ? flagPrefixed(0, pixels)
-                  : flagPrefixed(1, deflated),
-              );
-            } catch (e) {
-              console.error("Failed to pack rendered image:", e);
-              sendRenderResponse(new Uint8Array(0));
-            }
-          })();
-        } else if (format === "auto") {
-          // Content-adaptive: losslessly deflate-compressed pixels when the
-          // frame compresses well, an actual JPEG otherwise (see
-          // deflateAutoFrame). bufferCanvas is captured by the closure and
-          // immutable, so all readbacks can happen after message handling
-          // resumes.
-          viewerMutable.getRenderRequestState = "ready";
-          void (async () => {
-            try {
-              const deflated = await deflateAutoFrame(
-                ctx,
-                targetWidth,
-                targetHeight,
-              );
-              if (deflated !== null) {
-                sendRenderResponse(flagPrefixed(1, deflated));
-                return;
+        // The pixels are copied out of the renderer at this point, so
+        // message handling can resume NOW: the async encode below overlaps
+        // with whatever comes next, including the next capture.
+        viewerMutable.getRenderRequestState = "ready";
+        bufferCanvas.toBlob(
+          (blob) => {
+            void (async () => {
+              try {
+                // `toBlob` can hand back null (e.g. canvas too large / OOM);
+                // fall back to an empty payload so the server's pending
+                // request resolves instead of hanging forever.
+                sendRenderResponse(
+                  blob === null
+                    ? new Uint8Array(0)
+                    : new Uint8Array(await blob.arrayBuffer()),
+                );
+              } catch (e) {
+                console.error("Failed to read rendered image:", e);
+                sendRenderResponse(new Uint8Array(0));
               }
-              bufferCanvas.toBlob(
-                (blob) => {
-                  void (async () => {
-                    try {
-                      sendRenderResponse(
-                        blob === null
-                          ? new Uint8Array(0)
-                          : flagPrefixed(
-                              2,
-                              new Uint8Array(await blob.arrayBuffer()),
-                            ),
-                      );
-                    } catch (e) {
-                      console.error("Failed to read rendered image:", e);
-                      sendRenderResponse(new Uint8Array(0));
-                    }
-                  })();
-                },
-                "image/jpeg",
-                quality / 100.0,
-              );
-            } catch (e) {
-              console.error("Failed to pack rendered image:", e);
-              sendRenderResponse(new Uint8Array(0));
-            }
-          })();
-        } else {
-          // The pixels are copied out of the renderer at this point, so
-          // message handling can resume NOW: the async encode below overlaps
-          // with whatever comes next, including the next capture.
-          viewerMutable.getRenderRequestState = "ready";
-          bufferCanvas.toBlob(
-            (blob) => {
-              void (async () => {
-                try {
-                  // `toBlob` can hand back null (e.g. canvas too large / OOM);
-                  // fall back to an empty payload so the server's pending
-                  // request resolves instead of hanging forever.
-                  sendRenderResponse(
-                    blob === null
-                      ? new Uint8Array(0)
-                      : new Uint8Array(await blob.arrayBuffer()),
-                  );
-                } catch (e) {
-                  console.error("Failed to read rendered image:", e);
-                  sendRenderResponse(new Uint8Array(0));
-                }
-              })();
-              // The quality argument applies to JPEG only (PNG's encoder has
-              // no knobs in the web API); omitting it would silently encode
-              // at Chrome's 0.92 default -- larger and no faster.
-            },
-            format,
-            format === "image/jpeg" ? quality / 100.0 : undefined,
-          );
-        }
+            })();
+            // The quality argument applies to JPEG only (PNG's encoder has
+            // no knobs in the web API); omitting it would silently encode
+            // at Chrome's 0.92 default -- larger and no faster.
+          },
+          format,
+          format === "image/jpeg" ? quality / 100.0 : undefined,
+        );
       } catch (e) {
         console.error("Render request failed:", e);
         // The response wasn't sent above, so send the failure sentinel now --

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -942,12 +942,16 @@ function flagPrefixed(flag: number, data: Uint8Array): Uint8Array<ArrayBuffer> {
  * least `minRatio`; return null when it doesn't (or CompressionStream is
  * unavailable).
  *
- * Typical 3D renders (flat backgrounds, smooth shading) deflate 100-1000x
- * at a few milliseconds per megapixel. Incompressible content (photo
- * textures, dense splats) is the exception: deflate then costs tens of
- * milliseconds and saves nothing, so a small strided sample of the frame
- * decides first -- CompressionStream exposes no compression-level knob,
- * making a sample the only cheap way to bail out. */
+ * Measured on captured 720p frames: geometric scenes deflate 77-530x at
+ * 12-18ms, while high-entropy content (random-colored dense point clouds
+ * ~2.1x, photo/noise textures ~1.7x) costs 100-270ms -- deflate is slowest
+ * exactly where it saves least, and CompressionStream exposes no
+ * compression-level knob to cheapen it. A small strided sample therefore
+ * decides first, and the threshold below is deliberately well above
+ * break-even-on-bytes: in the low-ratio regime the CPU cost dwarfs the
+ * bandwidth saved on the local/LAN links these formats target. (A PNG-style
+ * per-row delta filter was also measured and does NOT improve any of these
+ * ratios; don't bother.) */
 async function deflateIfCompressible(
   pixels: Uint8Array<ArrayBuffer>,
   minRatio: number,
@@ -1355,7 +1359,7 @@ export function FrameSynchronizedMessageHandler() {
           );
           void (async () => {
             try {
-              const deflated = await deflateIfCompressible(pixels, 1.5);
+              const deflated = await deflateIfCompressible(pixels, 4.0);
               sendRenderResponse(
                 deflated === null
                   ? flagPrefixed(0, pixels)

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -928,6 +928,59 @@ function useFileDownloadHandler(): (
   };
 }
 
+/** Pack a raw RGBA render payload, deflate-compressing it when that's worth
+ * it. The result carries a 1-byte prefix read by the server's get_render():
+ * 0 = uncompressed RGBA follows, 1 = deflate-raw compressed RGBA follows.
+ *
+ * Typical 3D renders (flat backgrounds, smooth shading) deflate 100-1000x
+ * at a few milliseconds per megapixel, which removes most of the raw
+ * formats' bandwidth cost. Incompressible content (photo textures, dense
+ * splats) is the exception: deflate then costs tens of milliseconds and
+ * saves nothing, so a small strided sample of the frame decides first --
+ * CompressionStream exposes no compression-level knob, making a sample the
+ * only cheap way to bail out. */
+async function maybeDeflateRenderPayload(
+  pixels: Uint8Array<ArrayBuffer>,
+): Promise<Uint8Array<ArrayBuffer>> {
+  const withFlag = (flag: number, data: Uint8Array) => {
+    const out = new Uint8Array(data.length + 1);
+    out[0] = flag;
+    out.set(data, 1);
+    return out;
+  };
+  if (typeof CompressionStream === "undefined") return withFlag(0, pixels);
+
+  const deflate = async (data: Uint8Array<ArrayBuffer>) => {
+    const stream = new CompressionStream("deflate-raw");
+    const writer = stream.writable.getWriter();
+    void writer.write(data);
+    void writer.close();
+    return new Uint8Array(await new Response(stream.readable).arrayBuffer());
+  };
+
+  // Small frames: compressing outright costs about as much as sampling.
+  const sampleChunk = 4096;
+  const sampleCount = 64;
+  if (pixels.length > 2 * sampleChunk * sampleCount) {
+    const stride = Math.floor(pixels.length / sampleCount);
+    const sample = new Uint8Array(sampleChunk * sampleCount);
+    for (let i = 0; i < sampleCount; i++) {
+      sample.set(
+        pixels.subarray(i * stride, i * stride + sampleChunk),
+        i * sampleChunk,
+      );
+    }
+    const sampleCompressed = await deflate(sample);
+    // Under ~1.5x on the sample, full-frame deflate isn't worth its CPU:
+    // send uncompressed (the raw formats' worst case, exactly as before
+    // compression existed).
+    if (sampleCompressed.length * 1.5 > sample.length) {
+      return withFlag(0, pixels);
+    }
+  }
+  return withFlag(1, await deflate(pixels));
+}
+
 export function FrameSynchronizedMessageHandler() {
   const handleMessage = useMessageHandler();
   const viewer = useContext(ViewerContext)!;
@@ -1286,17 +1339,24 @@ export function FrameSynchronizedMessageHandler() {
 
         if (format === "raw_rgb" || format === "raw_rgba") {
           // Unencoded RGBA readback: no image encode here, no image decode
-          // on the server. Both raw formats send RGBA bytes; the server
+          // on the server. Both raw formats send RGBA bytes (adaptively
+          // deflate-compressed, see maybeDeflateRenderPayload); the server
           // drops the (uniformly opaque) alpha channel for raw_rgb.
           const imageData = ctx.getImageData(0, 0, targetWidth, targetHeight);
           viewerMutable.getRenderRequestState = "ready";
-          sendRenderResponse(
-            new Uint8Array(
-              imageData.data.buffer as ArrayBuffer,
-              imageData.data.byteOffset,
-              imageData.data.byteLength,
-            ),
+          const pixels = new Uint8Array(
+            imageData.data.buffer as ArrayBuffer,
+            imageData.data.byteOffset,
+            imageData.data.byteLength,
           );
+          void (async () => {
+            try {
+              sendRenderResponse(await maybeDeflateRenderPayload(pixels));
+            } catch (e) {
+              console.error("Failed to pack rendered image:", e);
+              sendRenderResponse(new Uint8Array(0));
+            }
+          })();
         } else {
           // The pixels are copied out of the renderer at this point, so
           // message handling can resume NOW: the async encode below overlaps

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -930,7 +930,7 @@ function useFileDownloadHandler(): (
 
 /** Prefix a render payload with its 1-byte encoding flag, read by the
  * server's get_render(): 0 = uncompressed RGBA, 1 = deflate-raw compressed
- * RGBA, 2 = JPEG bytes (the "auto" format's fallback). */
+ * RGBA. */
 function flagPrefixed(flag: number, data: Uint8Array): Uint8Array<ArrayBuffer> {
   const out = new Uint8Array(data.length + 1);
   out[0] = flag;
@@ -947,10 +947,7 @@ function flagPrefixed(flag: number, data: Uint8Array): Uint8Array<ArrayBuffer> {
  * textures, dense splats) is the exception: deflate then costs tens of
  * milliseconds and saves nothing, so a small strided sample of the frame
  * decides first -- CompressionStream exposes no compression-level knob,
- * making a sample the only cheap way to bail out. Callers pick the
- * threshold: ~1.5x when the alternative is sending uncompressed pixels
- * (raw formats), ~32x when the alternative is JPEG ("auto": 32x on 32
- * bits/pixel RGBA is ~1 bit/pixel, competitive with JPEG's rate). */
+ * making a sample the only cheap way to bail out. */
 async function deflateIfCompressible(
   pixels: Uint8Array<ArrayBuffer>,
   minRatio: number,
@@ -986,60 +983,6 @@ async function deflateRaw(
   void writer.write(data);
   void writer.close();
   return new Uint8Array(await new Response(stream.readable).arrayBuffer());
-}
-
-/** The "auto" format's lossless path: decide from a few sampled rows whether
- * the frame deflates at JPEG-competitive rates (~32x on RGBA is ~1
- * bit/pixel), and return the deflated full frame if so; null means "encode a
- * JPEG instead". The sample strips are read BEFORE paying for the full-frame
- * getImageData, so when the answer is JPEG -- the only case where a real
- * JPEG encode follows -- the readback overhead vs. plain JPEG stays tiny. */
-async function deflateAutoFrame(
-  ctx: CanvasRenderingContext2D,
-  width: number,
-  height: number,
-): Promise<Uint8Array<ArrayBuffer> | null> {
-  if (typeof CompressionStream === "undefined") return null;
-
-  // Small frames: deflate outright (bounded at ~10ms even on
-  // incompressible content) -- a tiny sample would be dominated by
-  // deflate's fixed overhead and systematically underestimate the frame's
-  // compressibility.
-  if (width * height * 4 > 512 * 1024) {
-    const sampleRows = Math.min(16, height);
-    const rowBytes = width * 4;
-    const sample = new Uint8Array(sampleRows * rowBytes);
-    for (let i = 0; i < sampleRows; i++) {
-      const y = Math.floor((i * (height - 1)) / Math.max(1, sampleRows - 1));
-      const strip = ctx.getImageData(0, y, width, 1);
-      sample.set(
-        new Uint8Array(
-          strip.data.buffer as ArrayBuffer,
-          strip.data.byteOffset,
-          strip.data.byteLength,
-        ),
-        i * rowBytes,
-      );
-    }
-    // The strip sample underestimates the full frame's ratio (no vertical
-    // redundancy, per-stream overhead), so gate at 16x as a biased-down
-    // proxy for "JPEG-competitive"; the final guard below bounds the cases
-    // where even that was too optimistic.
-    const sampleCompressed = await deflateRaw(sample);
-    if (sampleCompressed.length * 16.0 > sample.length) return null;
-  }
-
-  const img = ctx.getImageData(0, 0, width, height);
-  const pixels = new Uint8Array(
-    img.data.buffer as ArrayBuffer,
-    img.data.byteOffset,
-    img.data.byteLength,
-  );
-  const compressed = await deflateRaw(pixels);
-  // Final guard: never ship a payload outlandishly larger than the JPEG
-  // would have been.
-  if (compressed.length * 8 > pixels.length) return null;
-  return compressed;
 }
 
 export function FrameSynchronizedMessageHandler() {
@@ -1376,15 +1319,13 @@ export function FrameSynchronizedMessageHandler() {
             true,
           );
 
-        // Configure for capture. JPEG, raw_rgb, and auto are RGB results,
-        // rendered on an opaque white background; PNG and raw_rgba are RGBA
-        // with a transparent background.
+        // Configure for capture. JPEG and raw_rgb are RGB results, rendered
+        // on an opaque white background; PNG and raw_rgba are RGBA with a
+        // transparent background.
         gl.setSize(targetWidth, targetHeight);
         gl.setClearColor(0xffffff);
         gl.setClearAlpha(
-          format === "image/jpeg" || format === "raw_rgb" || format === "auto"
-            ? 1.0
-            : 0.0,
+          format === "image/jpeg" || format === "raw_rgb" ? 1.0 : 0.0,
         );
 
         // Render the scene.
@@ -1419,51 +1360,6 @@ export function FrameSynchronizedMessageHandler() {
                 deflated === null
                   ? flagPrefixed(0, pixels)
                   : flagPrefixed(1, deflated),
-              );
-            } catch (e) {
-              console.error("Failed to pack rendered image:", e);
-              sendRenderResponse(new Uint8Array(0));
-            }
-          })();
-        } else if (format === "auto") {
-          // Content-adaptive: losslessly deflate-compressed pixels when the
-          // frame compresses at JPEG-competitive rates, an actual JPEG
-          // otherwise (see deflateAutoFrame). bufferCanvas is captured by
-          // the closure and immutable, so all readbacks can happen after
-          // message handling resumes.
-          const quality = viewerMutable.getRenderRequest!.quality;
-          viewerMutable.getRenderRequestState = "ready";
-          void (async () => {
-            try {
-              const deflated = await deflateAutoFrame(
-                ctx,
-                targetWidth,
-                targetHeight,
-              );
-              if (deflated !== null) {
-                sendRenderResponse(flagPrefixed(1, deflated));
-                return;
-              }
-              bufferCanvas.toBlob(
-                (blob) => {
-                  void (async () => {
-                    try {
-                      sendRenderResponse(
-                        blob === null
-                          ? new Uint8Array(0)
-                          : flagPrefixed(
-                              2,
-                              new Uint8Array(await blob.arrayBuffer()),
-                            ),
-                      );
-                    } catch (e) {
-                      console.error("Failed to read rendered image:", e);
-                      sendRenderResponse(new Uint8Array(0));
-                    }
-                  })();
-                },
-                "image/jpeg",
-                quality / 100.0,
               );
             } catch (e) {
               console.error("Failed to pack rendered image:", e);

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -1199,7 +1199,11 @@ export function FrameSynchronizedMessageHandler() {
           if (pose === undefined || pose.poseUpdateState !== "needsUpdate")
             continue;
           const obj = viewerMutable.nodeRefFromName[name];
-          if (obj === undefined) continue;
+          // == null: the map's type says undefined, but React ref callbacks
+          // write null on detach (e.g. unmountWhenInvisible nodes that are
+          // currently hidden), and a TypeError here would fail the whole
+          // capture with the pose still pending.
+          if (obj == null) continue;
           pose.poseUpdateState = "updated";
           if (viewer.useSceneTree.get(name)?.message.type !== "LabelMessage") {
             obj.quaternion.set(

--- a/src/viser/client/src/ViewerContext.ts
+++ b/src/viser/client/src/ViewerContext.ts
@@ -60,7 +60,11 @@ export type ViewerMutable = {
   // hack runs again. Lives here (not a component ref) so WebsocketInterface can
   // reset it on reconnect.
   firstMessageBatch: boolean;
-  getRenderRequestState: "ready" | "triggered" | "pause" | "in_progress";
+  // Render-capture state machine (see RenderCapture in MessageHandler.tsx):
+  // "ready" -> nothing pending; "commit_wait" -> request processed alongside
+  // other messages, give React one frame to commit them; "capture" -> capture
+  // this frame. Message handling is gated on "ready".
+  getRenderRequestState: "ready" | "commit_wait" | "capture";
   getRenderRequest: null | GetRenderRequestMessage;
 
   // Diagnostic snapshot for the initial-camera / scene-orientation flow,

--- a/src/viser/client/src/ViewerContext.ts
+++ b/src/viser/client/src/ViewerContext.ts
@@ -60,9 +60,10 @@ export type ViewerMutable = {
   // hack runs again. Lives here (not a component ref) so WebsocketInterface can
   // reset it on reconnect.
   firstMessageBatch: boolean;
-  // Render-capture state machine (see RenderCapture in MessageHandler.tsx):
-  // "ready" -> nothing pending; "commit_wait" -> request processed alongside
-  // other messages, give React one frame to commit them; "capture" -> capture
+  // Render-capture state machine (driven by the two useFrame hooks in
+  // MessageHandler.tsx's FrameSynchronizedMessageHandler): "ready" ->
+  // nothing pending; "commit_wait" -> request processed alongside other
+  // messages, give React one frame to commit them; "capture" -> capture
   // this frame. Message handling is gated on "ready".
   getRenderRequestState: "ready" | "commit_wait" | "capture";
   getRenderRequest: null | GetRenderRequestMessage;

--- a/src/viser/client/src/WebsocketInterface.tsx
+++ b/src/viser/client/src/WebsocketInterface.tsx
@@ -77,7 +77,17 @@ export function WebsocketMessageProducer() {
         viewer.useGui.set({ websocketState: "connected" });
         updateRetryInterval();
         viewerMutable.sendMessage = (message) => {
-          postToWorker({ type: "send", message });
+          if (message.type === "GetRenderResponseMessage") {
+            // Multi-megabyte render payloads: TRANSFER the buffer to the
+            // worker instead of structured-cloning it. The payload is
+            // freshly allocated per capture, so detaching it here is safe,
+            // and the clone of a large frame measurably delays the send.
+            worker.postMessage({ type: "send", message } as WsWorkerIncoming, [
+              message.payload.buffer,
+            ]);
+          } else {
+            postToWorker({ type: "send", message });
+          }
         };
       } else if (data.type === "closed") {
         isConnected = false;

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -1825,7 +1825,7 @@ export interface ThemeConfigurationMessage {
  */
 export interface GetRenderRequestMessage {
   type: "GetRenderRequestMessage";
-  format: "image/jpeg" | "image/png" | "deflate_rgb" | "deflate_rgba" | "auto";
+  format: "image/jpeg" | "image/png";
   height: number;
   width: number;
   quality: number;

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -1825,7 +1825,7 @@ export interface ThemeConfigurationMessage {
  */
 export interface GetRenderRequestMessage {
   type: "GetRenderRequestMessage";
-  format: "image/jpeg" | "image/png" | "raw";
+  format: "image/jpeg" | "image/png" | "raw_rgb" | "raw_rgba";
   height: number;
   width: number;
   quality: number;

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -1825,7 +1825,7 @@ export interface ThemeConfigurationMessage {
  */
 export interface GetRenderRequestMessage {
   type: "GetRenderRequestMessage";
-  format: "image/jpeg" | "image/png" | "raw_rgb" | "raw_rgba";
+  format: "image/jpeg" | "image/png" | "raw_rgb" | "raw_rgba" | "auto";
   height: number;
   width: number;
   quality: number;

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -1825,7 +1825,7 @@ export interface ThemeConfigurationMessage {
  */
 export interface GetRenderRequestMessage {
   type: "GetRenderRequestMessage";
-  format: "image/jpeg" | "image/png" | "deflate_rgb" | "deflate_rgba";
+  format: "image/jpeg" | "image/png" | "deflate_rgb" | "deflate_rgba" | "auto";
   height: number;
   width: number;
   quality: number;

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -1825,7 +1825,7 @@ export interface ThemeConfigurationMessage {
  */
 export interface GetRenderRequestMessage {
   type: "GetRenderRequestMessage";
-  format: "image/jpeg" | "image/png";
+  format: "image/jpeg" | "image/png" | "raw";
   height: number;
   width: number;
   quality: number;

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -1825,7 +1825,7 @@ export interface ThemeConfigurationMessage {
  */
 export interface GetRenderRequestMessage {
   type: "GetRenderRequestMessage";
-  format: "image/jpeg" | "image/png" | "raw_rgb" | "raw_rgba" | "auto";
+  format: "image/jpeg" | "image/png" | "raw_rgb" | "raw_rgba";
   height: number;
   width: number;
   quality: number;

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -1825,7 +1825,7 @@ export interface ThemeConfigurationMessage {
  */
 export interface GetRenderRequestMessage {
   type: "GetRenderRequestMessage";
-  format: "image/jpeg" | "image/png" | "raw_rgb" | "raw_rgba";
+  format: "image/jpeg" | "image/png" | "deflate_rgb" | "deflate_rgba";
   height: number;
   width: number;
   quality: number;

--- a/src/viser/infra/_infra.py
+++ b/src/viser/infra/_infra.py
@@ -242,9 +242,11 @@ class WebsockMessageHandler:
         callback: Callable[[ClientId, TMessage], None | Coroutine],
     ) -> None:
         """Register a handler for a particular message type."""
-        if message_cls not in self._incoming_handlers:
-            self._incoming_handlers[message_cls] = []
-        self._incoming_handlers[message_cls].append(callback)  # type: ignore
+        # setdefault: registration is reachable from multiple threads (e.g.
+        # concurrent get_render() calls), and an unsynchronized
+        # check-then-create could discard a list another thread just
+        # created+appended to, silently dropping its handler.
+        self._incoming_handlers.setdefault(message_cls, []).append(callback)  # type: ignore
 
     def unregister_handler(
         self,

--- a/tests/e2e/test_get_render_capture.py
+++ b/tests/e2e/test_get_render_capture.py
@@ -289,3 +289,30 @@ def test_get_render_does_not_leak_capture_state_into_splat_view(
     finally:
         page.close()  # type: ignore[attr-defined]
         context.close()  # type: ignore[attr-defined]
+
+
+def test_get_render_survives_hidden_unmounted_node_pose_update(
+    own_server: viser.ViserServer, browser: Browser
+) -> None:
+    """A pose update to a HIDDEN unmountWhenInvisible node (transform
+    controls, 3D GUI, ...) must not break capture. When such a node is
+    hidden, React unmounts it and its ref callback writes null into
+    nodeRefFromName (whose type only admits undefined); a later pose update
+    marks the pose "needsUpdate", which SceneTree's own applier skips while
+    the ref is null. The capture hook's defensive pose sweep must skip it
+    too -- an undefined-only guard let the null through to a TypeError,
+    failing the whole capture with a spurious "could not capture a frame"
+    RuntimeError on a healthy client."""
+    client, page, context = _connect_client(own_server, browser)
+    try:
+        tc = own_server.scene.add_transform_controls("/gizmo")
+        time.sleep(1.0)  # Mount.
+        tc.visible = False
+        time.sleep(0.8)  # Unmount; ref callback nulls the map entry.
+        tc.position = (1.0, 0.0, 0.0)  # Pose pending while the ref is null.
+        time.sleep(0.3)
+        img = client.get_render(height=64, width=64, timeout=30.0)
+        assert img.shape == (64, 64, 3)
+    finally:
+        page.close()  # type: ignore[attr-defined]
+        context.close()  # type: ignore[attr-defined]

--- a/tests/e2e/test_get_render_capture.py
+++ b/tests/e2e/test_get_render_capture.py
@@ -230,8 +230,10 @@ def test_get_render_transport_formats_agree(
         assert int(raw[0, 0, 3]) == 0 and int(png[0, 0, 3]) == 0
         assert np.all(rgb[0, 0] >= 250) and np.all(jpeg[0, 0] >= 245)
 
-        # The default (deflate_rgb) returns (H, W, 3) on white, pixel-exact
-        # against an explicit deflate_rgb capture.
+        # The default ("auto") returns (H, W, 3) on white. On this simple
+        # scene the content compresses far beyond auto's lossless threshold,
+        # so the frame must be pixel-exact against deflate_rgb -- proof the
+        # lossless wire path engaged end to end.
         default = client.get_render(height=h, width=w, timeout=30)
         assert default.shape == (h, w, 3) and default.dtype == np.uint8
         assert np.all(default[0, 0] >= 250)

--- a/tests/e2e/test_get_render_capture.py
+++ b/tests/e2e/test_get_render_capture.py
@@ -230,14 +230,12 @@ def test_get_render_transport_formats_agree(
         assert int(raw[0, 0, 3]) == 0 and int(png[0, 0, 3]) == 0
         assert np.all(rgb[0, 0] >= 250) and np.all(jpeg[0, 0] >= 245)
 
-        # The default ("auto") returns (H, W, 3) on white like jpeg/raw_rgb.
-        # On this simple scene the content compresses far beyond auto's
-        # lossless threshold, so the frame must be pixel-exact against
-        # raw_rgb -- proof the lossless wire path engaged end to end.
-        auto = client.get_render(height=h, width=w, timeout=30)
-        assert auto.shape == (h, w, 3) and auto.dtype == np.uint8
-        assert np.all(auto[0, 0] >= 250)
-        assert np.allclose(auto[mask].mean(axis=0), rgb[mask].mean(axis=0), atol=2.0)
+        # The default (raw_rgb) returns (H, W, 3) on white, pixel-exact
+        # against an explicit raw_rgb capture.
+        default = client.get_render(height=h, width=w, timeout=30)
+        assert default.shape == (h, w, 3) and default.dtype == np.uint8
+        assert np.all(default[0, 0] >= 250)
+        assert np.allclose(default[mask].mean(axis=0), rgb[mask].mean(axis=0), atol=2.0)
 
         # Back-to-back solo captures (no interleaved scene updates) take the
         # same-frame capture path; they must stay correct and identical-ish.

--- a/tests/e2e/test_get_render_capture.py
+++ b/tests/e2e/test_get_render_capture.py
@@ -223,3 +223,69 @@ def test_get_render_transport_formats_agree(
     finally:
         page.close()  # type: ignore[attr-defined]
         context.close()  # type: ignore[attr-defined]
+
+
+def test_get_render_does_not_leak_capture_state_into_splat_view(
+    own_server: viser.ViserServer, browser: Browser
+) -> None:
+    """Capturing must not corrupt the INTERACTIVE Gaussian splat view. The
+    capture path calls the splat updateCamera with its virtual camera
+    (uniforms, group transforms, blocking sort) and only restores the
+    sorted-index attribute itself; it relies on running BEFORE the splat
+    per-frame hook (priority -100), which re-applies interactive-camera
+    state in the same frame. At a later priority, the frame's visible
+    render draws the viewport with the capture's splat uniforms -- observed
+    here as the capture's viewport size leaking across a frame boundary
+    into the splat material (an in-page rAF probe can only ever see it if
+    the same-frame repair did not happen)."""
+    client, page, context = _connect_client(own_server, browser)
+    try:
+        rng = np.random.default_rng(0)
+        n = 2000
+        own_server.scene.add_gaussian_splats(
+            "/splats",
+            centers=rng.normal(size=(n, 3)).astype(np.float32),
+            covariances=np.tile(np.eye(3, dtype=np.float32) * 0.005, (n, 1, 1)),
+            rgbs=rng.integers(0, 255, (n, 3), dtype=np.uint8),
+            opacities=rng.uniform(0.5, 1.0, (n, 1)).astype(np.float32),
+        )
+        time.sleep(4.0)  # Splat sorter + WASM warmup.
+        page.evaluate(  # type: ignore[attr-defined]
+            """
+            () => {
+              window.__viewportSamples = new Set();
+              const sample = () => {
+                const scene = window.__viserMutable && window.__viserMutable.scene;
+                if (scene) {
+                  scene.traverse((obj) => {
+                    const u = obj.material && obj.material.uniforms;
+                    if (u && u.viewport && Array.isArray(u.viewport.value)) {
+                      window.__viewportSamples.add(u.viewport.value.join('x'));
+                    }
+                  });
+                }
+                requestAnimationFrame(sample);
+              };
+              requestAnimationFrame(sample);
+            }
+            """
+        )
+        for _ in range(10):
+            img = client.get_render(
+                height=96, width=128, transport_format="jpeg", timeout=60.0
+            )
+            assert img.shape == (96, 128, 3)
+        time.sleep(0.5)
+        samples = page.evaluate(  # type: ignore[attr-defined]
+            "() => Array.from(window.__viewportSamples)"
+        )
+        assert "128x96" not in samples, (
+            f"capture-sized splat viewport leaked into the interactive view "
+            f"(observed uniform values: {sorted(samples)})"
+        )
+        # Sanity: the probe did observe the interactive viewport (i.e., it
+        # actually sampled splat material state).
+        assert len(samples) > 0
+    finally:
+        page.close()  # type: ignore[attr-defined]
+        context.close()  # type: ignore[attr-defined]

--- a/tests/e2e/test_get_render_capture.py
+++ b/tests/e2e/test_get_render_capture.py
@@ -4,7 +4,7 @@ The client-side capture path is latency-optimized: a request that arrives
 alone captures in the same frame it is processed (after the SceneTree pose
 appliers), a request that arrives alongside scene updates waits exactly one
 frame for React to commit them, JPEG/PNG encoding happens off the
-message-handling critical path, and the raw_rgb/raw_rgba transports skip
+message-handling critical path, and the deflate_rgb/deflate_rgba transports skip
 image encoding entirely. These tests pin the contract those optimizations must
 preserve: a frame returned by get_render() reflects every scene update made
 before the call, and every transport format returns sane pixels.
@@ -91,7 +91,7 @@ def test_get_render_reflects_prior_scene_updates(
         for i, color in enumerate(colors):
             box.color = color
             img = client.get_render(
-                height=96, width=128, transport_format="raw_rgba", timeout=30.0
+                height=96, width=128, transport_format="deflate_rgba", timeout=30.0
             )
             center = _center_mean(img)
             expected_channel = int(np.argmax(color))
@@ -132,7 +132,7 @@ def test_get_render_reflects_fresh_node_poses(
             time.sleep(1.0)
             truth[x] = centroid_x(
                 client.get_render(
-                    height=h, width=w, transport_format="raw_rgba", timeout=30
+                    height=h, width=w, transport_format="deflate_rgba", timeout=30
                 )
             )
         own_server.scene.remove_by_name("/truth")
@@ -155,7 +155,7 @@ def test_get_render_reflects_fresh_node_poses(
                 position=(x, 0, 0),
             )
             img = client.get_render(
-                height=h, width=w, transport_format="raw_rgba", timeout=30.0
+                height=h, width=w, transport_format="deflate_rgba", timeout=30.0
             )
             cx = centroid_x(img)
             assert np.isfinite(cx) and (cx < mid) == (truth[x] < mid), (
@@ -172,7 +172,7 @@ def test_get_render_transport_formats_agree(
     own_server: viser.ViserServer, browser: Browser
 ) -> None:
     """All transport formats return correctly-shaped arrays of the same
-    scene: JPEG and raw_rgb (H, W, 3) on white; PNG and raw_rgba (H, W, 4)
+    scene: JPEG and deflate_rgb (H, W, 3) on white; PNG and deflate_rgba (H, W, 4)
     on transparent -- with the lossless formats agreeing on the center
     pixels, corner pixels showing each format's background convention, and
     repeated solo captures (the same-frame fast path) staying stable."""
@@ -190,7 +190,7 @@ def test_get_render_transport_formats_agree(
         for _ in range(40):
             cur = _center_mean(
                 client.get_render(
-                    height=h, width=w, transport_format="raw_rgba", timeout=30
+                    height=h, width=w, transport_format="deflate_rgba", timeout=30
                 )
             )
             if prev is not None and np.allclose(cur, prev, atol=2.0):
@@ -200,10 +200,10 @@ def test_get_render_transport_formats_agree(
         jpeg = client.get_render(height=h, width=w, transport_format="jpeg", timeout=30)
         png = client.get_render(height=h, width=w, transport_format="png", timeout=30)
         raw = client.get_render(
-            height=h, width=w, transport_format="raw_rgba", timeout=30
+            height=h, width=w, transport_format="deflate_rgba", timeout=30
         )
         rgb = client.get_render(
-            height=h, width=w, transport_format="raw_rgb", timeout=30
+            height=h, width=w, transport_format="deflate_rgb", timeout=30
         )
         assert jpeg.shape == (h, w, 3) and jpeg.dtype == np.uint8
         assert png.shape == (h, w, 4) and png.dtype == np.uint8
@@ -230,8 +230,8 @@ def test_get_render_transport_formats_agree(
         assert int(raw[0, 0, 3]) == 0 and int(png[0, 0, 3]) == 0
         assert np.all(rgb[0, 0] >= 250) and np.all(jpeg[0, 0] >= 245)
 
-        # The default (raw_rgb) returns (H, W, 3) on white, pixel-exact
-        # against an explicit raw_rgb capture.
+        # The default (deflate_rgb) returns (H, W, 3) on white, pixel-exact
+        # against an explicit deflate_rgb capture.
         default = client.get_render(height=h, width=w, timeout=30)
         assert default.shape == (h, w, 3) and default.dtype == np.uint8
         assert np.all(default[0, 0] >= 250)
@@ -240,7 +240,7 @@ def test_get_render_transport_formats_agree(
         # Back-to-back solo captures (no interleaved scene updates) take the
         # same-frame capture path; they must stay correct and identical-ish.
         again = client.get_render(
-            height=h, width=w, transport_format="raw_rgba", timeout=30
+            height=h, width=w, transport_format="deflate_rgba", timeout=30
         )
         assert np.allclose(_center_mean(again), _center_mean(raw), atol=3.0)
     finally:

--- a/tests/e2e/test_get_render_capture.py
+++ b/tests/e2e/test_get_render_capture.py
@@ -1,0 +1,141 @@
+"""get_render() capture correctness, across transport formats.
+
+The client-side capture path is latency-optimized: a request that arrives
+alone captures in the same frame it is processed (after the SceneTree pose
+appliers), a request that arrives alongside scene updates waits exactly one
+frame for React to commit them, JPEG/PNG encoding happens off the
+message-handling critical path, and the "raw" transport skips image
+encoding entirely. These tests pin the contract those optimizations must
+preserve: a frame returned by get_render() reflects every scene update made
+before the call, and every transport format returns sane pixels.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Generator
+
+import numpy as np
+import pytest
+from playwright.sync_api import Browser
+
+import viser
+import viser._client_autobuild
+
+from .utils import find_free_port, wait_for_connection, wait_for_server_ready
+
+
+@pytest.fixture()
+def own_server() -> Generator[viser.ViserServer, None, None]:
+    viser._client_autobuild.ensure_client_is_built = lambda: None
+    server: viser.ViserServer | None = None
+    for attempt in range(3):
+        try:
+            server = viser.ViserServer(port=find_free_port(), verbose=False)
+            break
+        except OSError:
+            if attempt == 2:
+                raise
+    assert server is not None
+    wait_for_server_ready(server.get_port())
+    yield server
+    server.stop()
+
+
+def _connect_client(
+    own_server: viser.ViserServer, browser: Browser
+) -> tuple[viser.ClientHandle, object, object]:
+    captured: list[viser.ClientHandle] = []
+    own_server.on_client_connect(lambda client: captured.append(client))
+    context = browser.new_context()
+    page = context.new_page()
+    wait_for_connection(page, own_server.get_port())
+    deadline = time.monotonic() + 10
+    while not captured and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert captured, "client never connected"
+    client = captured[0]
+    # Wait for the first camera update so get_render() can read camera state.
+    while client.camera._state.update_timestamp == 0.0 and (
+        time.monotonic() < deadline
+    ):
+        time.sleep(0.05)
+    assert client.camera._state.update_timestamp != 0.0, "camera never synced"
+    return client, page, context
+
+
+def _center_mean(img: np.ndarray) -> np.ndarray:
+    h, w = img.shape[:2]
+    return img[
+        h // 2 - h // 8 : h // 2 + h // 8,
+        w // 2 - w // 8 : w // 2 + w // 8,
+        :3,
+    ].mean(axis=(0, 1))
+
+
+def test_get_render_reflects_prior_scene_updates(
+    own_server: viser.ViserServer, browser: Browser
+) -> None:
+    """A capture requested immediately after a scene mutation must show that
+    mutation. This exercises the "commit_wait" path (update + request race
+    down two different server buffers and the client needs a React commit
+    before capturing) repeatedly, alternating colors so ANY stale frame
+    fails the dominant-channel check."""
+    client, page, context = _connect_client(own_server, browser)
+    try:
+        # A box that fills the view center from the default camera pose.
+        box = own_server.scene.add_box(
+            "/box", color=(255, 0, 0), dimensions=(2.0, 2.0, 2.0)
+        )
+        colors = [(255, 0, 0), (0, 255, 0), (0, 0, 255)] * 2
+        for i, color in enumerate(colors):
+            box.color = color
+            img = client.get_render(
+                height=96, width=128, transport_format="raw", timeout=30.0
+            )
+            center = _center_mean(img)
+            expected_channel = int(np.argmax(color))
+            assert int(np.argmax(center)) == expected_channel, (
+                f"iteration {i}: set color {color} but captured center "
+                f"{center} -- get_render() returned a stale frame"
+            )
+    finally:
+        page.close()  # type: ignore[attr-defined]
+        context.close()  # type: ignore[attr-defined]
+
+
+def test_get_render_transport_formats_agree(
+    own_server: viser.ViserServer, browser: Browser
+) -> None:
+    """All three transport formats return correctly-shaped arrays of the same
+    scene: JPEG (H, W, 3), PNG and raw (H, W, 4) -- with raw and PNG (both
+    lossless, same render path) agreeing on the center pixels, and repeated
+    solo captures (the same-frame fast path) staying stable."""
+    client, page, context = _connect_client(own_server, browser)
+    try:
+        own_server.scene.add_box(
+            "/box", color=(0, 120, 255), dimensions=(2.0, 2.0, 2.0)
+        )
+        h, w = 96, 128
+        jpeg = client.get_render(height=h, width=w, transport_format="jpeg", timeout=30)
+        png = client.get_render(height=h, width=w, transport_format="png", timeout=30)
+        raw = client.get_render(height=h, width=w, transport_format="raw", timeout=30)
+        assert jpeg.shape == (h, w, 3) and jpeg.dtype == np.uint8
+        assert png.shape == (h, w, 4) and png.dtype == np.uint8
+        assert raw.shape == (h, w, 4) and raw.dtype == np.uint8
+        # Lossless formats agree on the (fully opaque) box at the center.
+        assert np.allclose(_center_mean(png), _center_mean(raw), atol=3.0), (
+            f"png center {_center_mean(png)} != raw center {_center_mean(raw)}"
+        )
+        assert np.allclose(_center_mean(jpeg), _center_mean(raw), atol=12.0)
+        # The center is opaque in the alpha formats.
+        assert int(raw[h // 2, w // 2, 3]) == 255
+        assert int(png[h // 2, w // 2, 3]) == 255
+
+        # Back-to-back solo captures (no interleaved scene updates) take the
+        # same-frame capture path; they must stay correct and identical-ish.
+        again = client.get_render(height=h, width=w, transport_format="raw", timeout=30)
+        assert np.allclose(_center_mean(again), _center_mean(raw), atol=3.0)
+    finally:
+        page.close()  # type: ignore[attr-defined]
+        context.close()  # type: ignore[attr-defined]

--- a/tests/e2e/test_get_render_capture.py
+++ b/tests/e2e/test_get_render_capture.py
@@ -104,6 +104,68 @@ def test_get_render_reflects_prior_scene_updates(
         context.close()  # type: ignore[attr-defined]
 
 
+def test_get_render_reflects_fresh_node_poses(
+    own_server: viser.ViserServer, browser: Browser
+) -> None:
+    """A capture requested immediately after ADDING a node at a pose must show
+    the node at that pose. This is the narrowest window of the same-frame
+    capture path: a fresh mount's pose transitions "waitForMakeObject" ->
+    "needsUpdate" via a passive React effect, which -- unlike the store
+    commit itself -- is not synchronously flushed with the sync-lane render.
+    The capture hook's defensive pose sweep plus the one-frame commit wait
+    must cover it; a capture of the box at the default pose (origin) or the
+    previous box's position fails the centroid side check."""
+    client, page, context = _connect_client(own_server, browser)
+    try:
+        h, w = 96, 128
+
+        def centroid_x(img: np.ndarray) -> float:
+            xs = np.nonzero(img[:, :, 3] > 128)[1]
+            return float(xs.mean()) if len(xs) else float("nan")
+
+        # Ground truth: let each position fully settle, then capture.
+        truth = {}
+        for x in (-1.5, 1.5):
+            own_server.scene.add_box(
+                "/truth", color=(255, 0, 0), dimensions=(1, 1, 1), position=(x, 0, 0)
+            )
+            time.sleep(1.0)
+            truth[x] = centroid_x(
+                client.get_render(height=h, width=w, transport_format="raw", timeout=30)
+            )
+        own_server.scene.remove_by_name("/truth")
+        time.sleep(0.5)
+        mid = (truth[-1.5] + truth[1.5]) / 2
+        assert abs(truth[-1.5] - truth[1.5]) > 15, (
+            f"positions not distinguishable from the default camera: {truth}"
+        )
+
+        # Rapid add-at-pose -> capture cycles, alternating sides, each with a
+        # FRESH node name (a true first mount) and the previous node removed.
+        for i in range(12):
+            x = -1.5 if i % 2 == 0 else 1.5
+            if i > 0:
+                own_server.scene.remove_by_name(f"/fresh_{i - 1}")
+            own_server.scene.add_box(
+                f"/fresh_{i}",
+                color=(255, 0, 0),
+                dimensions=(1, 1, 1),
+                position=(x, 0, 0),
+            )
+            img = client.get_render(
+                height=h, width=w, transport_format="raw", timeout=30.0
+            )
+            cx = centroid_x(img)
+            assert np.isfinite(cx) and (cx < mid) == (truth[x] < mid), (
+                f"iteration {i}: box added at x={x} but captured centroid "
+                f"{cx:.1f}px (expected side of {mid:.1f}) -- capture ran "
+                "before the fresh node's pose was applied"
+            )
+    finally:
+        page.close()  # type: ignore[attr-defined]
+        context.close()  # type: ignore[attr-defined]
+
+
 def test_get_render_transport_formats_agree(
     own_server: viser.ViserServer, browser: Browser
 ) -> None:
@@ -117,6 +179,19 @@ def test_get_render_transport_formats_agree(
             "/box", color=(0, 120, 255), dimensions=(2.0, 2.0, 2.0)
         )
         h, w = 96, 128
+        # The environment lighting loads asynchronously after connect, so
+        # captures taken before/after it lands have different shading (that's
+        # true for a capture at any speed, and not what this test is about).
+        # Stabilize first: capture until two consecutive frames agree.
+        prev = None
+        for _ in range(40):
+            cur = _center_mean(
+                client.get_render(height=h, width=w, transport_format="raw", timeout=30)
+            )
+            if prev is not None and np.allclose(cur, prev, atol=2.0):
+                break
+            prev = cur
+            time.sleep(0.1)
         jpeg = client.get_render(height=h, width=w, transport_format="jpeg", timeout=30)
         png = client.get_render(height=h, width=w, transport_format="png", timeout=30)
         raw = client.get_render(height=h, width=w, transport_format="raw", timeout=30)

--- a/tests/e2e/test_get_render_capture.py
+++ b/tests/e2e/test_get_render_capture.py
@@ -3,11 +3,11 @@
 The client-side capture path is latency-optimized: a request that arrives
 alone captures in the same frame it is processed (after the SceneTree pose
 appliers), a request that arrives alongside scene updates waits exactly one
-frame for React to commit them, JPEG/PNG encoding happens off the
-message-handling critical path, and the deflate_rgb/deflate_rgba transports skip
-image encoding entirely. These tests pin the contract those optimizations must
-preserve: a frame returned by get_render() reflects every scene update made
-before the call, and every transport format returns sane pixels.
+frame for React to commit them, and JPEG/PNG encoding happens off the
+message-handling critical path. These tests pin the contract those
+optimizations must preserve: a frame returned by get_render() reflects every
+scene update made before the call, and both transport formats return sane
+pixels.
 """
 
 from __future__ import annotations
@@ -91,7 +91,7 @@ def test_get_render_reflects_prior_scene_updates(
         for i, color in enumerate(colors):
             box.color = color
             img = client.get_render(
-                height=96, width=128, transport_format="deflate_rgba", timeout=30.0
+                height=96, width=128, transport_format="png", timeout=30.0
             )
             center = _center_mean(img)
             expected_channel = int(np.argmax(color))
@@ -131,9 +131,7 @@ def test_get_render_reflects_fresh_node_poses(
             )
             time.sleep(1.0)
             truth[x] = centroid_x(
-                client.get_render(
-                    height=h, width=w, transport_format="deflate_rgba", timeout=30
-                )
+                client.get_render(height=h, width=w, transport_format="png", timeout=30)
             )
         own_server.scene.remove_by_name("/truth")
         time.sleep(0.5)
@@ -155,7 +153,7 @@ def test_get_render_reflects_fresh_node_poses(
                 position=(x, 0, 0),
             )
             img = client.get_render(
-                height=h, width=w, transport_format="deflate_rgba", timeout=30.0
+                height=h, width=w, transport_format="png", timeout=30.0
             )
             cx = centroid_x(img)
             assert np.isfinite(cx) and (cx < mid) == (truth[x] < mid), (
@@ -171,11 +169,11 @@ def test_get_render_reflects_fresh_node_poses(
 def test_get_render_transport_formats_agree(
     own_server: viser.ViserServer, browser: Browser
 ) -> None:
-    """All transport formats return correctly-shaped arrays of the same
-    scene: JPEG and deflate_rgb (H, W, 3) on white; PNG and deflate_rgba (H, W, 4)
-    on transparent -- with the lossless formats agreeing on the center
-    pixels, corner pixels showing each format's background convention, and
-    repeated solo captures (the same-frame fast path) staying stable."""
+    """Both transport formats return correctly-shaped arrays of the same
+    scene: JPEG (H, W, 3) on white, PNG (H, W, 4) on transparent -- agreeing
+    on the center pixels, with corner pixels showing each format's
+    background convention, and repeated solo captures (the same-frame fast
+    path) staying stable. The default is JPEG."""
     client, page, context = _connect_client(own_server, browser)
     try:
         own_server.scene.add_box(
@@ -189,9 +187,7 @@ def test_get_render_transport_formats_agree(
         prev = None
         for _ in range(40):
             cur = _center_mean(
-                client.get_render(
-                    height=h, width=w, transport_format="deflate_rgba", timeout=30
-                )
+                client.get_render(height=h, width=w, transport_format="png", timeout=30)
             )
             if prev is not None and np.allclose(cur, prev, atol=2.0):
                 break
@@ -199,52 +195,31 @@ def test_get_render_transport_formats_agree(
             time.sleep(0.1)
         jpeg = client.get_render(height=h, width=w, transport_format="jpeg", timeout=30)
         png = client.get_render(height=h, width=w, transport_format="png", timeout=30)
-        raw = client.get_render(
-            height=h, width=w, transport_format="deflate_rgba", timeout=30
-        )
-        rgb = client.get_render(
-            height=h, width=w, transport_format="deflate_rgb", timeout=30
-        )
         assert jpeg.shape == (h, w, 3) and jpeg.dtype == np.uint8
         assert png.shape == (h, w, 4) and png.dtype == np.uint8
-        assert raw.shape == (h, w, 4) and raw.dtype == np.uint8
-        assert rgb.shape == (h, w, 3) and rgb.dtype == np.uint8
-        # Same-background formats agree on the full center region...
-        assert np.allclose(_center_mean(png), _center_mean(raw), atol=3.0), (
-            f"png center {_center_mean(png)} != raw center {_center_mean(raw)}"
-        )
-        assert np.allclose(_center_mean(jpeg), _center_mean(rgb), atol=12.0)
-        # ...while rgb-vs-rgba are compared only where the box is fully
-        # opaque: background pixels legitimately differ (white vs
-        # transparent), and the center window can catch some.
-        mask = raw[:, :, 3] == 255
+        # The formats agree where the box is fully opaque (background pixels
+        # legitimately differ: white for JPEG, transparent for PNG).
+        mask = png[:, :, 3] == 255
         assert mask.mean() > 0.02, "no opaque pixels to compare"
         assert np.allclose(
-            rgb[mask].mean(axis=0), raw[mask][:, :3].mean(axis=0), atol=3.0
-        ), f"rgb {rgb[mask].mean(axis=0)} != rgba {raw[mask][:, :3].mean(axis=0)}"
-        # The center is opaque in the alpha formats.
-        assert int(raw[h // 2, w // 2, 3]) == 255
-        assert int(png[h // 2, w // 2, 3]) == 255
-        # Background conventions: the corner is off-scene from the default
-        # camera -- transparent for the RGBA formats, white for the RGB ones.
-        assert int(raw[0, 0, 3]) == 0 and int(png[0, 0, 3]) == 0
-        assert np.all(rgb[0, 0] >= 250) and np.all(jpeg[0, 0] >= 245)
+            jpeg[mask].mean(axis=0), png[mask][:, :3].mean(axis=0), atol=12.0
+        ), f"jpeg {jpeg[mask].mean(axis=0)} != png {png[mask][:, :3].mean(axis=0)}"
+        # Background conventions at an off-scene corner.
+        assert int(png[0, 0, 3]) == 0
+        assert np.all(jpeg[0, 0] >= 245)
 
-        # The default ("auto") returns (H, W, 3) on white. On this simple
-        # scene the content compresses far beyond auto's lossless threshold,
-        # so the frame must be pixel-exact against deflate_rgb -- proof the
-        # lossless wire path engaged end to end.
+        # The default is JPEG: same shape and white background.
         default = client.get_render(height=h, width=w, timeout=30)
         assert default.shape == (h, w, 3) and default.dtype == np.uint8
-        assert np.all(default[0, 0] >= 250)
-        assert np.allclose(default[mask].mean(axis=0), rgb[mask].mean(axis=0), atol=2.0)
+        assert np.all(default[0, 0] >= 245)
+        assert np.allclose(
+            default[mask].mean(axis=0), jpeg[mask].mean(axis=0), atol=12.0
+        )
 
         # Back-to-back solo captures (no interleaved scene updates) take the
         # same-frame capture path; they must stay correct and identical-ish.
-        again = client.get_render(
-            height=h, width=w, transport_format="deflate_rgba", timeout=30
-        )
-        assert np.allclose(_center_mean(again), _center_mean(raw), atol=3.0)
+        again = client.get_render(height=h, width=w, transport_format="png", timeout=30)
+        assert np.allclose(_center_mean(again), _center_mean(png), atol=3.0)
     finally:
         page.close()  # type: ignore[attr-defined]
         context.close()  # type: ignore[attr-defined]

--- a/tests/e2e/test_get_render_capture.py
+++ b/tests/e2e/test_get_render_capture.py
@@ -230,6 +230,15 @@ def test_get_render_transport_formats_agree(
         assert int(raw[0, 0, 3]) == 0 and int(png[0, 0, 3]) == 0
         assert np.all(rgb[0, 0] >= 250) and np.all(jpeg[0, 0] >= 245)
 
+        # The default ("auto") returns (H, W, 3) on white like jpeg/raw_rgb.
+        # On this simple scene the content compresses far beyond auto's
+        # lossless threshold, so the frame must be pixel-exact against
+        # raw_rgb -- proof the lossless wire path engaged end to end.
+        auto = client.get_render(height=h, width=w, timeout=30)
+        assert auto.shape == (h, w, 3) and auto.dtype == np.uint8
+        assert np.all(auto[0, 0] >= 250)
+        assert np.allclose(auto[mask].mean(axis=0), rgb[mask].mean(axis=0), atol=2.0)
+
         # Back-to-back solo captures (no interleaved scene updates) take the
         # same-frame capture path; they must stay correct and identical-ish.
         again = client.get_render(

--- a/tests/e2e/test_get_render_capture.py
+++ b/tests/e2e/test_get_render_capture.py
@@ -4,8 +4,8 @@ The client-side capture path is latency-optimized: a request that arrives
 alone captures in the same frame it is processed (after the SceneTree pose
 appliers), a request that arrives alongside scene updates waits exactly one
 frame for React to commit them, JPEG/PNG encoding happens off the
-message-handling critical path, and the "raw" transport skips image
-encoding entirely. These tests pin the contract those optimizations must
+message-handling critical path, and the raw_rgb/raw_rgba transports skip
+image encoding entirely. These tests pin the contract those optimizations must
 preserve: a frame returned by get_render() reflects every scene update made
 before the call, and every transport format returns sane pixels.
 """
@@ -91,7 +91,7 @@ def test_get_render_reflects_prior_scene_updates(
         for i, color in enumerate(colors):
             box.color = color
             img = client.get_render(
-                height=96, width=128, transport_format="raw", timeout=30.0
+                height=96, width=128, transport_format="raw_rgba", timeout=30.0
             )
             center = _center_mean(img)
             expected_channel = int(np.argmax(color))
@@ -131,7 +131,9 @@ def test_get_render_reflects_fresh_node_poses(
             )
             time.sleep(1.0)
             truth[x] = centroid_x(
-                client.get_render(height=h, width=w, transport_format="raw", timeout=30)
+                client.get_render(
+                    height=h, width=w, transport_format="raw_rgba", timeout=30
+                )
             )
         own_server.scene.remove_by_name("/truth")
         time.sleep(0.5)
@@ -153,7 +155,7 @@ def test_get_render_reflects_fresh_node_poses(
                 position=(x, 0, 0),
             )
             img = client.get_render(
-                height=h, width=w, transport_format="raw", timeout=30.0
+                height=h, width=w, transport_format="raw_rgba", timeout=30.0
             )
             cx = centroid_x(img)
             assert np.isfinite(cx) and (cx < mid) == (truth[x] < mid), (
@@ -169,10 +171,11 @@ def test_get_render_reflects_fresh_node_poses(
 def test_get_render_transport_formats_agree(
     own_server: viser.ViserServer, browser: Browser
 ) -> None:
-    """All three transport formats return correctly-shaped arrays of the same
-    scene: JPEG (H, W, 3), PNG and raw (H, W, 4) -- with raw and PNG (both
-    lossless, same render path) agreeing on the center pixels, and repeated
-    solo captures (the same-frame fast path) staying stable."""
+    """All transport formats return correctly-shaped arrays of the same
+    scene: JPEG and raw_rgb (H, W, 3) on white; PNG and raw_rgba (H, W, 4)
+    on transparent -- with the lossless formats agreeing on the center
+    pixels, corner pixels showing each format's background convention, and
+    repeated solo captures (the same-frame fast path) staying stable."""
     client, page, context = _connect_client(own_server, browser)
     try:
         own_server.scene.add_box(
@@ -186,7 +189,9 @@ def test_get_render_transport_formats_agree(
         prev = None
         for _ in range(40):
             cur = _center_mean(
-                client.get_render(height=h, width=w, transport_format="raw", timeout=30)
+                client.get_render(
+                    height=h, width=w, transport_format="raw_rgba", timeout=30
+                )
             )
             if prev is not None and np.allclose(cur, prev, atol=2.0):
                 break
@@ -194,22 +199,42 @@ def test_get_render_transport_formats_agree(
             time.sleep(0.1)
         jpeg = client.get_render(height=h, width=w, transport_format="jpeg", timeout=30)
         png = client.get_render(height=h, width=w, transport_format="png", timeout=30)
-        raw = client.get_render(height=h, width=w, transport_format="raw", timeout=30)
+        raw = client.get_render(
+            height=h, width=w, transport_format="raw_rgba", timeout=30
+        )
+        rgb = client.get_render(
+            height=h, width=w, transport_format="raw_rgb", timeout=30
+        )
         assert jpeg.shape == (h, w, 3) and jpeg.dtype == np.uint8
         assert png.shape == (h, w, 4) and png.dtype == np.uint8
         assert raw.shape == (h, w, 4) and raw.dtype == np.uint8
-        # Lossless formats agree on the (fully opaque) box at the center.
+        assert rgb.shape == (h, w, 3) and rgb.dtype == np.uint8
+        # Same-background formats agree on the full center region...
         assert np.allclose(_center_mean(png), _center_mean(raw), atol=3.0), (
             f"png center {_center_mean(png)} != raw center {_center_mean(raw)}"
         )
-        assert np.allclose(_center_mean(jpeg), _center_mean(raw), atol=12.0)
+        assert np.allclose(_center_mean(jpeg), _center_mean(rgb), atol=12.0)
+        # ...while rgb-vs-rgba are compared only where the box is fully
+        # opaque: background pixels legitimately differ (white vs
+        # transparent), and the center window can catch some.
+        mask = raw[:, :, 3] == 255
+        assert mask.mean() > 0.02, "no opaque pixels to compare"
+        assert np.allclose(
+            rgb[mask].mean(axis=0), raw[mask][:, :3].mean(axis=0), atol=3.0
+        ), f"rgb {rgb[mask].mean(axis=0)} != rgba {raw[mask][:, :3].mean(axis=0)}"
         # The center is opaque in the alpha formats.
         assert int(raw[h // 2, w // 2, 3]) == 255
         assert int(png[h // 2, w // 2, 3]) == 255
+        # Background conventions: the corner is off-scene from the default
+        # camera -- transparent for the RGBA formats, white for the RGB ones.
+        assert int(raw[0, 0, 3]) == 0 and int(png[0, 0, 3]) == 0
+        assert np.all(rgb[0, 0] >= 250) and np.all(jpeg[0, 0] >= 245)
 
         # Back-to-back solo captures (no interleaved scene updates) take the
         # same-frame capture path; they must stay correct and identical-ish.
-        again = client.get_render(height=h, width=w, transport_format="raw", timeout=30)
+        again = client.get_render(
+            height=h, width=w, transport_format="raw_rgba", timeout=30
+        )
         assert np.allclose(_center_mean(again), _center_mean(raw), atol=3.0)
     finally:
         page.close()  # type: ignore[attr-defined]

--- a/tests/test_get_render_latency.py
+++ b/tests/test_get_render_latency.py
@@ -389,211 +389,23 @@ def _wait_for_request(
     raise AssertionError("get_render never registered/queued its request")
 
 
-def test_get_render_default_transport_is_auto() -> None:
-    """The default transport is "auto": lossless compressed pixels when the
-    frame compresses well (typical 3D scenes; much faster than JPEG on both
-    ends), JPEG otherwise. Measured on 720p frames, the fixed alternatives
-    each have a content class where they lose badly -- deflate grinds at
-    100-270ms on high-entropy frames (dense colored point clouds, splats,
-    photo textures) or ships them as multi-MB payloads, while JPEG wastes
-    30-45ms of codec work on frames that deflate 100x+ in ~13ms -- so only
-    the per-frame choice is never meaningfully slower than either."""
+def test_get_render_default_transport_is_jpeg() -> None:
+    """The transport lineup is deliberately just jpeg (default) and png.
+    Content-adaptive lossless transports (deflate-compressed raw pixels,
+    with or without a JPEG fallback) were built, measured, and removed:
+    every fixed lossless choice had a content class where it lost badly
+    (high-entropy frames deflate at ~2x for 100-270ms, or ship as multi-MB
+    payloads), and the per-frame adaptive variant's win over plain JPEG --
+    after the capture-path optimizations that benefit every format -- was
+    too small to justify two extra formats, a payload-flag protocol, and
+    sampling thresholds. See the branch history for the measurements."""
     import inspect
 
     from viser._viser import CameraHandle
 
     for fn in (ClientHandle.get_render, CameraHandle.get_render):
         default = inspect.signature(fn).parameters["transport_format"].default
-        assert default == "auto", f"{fn.__qualname__} default is {default!r}"
-
-
-def test_get_render_auto_transport_round_trip() -> None:
-    """The "auto" transport decodes both of its per-frame encodings to an
-    (H, W, 3) RGB array: flag 1 (deflate-compressed RGBA, alpha dropped,
-    lossless) and flag 2 (JPEG bytes). Unknown flags raise."""
-    import zlib
-
-    height, width = 4, 6
-    with _server() as server:
-        conn = _RecordingConn()
-        client = ClientHandle.__new__(ClientHandle)
-        client.client_id = 810_006
-        client._websock_connection = conn  # type: ignore[assignment]
-        client._viser_server = server
-        server._connected_clients[client.client_id] = cast(viser.ClientHandle, client)
-        try:
-            result: dict[str, object] = {}
-
-            def call() -> None:
-                try:
-                    # transport_format deliberately omitted: exercises the
-                    # "auto" default end to end.
-                    result["out"] = client.get_render(
-                        height=height,
-                        width=width,
-                        **_camera_kwargs(),
-                        timeout=5.0,
-                    )
-                except BaseException as e:  # noqa: BLE001
-                    result["err"] = e
-
-            def run_once(payload: bytes) -> object:
-                result.clear()
-                conn.sent.clear()
-                thread = threading.Thread(target=call)
-                thread.start()
-                cb, uuid = _wait_for_request(conn)
-                request = next(
-                    m
-                    for m in conn.sent
-                    if isinstance(m, _messages.GetRenderRequestMessage)
-                )
-                assert request.format == "auto"
-                cb(
-                    client.client_id,
-                    _messages.GetRenderResponseMessage(payload, uuid),
-                )
-                thread.join(timeout=8.0)
-                assert not thread.is_alive()
-                return result.get("out", result.get("err"))
-
-            pixels = np.arange(height * width * 4, dtype=np.uint8).reshape(
-                height, width, 4
-            )
-            compressor = zlib.compressobj(wbits=-15)
-            deflated = compressor.compress(pixels.tobytes()) + compressor.flush()
-            out = run_once(b"\x01" + deflated)
-            assert isinstance(out, np.ndarray), f"caller raised: {out!r}"
-            assert out.shape == (height, width, 3)
-            assert np.array_equal(out, pixels[:, :, :3])  # lossless
-
-            out = run_once(b"\x02" + _jpeg_payload(height, width))
-            assert isinstance(out, np.ndarray), f"caller raised: {out!r}"
-            assert out.shape == (height, width, 3)
-
-            err = run_once(b"\x07" + b"???")
-            assert isinstance(err, RuntimeError) and "unknown" in str(err)
-        finally:
-            server._connected_clients.pop(client.client_id, None)
-
-
-def test_get_render_deflate_transport_round_trip() -> None:
-    """transport_format="deflate_rgb" requests deflate_rgb on the wire and
-    returns the RGBA payload (1-byte flag + pixels, optionally
-    deflate-compressed) reshaped, alpha dropped, to a writable (H, W, 3)
-    array -- no image decode. deflate_rgba keeps all four channels.
-    Size-mismatched or corrupt payloads raise instead of returning
-    garbage."""
-    import zlib
-
-    height, width = 4, 6
-    with _server() as server:
-        conn = _RecordingConn()
-        client = ClientHandle.__new__(ClientHandle)
-        client.client_id = 810_004
-        client._websock_connection = conn  # type: ignore[assignment]
-        client._viser_server = server
-        server._connected_clients[client.client_id] = cast(viser.ClientHandle, client)
-        try:
-            result: dict[str, object] = {}
-
-            def call() -> None:
-                try:
-                    result["out"] = client.get_render(
-                        height=height,
-                        width=width,
-                        **_camera_kwargs(),
-                        transport_format="deflate_rgb",
-                        timeout=5.0,
-                    )
-                except BaseException as e:  # noqa: BLE001
-                    result["err"] = e
-
-            thread = threading.Thread(target=call)
-            thread.start()
-            cb, uuid = _wait_for_request(conn)
-            request = next(
-                m for m in conn.sent if isinstance(m, _messages.GetRenderRequestMessage)
-            )
-            assert request.format == "deflate_rgb"
-            pixels = np.arange(height * width * 4, dtype=np.uint8).reshape(
-                height, width, 4
-            )
-            cb(
-                client.client_id,
-                _messages.GetRenderResponseMessage(b"\x00" + pixels.tobytes(), uuid),
-            )
-            thread.join(timeout=8.0)
-            assert not thread.is_alive()
-            assert "err" not in result, f"caller raised: {result.get('err')!r}"
-            out = cast(np.ndarray, result["out"])
-            assert out.shape == (height, width, 3)
-            assert out.dtype == np.uint8
-            assert np.array_equal(out, pixels[:, :, :3])
-            assert out.flags.writeable
-
-            # deflate_rgba keeps the alpha channel.
-            result.clear()
-            conn.sent.clear()
-
-            def call_rgba() -> None:
-                try:
-                    result["out"] = client.get_render(
-                        height=height,
-                        width=width,
-                        **_camera_kwargs(),
-                        transport_format="deflate_rgba",
-                        timeout=5.0,
-                    )
-                except BaseException as e:  # noqa: BLE001
-                    result["err"] = e
-
-            thread = threading.Thread(target=call_rgba)
-            thread.start()
-            cb, uuid = _wait_for_request(conn)
-            request = next(
-                m for m in conn.sent if isinstance(m, _messages.GetRenderRequestMessage)
-            )
-            assert request.format == "deflate_rgba"
-            # Deliver deflate-compressed (flag 1), as the client does for
-            # compressible content.
-            compressor = zlib.compressobj(wbits=-15)
-            deflated = compressor.compress(pixels.tobytes()) + compressor.flush()
-            cb(
-                client.client_id,
-                _messages.GetRenderResponseMessage(b"\x01" + deflated, uuid),
-            )
-            thread.join(timeout=8.0)
-            assert not thread.is_alive()
-            assert "err" not in result, f"caller raised: {result.get('err')!r}"
-            out = cast(np.ndarray, result["out"])
-            assert out.shape == (height, width, 4)
-            assert np.array_equal(out, pixels)
-            assert out.flags.writeable
-
-            # Size-mismatched (flag 0) and corrupt-compressed (flag 1)
-            # payloads must raise, not reshape-crash or return garbage.
-            for bad_payload, match in [
-                (b"\x00" * 17, "expected"),
-                (b"\x01" + b"not deflate data", "corrupt"),
-            ]:
-                result.clear()
-                thread = threading.Thread(target=call)
-                conn.sent.clear()
-                thread.start()
-                cb, uuid = _wait_for_request(conn)
-                cb(
-                    client.client_id,
-                    _messages.GetRenderResponseMessage(bad_payload, uuid),
-                )
-                thread.join(timeout=8.0)
-                assert not thread.is_alive()
-                err = result.get("err")
-                assert isinstance(err, RuntimeError) and match in str(err), (
-                    f"payload {bad_payload[:8]!r}: got {err!r}"
-                )
-        finally:
-            server._connected_clients.pop(client.client_id, None)
+        assert default == "jpeg", f"{fn.__qualname__} default is {default!r}"
 
 
 def test_get_render_jpeg_quality_reaches_the_wire() -> None:

--- a/tests/test_get_render_latency.py
+++ b/tests/test_get_render_latency.py
@@ -389,8 +389,8 @@ def _wait_for_request(
     raise AssertionError("get_render never registered/queued its request")
 
 
-def test_get_render_default_transport_is_raw_rgb() -> None:
-    """The default transport is "raw_rgb": lossless, no image codec on
+def test_get_render_default_transport_is_deflate_rgb() -> None:
+    """The default transport is "deflate_rgb": lossless, no image codec on
     either end, and adaptively deflate-compressed on the wire (typical 3D
     scenes: 100x+), keeping bandwidth reasonable in the common case. The
     worst case for incompressible content is uncompressed pixels; jpeg
@@ -401,14 +401,14 @@ def test_get_render_default_transport_is_raw_rgb() -> None:
 
     for fn in (ClientHandle.get_render, CameraHandle.get_render):
         default = inspect.signature(fn).parameters["transport_format"].default
-        assert default == "raw_rgb", f"{fn.__qualname__} default is {default!r}"
+        assert default == "deflate_rgb", f"{fn.__qualname__} default is {default!r}"
 
 
-def test_get_render_raw_transport_round_trip() -> None:
-    """The DEFAULT transport requests raw_rgb on the wire and returns the
+def test_get_render_deflate_transport_round_trip() -> None:
+    """The DEFAULT transport requests deflate_rgb on the wire and returns the
     RGBA payload (1-byte flag + pixels, optionally deflate-compressed)
     reshaped, alpha dropped, to a writable (H, W, 3) array -- no image
-    decode. raw_rgba keeps all four channels. Size-mismatched or corrupt
+    decode. deflate_rgba keeps all four channels. Size-mismatched or corrupt
     payloads raise instead of returning garbage. (transport_format is
     deliberately omitted in the first call: this also pins the default end
     to end.)"""
@@ -442,7 +442,7 @@ def test_get_render_raw_transport_round_trip() -> None:
             request = next(
                 m for m in conn.sent if isinstance(m, _messages.GetRenderRequestMessage)
             )
-            assert request.format == "raw_rgb"
+            assert request.format == "deflate_rgb"
             pixels = np.arange(height * width * 4, dtype=np.uint8).reshape(
                 height, width, 4
             )
@@ -459,7 +459,7 @@ def test_get_render_raw_transport_round_trip() -> None:
             assert np.array_equal(out, pixels[:, :, :3])
             assert out.flags.writeable
 
-            # raw_rgba keeps the alpha channel.
+            # deflate_rgba keeps the alpha channel.
             result.clear()
             conn.sent.clear()
 
@@ -469,7 +469,7 @@ def test_get_render_raw_transport_round_trip() -> None:
                         height=height,
                         width=width,
                         **_camera_kwargs(),
-                        transport_format="raw_rgba",
+                        transport_format="deflate_rgba",
                         timeout=5.0,
                     )
                 except BaseException as e:  # noqa: BLE001
@@ -481,7 +481,7 @@ def test_get_render_raw_transport_round_trip() -> None:
             request = next(
                 m for m in conn.sent if isinstance(m, _messages.GetRenderRequestMessage)
             )
-            assert request.format == "raw_rgba"
+            assert request.format == "deflate_rgba"
             # Deliver deflate-compressed (flag 1), as the client does for
             # compressible content.
             compressor = zlib.compressobj(wbits=-15)

--- a/tests/test_get_render_latency.py
+++ b/tests/test_get_render_latency.py
@@ -389,97 +389,29 @@ def _wait_for_request(
     raise AssertionError("get_render never registered/queued its request")
 
 
-def test_get_render_default_transport_is_auto() -> None:
-    """The default transport is "auto": lossless compressed pixels when the
-    content compresses at JPEG-competitive rates (typical 3D scenes; much
-    faster than JPEG), JPEG otherwise -- so unlike the raw formats, the
-    payload stays small on arbitrary content and connections, which is what
-    a default must guarantee."""
+def test_get_render_default_transport_is_raw_rgb() -> None:
+    """The default transport is "raw_rgb": lossless, no image codec on
+    either end, and adaptively deflate-compressed on the wire (typical 3D
+    scenes: 100x+), keeping bandwidth reasonable in the common case. The
+    worst case for incompressible content is uncompressed pixels; jpeg
+    stays available for slow links with such scenes."""
     import inspect
 
     from viser._viser import CameraHandle
 
     for fn in (ClientHandle.get_render, CameraHandle.get_render):
         default = inspect.signature(fn).parameters["transport_format"].default
-        assert default == "auto", f"{fn.__qualname__} default is {default!r}"
-
-
-def test_get_render_auto_transport_round_trip() -> None:
-    """The "auto" transport decodes both of its per-frame encodings to an
-    (H, W, 3) RGB array: flag 1 (deflate-compressed RGBA, alpha dropped,
-    lossless) and flag 2 (JPEG bytes). Unknown flags raise."""
-    import zlib
-
-    height, width = 4, 6
-    with _server() as server:
-        conn = _RecordingConn()
-        client = ClientHandle.__new__(ClientHandle)
-        client.client_id = 810_006
-        client._websock_connection = conn  # type: ignore[assignment]
-        client._viser_server = server
-        server._connected_clients[client.client_id] = cast(viser.ClientHandle, client)
-        try:
-            result: dict[str, object] = {}
-
-            def call() -> None:
-                try:
-                    # transport_format deliberately omitted: exercises the
-                    # "auto" default end to end.
-                    result["out"] = client.get_render(
-                        height=height,
-                        width=width,
-                        **_camera_kwargs(),
-                        timeout=5.0,
-                    )
-                except BaseException as e:  # noqa: BLE001
-                    result["err"] = e
-
-            def run_once(payload: bytes) -> object:
-                result.clear()
-                conn.sent.clear()
-                thread = threading.Thread(target=call)
-                thread.start()
-                cb, uuid = _wait_for_request(conn)
-                request = next(
-                    m
-                    for m in conn.sent
-                    if isinstance(m, _messages.GetRenderRequestMessage)
-                )
-                assert request.format == "auto"
-                cb(
-                    client.client_id,
-                    _messages.GetRenderResponseMessage(payload, uuid),
-                )
-                thread.join(timeout=8.0)
-                assert not thread.is_alive()
-                return result.get("out", result.get("err"))
-
-            pixels = np.arange(height * width * 4, dtype=np.uint8).reshape(
-                height, width, 4
-            )
-            compressor = zlib.compressobj(wbits=-15)
-            deflated = compressor.compress(pixels.tobytes()) + compressor.flush()
-            out = run_once(b"\x01" + deflated)
-            assert isinstance(out, np.ndarray), f"caller raised: {out!r}"
-            assert out.shape == (height, width, 3)
-            assert np.array_equal(out, pixels[:, :, :3])  # lossless
-
-            out = run_once(b"\x02" + _jpeg_payload(height, width))
-            assert isinstance(out, np.ndarray), f"caller raised: {out!r}"
-            assert out.shape == (height, width, 3)
-
-            err = run_once(b"\x07" + b"???")
-            assert isinstance(err, RuntimeError) and "unknown" in str(err)
-        finally:
-            server._connected_clients.pop(client.client_id, None)
+        assert default == "raw_rgb", f"{fn.__qualname__} default is {default!r}"
 
 
 def test_get_render_raw_transport_round_trip() -> None:
-    """transport_format="raw_rgb" requests raw_rgb on the wire and returns
-    the RGBA payload (1-byte flag + pixels, optionally deflate-compressed)
+    """The DEFAULT transport requests raw_rgb on the wire and returns the
+    RGBA payload (1-byte flag + pixels, optionally deflate-compressed)
     reshaped, alpha dropped, to a writable (H, W, 3) array -- no image
     decode. raw_rgba keeps all four channels. Size-mismatched or corrupt
-    payloads raise instead of returning garbage."""
+    payloads raise instead of returning garbage. (transport_format is
+    deliberately omitted in the first call: this also pins the default end
+    to end.)"""
     import zlib
 
     height, width = 4, 6
@@ -499,7 +431,6 @@ def test_get_render_raw_transport_round_trip() -> None:
                         height=height,
                         width=width,
                         **_camera_kwargs(),
-                        transport_format="raw_rgb",
                         timeout=5.0,
                     )
                 except BaseException as e:  # noqa: BLE001

--- a/tests/test_get_render_latency.py
+++ b/tests/test_get_render_latency.py
@@ -389,18 +389,89 @@ def _wait_for_request(
     raise AssertionError("get_render never registered/queued its request")
 
 
-def test_get_render_default_transport_is_jpeg() -> None:
-    """The default transport stays "jpeg": raw is 10-20x larger on the wire
-    (width * height * 4 bytes), so making it the default would silently
-    regress callers capturing over slow or remote links (e.g. share URLs).
-    Raw is opt-in for local connections."""
+def test_get_render_default_transport_is_auto() -> None:
+    """The default transport is "auto": lossless compressed pixels when the
+    content compresses at JPEG-competitive rates (typical 3D scenes; much
+    faster than JPEG), JPEG otherwise -- so unlike the raw formats, the
+    payload stays small on arbitrary content and connections, which is what
+    a default must guarantee."""
     import inspect
 
     from viser._viser import CameraHandle
 
     for fn in (ClientHandle.get_render, CameraHandle.get_render):
         default = inspect.signature(fn).parameters["transport_format"].default
-        assert default == "jpeg", f"{fn.__qualname__} default is {default!r}"
+        assert default == "auto", f"{fn.__qualname__} default is {default!r}"
+
+
+def test_get_render_auto_transport_round_trip() -> None:
+    """The "auto" transport decodes both of its per-frame encodings to an
+    (H, W, 3) RGB array: flag 1 (deflate-compressed RGBA, alpha dropped,
+    lossless) and flag 2 (JPEG bytes). Unknown flags raise."""
+    import zlib
+
+    height, width = 4, 6
+    with _server() as server:
+        conn = _RecordingConn()
+        client = ClientHandle.__new__(ClientHandle)
+        client.client_id = 810_006
+        client._websock_connection = conn  # type: ignore[assignment]
+        client._viser_server = server
+        server._connected_clients[client.client_id] = cast(viser.ClientHandle, client)
+        try:
+            result: dict[str, object] = {}
+
+            def call() -> None:
+                try:
+                    # transport_format deliberately omitted: exercises the
+                    # "auto" default end to end.
+                    result["out"] = client.get_render(
+                        height=height,
+                        width=width,
+                        **_camera_kwargs(),
+                        timeout=5.0,
+                    )
+                except BaseException as e:  # noqa: BLE001
+                    result["err"] = e
+
+            def run_once(payload: bytes) -> object:
+                result.clear()
+                conn.sent.clear()
+                thread = threading.Thread(target=call)
+                thread.start()
+                cb, uuid = _wait_for_request(conn)
+                request = next(
+                    m
+                    for m in conn.sent
+                    if isinstance(m, _messages.GetRenderRequestMessage)
+                )
+                assert request.format == "auto"
+                cb(
+                    client.client_id,
+                    _messages.GetRenderResponseMessage(payload, uuid),
+                )
+                thread.join(timeout=8.0)
+                assert not thread.is_alive()
+                return result.get("out", result.get("err"))
+
+            pixels = np.arange(height * width * 4, dtype=np.uint8).reshape(
+                height, width, 4
+            )
+            compressor = zlib.compressobj(wbits=-15)
+            deflated = compressor.compress(pixels.tobytes()) + compressor.flush()
+            out = run_once(b"\x01" + deflated)
+            assert isinstance(out, np.ndarray), f"caller raised: {out!r}"
+            assert out.shape == (height, width, 3)
+            assert np.array_equal(out, pixels[:, :, :3])  # lossless
+
+            out = run_once(b"\x02" + _jpeg_payload(height, width))
+            assert isinstance(out, np.ndarray), f"caller raised: {out!r}"
+            assert out.shape == (height, width, 3)
+
+            err = run_once(b"\x07" + b"???")
+            assert isinstance(err, RuntimeError) and "unknown" in str(err)
+        finally:
+            server._connected_clients.pop(client.client_id, None)
 
 
 def test_get_render_raw_transport_round_trip() -> None:

--- a/tests/test_get_render_latency.py
+++ b/tests/test_get_render_latency.py
@@ -523,6 +523,51 @@ def test_get_render_deflate_transport_round_trip() -> None:
             server._connected_clients.pop(client.client_id, None)
 
 
+def test_get_render_jpeg_quality_reaches_the_wire() -> None:
+    """jpeg_quality must land in the request's quality field (the client
+    passes it to toBlob; omitting it there silently encoded at Chrome's
+    0.92 default -- larger, no faster), and out-of-range values raise."""
+    with _server() as server:
+        conn = _RecordingConn()
+        client = ClientHandle.__new__(ClientHandle)
+        client.client_id = 810_007
+        client._websock_connection = conn  # type: ignore[assignment]
+        client._viser_server = server
+        server._connected_clients[client.client_id] = cast(viser.ClientHandle, client)
+        try:
+            with pytest.raises(ValueError, match="jpeg_quality"):
+                client.get_render(height=8, width=8, **_camera_kwargs(), jpeg_quality=0)
+
+            def call() -> None:
+                try:
+                    client.get_render(
+                        height=8,
+                        width=8,
+                        **_camera_kwargs(),
+                        transport_format="jpeg",
+                        jpeg_quality=55,
+                        timeout=2.0,
+                    )
+                except BaseException:  # noqa: BLE001
+                    pass
+
+            thread = threading.Thread(target=call)
+            thread.start()
+            cb, uuid = _wait_for_request(conn)
+            request = next(
+                m for m in conn.sent if isinstance(m, _messages.GetRenderRequestMessage)
+            )
+            assert request.quality == 55
+            cb(
+                client.client_id,
+                _messages.GetRenderResponseMessage(_jpeg_payload(8, 8), uuid),
+            )
+            thread.join(timeout=5.0)
+            assert not thread.is_alive()
+        finally:
+            server._connected_clients.pop(client.client_id, None)
+
+
 def test_get_render_flushes_broadcast_buffer_first() -> None:
     """Scene updates made before get_render() ride the BROADCAST buffer while
     the render request rides the per-client buffer. get_render() must flush

--- a/tests/test_get_render_latency.py
+++ b/tests/test_get_render_latency.py
@@ -1,0 +1,349 @@
+"""Regression tests for get_render() latency fixes and request races.
+
+get_render() is a blocking round trip, so fixed per-call overhead directly
+caps capture throughput. Three server-side problems are pinned here:
+
+- The request message used to sit in the outgoing per-client buffer for up to
+  one windowing delay (``window_duration_sec``) before hitting the wire;
+  get_render() now flushes the buffer immediately after queueing.
+- ``GetRenderRequestMessage`` had no ``redundancy_key`` override, so every
+  request shared the class-name default key: a second concurrent
+  get_render() on the same client evicted the first caller's still-unsent
+  request from the buffer, hanging that caller until timeout.
+- The response payload used to be decoded (plus imageio's slow first import)
+  inside the response callback, which runs on the server's asyncio event
+  loop -- blocking message handling for every client. Decoding now happens
+  on the calling thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import threading
+import time
+from contextlib import contextmanager
+from typing import Generator, cast
+
+import numpy as np
+import pytest
+
+import viser
+from viser import _messages
+from viser._viser import ClientHandle
+from viser.infra._async_message_buffer import AsyncMessageBuffer
+from viser.infra._infra import (
+    WebsockClientConnection,
+    WebsockMessageHandler,
+    _ClientHandleState,
+)
+
+
+@contextmanager
+def _server() -> Generator[viser.ViserServer, None, None]:
+    server = viser.ViserServer(port=0, verbose=False)
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+def _camera_kwargs() -> dict:
+    """Explicit camera args so fabricated clients never read camera state."""
+    return dict(
+        wxyz=(1.0, 0.0, 0.0, 0.0),
+        position=(0.0, 0.0, 0.0),
+        fov=1.0,
+    )
+
+
+def _jpeg_payload(height: int, width: int) -> bytes:
+    import imageio.v3 as iio
+
+    buf = io.BytesIO()
+    iio.imwrite(buf, np.zeros((height, width, 3), dtype=np.uint8), extension=".jpeg")
+    return buf.getvalue()
+
+
+def _make_buffered_client(
+    server: viser.ViserServer, client_id: int
+) -> tuple[ClientHandle, AsyncMessageBuffer, WebsockClientConnection]:
+    """A ClientHandle whose connection is backed by a REAL (non-persistent)
+    AsyncMessageBuffer on the server's live event loop, as for a browser
+    client -- so buffer-level behavior (coalescing, windowing, flushing) is
+    actually exercised. The caller is responsible for popping the client from
+    ``server._connected_clients`` / ``_client_state_from_id`` afterwards."""
+    loop = server._websock_server._background_event_loop
+    assert loop is not None
+    buffer = AsyncMessageBuffer(loop, persistent_messages=False)
+    client_state = _ClientHandleState(buffer, loop)
+    conn = WebsockClientConnection(client_id, client_state)
+    client = ClientHandle.__new__(ClientHandle)
+    client.client_id = client_id
+    client._websock_connection = conn
+    client._viser_server = server
+    server._connected_clients[client_id] = cast(viser.ClientHandle, client)
+    # Registered so ClientHandle.flush() (-> flush_client) reaches this buffer.
+    server._websock_server._client_state_from_id[client_id] = client_state
+    return client, buffer, conn
+
+
+def test_render_request_redundancy_key_is_per_request() -> None:
+    """Two render requests must occupy independent buffer slots. Under the
+    class-name default key, push() evicted the earlier request."""
+
+    def request(uuid: str) -> _messages.GetRenderRequestMessage:
+        return _messages.GetRenderRequestMessage(
+            "image/jpeg",
+            height=8,
+            width=8,
+            quality=80,
+            position=(0.0, 0.0, 0.0),
+            wxyz=(1.0, 0.0, 0.0, 0.0),
+            fov=1.0,
+            render_uuid=uuid,
+        )
+
+    assert request("aa").redundancy_key() != request("bb").redundancy_key()
+
+    async def scenario() -> int:
+        buffer = AsyncMessageBuffer(
+            asyncio.get_running_loop(), persistent_messages=False
+        )
+        buffer.push(request("aa"))
+        buffer.push(request("bb"))
+        return sum(
+            isinstance(m, _messages.GetRenderRequestMessage)
+            for m in buffer.message_from_id.values()
+        )
+
+    from .thread_isolation import run_isolated
+
+    assert run_isolated(lambda: asyncio.run(scenario())) == 2
+
+
+def test_concurrent_get_render_requests_both_survive_and_resolve() -> None:
+    """Two concurrent get_render() calls on the SAME client: both requests
+    must reach the outgoing buffer (pre-fix, the second evicted the first),
+    and crossed responses must resolve each caller to its own frame."""
+    with _server() as server:
+        client, buffer, conn = _make_buffered_client(server, client_id=810_001)
+        results: dict[int, object] = {}
+        results_lock = threading.Lock()
+
+        def call(height: int) -> None:
+            try:
+                out = client.get_render(
+                    height=height, width=height, **_camera_kwargs(), timeout=6.0
+                )
+                with results_lock:
+                    results[height] = out
+            except BaseException as e:  # noqa: BLE001
+                with results_lock:
+                    results[height] = e
+
+        threads = [
+            threading.Thread(target=call, args=(8,)),
+            threading.Thread(target=call, args=(16,)),
+        ]
+        try:
+            for t in threads:
+                t.start()
+
+            # Both requests must be present in the buffer simultaneously.
+            deadline = time.monotonic() + 5.0
+            requests: list[_messages.GetRenderRequestMessage] = []
+            while time.monotonic() < deadline:
+                with buffer.buffer_lock:
+                    requests = [
+                        m
+                        for m in buffer.message_from_id.values()
+                        if isinstance(m, _messages.GetRenderRequestMessage)
+                    ]
+                if len(requests) == 2:
+                    break
+                time.sleep(0.002)
+            assert len(requests) == 2, (
+                f"expected both in-flight render requests in the buffer, found "
+                f"{len(requests)} (concurrent requests coalesced?)"
+            )
+
+            uuid_by_height = {r.height: r.render_uuid for r in requests}
+            # Dispatch crossed responses (largest first) to a handler snapshot,
+            # as the server's dispatch loop would: each caller must take only
+            # the frame matching its own request uuid.
+            handlers = list(conn._incoming_handlers[_messages.GetRenderResponseMessage])
+            assert len(handlers) == 2
+            for height in (16, 8):
+                message = _messages.GetRenderResponseMessage(
+                    _jpeg_payload(height, height), uuid_by_height[height]
+                )
+                for cb in handlers:
+                    cb(client.client_id, message)
+
+            for t in threads:
+                t.join(timeout=8.0)
+            assert all(not t.is_alive() for t in threads), "get_render hung"
+            for height in (8, 16):
+                out = results[height]
+                assert isinstance(out, np.ndarray), f"caller raised: {out!r}"
+                assert out.shape == (height, height, 3)
+        finally:
+            server._connected_clients.pop(client.client_id, None)
+            server._websock_server._client_state_from_id.pop(client.client_id, None)
+
+
+def test_get_render_request_skips_windowing_delay() -> None:
+    """The render request must be flushed onto the wire immediately, not sit
+    out the buffer's windowing delay. The buffer's window delay is set
+    absurdly high (10s); with the producer parked in that delay, the request
+    window must still arrive promptly because get_render() flushes."""
+    with _server() as server:
+        loop = server._websock_server._background_event_loop
+        assert loop is not None
+        client, buffer, conn = _make_buffered_client(server, client_id=810_002)
+        buffer.window_duration_sec = 10.0
+        dummy_seen = threading.Event()
+
+        async def collect_until_request() -> tuple[float, list]:
+            gen = buffer.window_generator(client.client_id)
+            try:
+                while True:
+                    window = await gen.__anext__()
+                    if any(
+                        isinstance(m, _messages.GetRenderRequestMessage) for m in window
+                    ):
+                        return time.monotonic(), list(window)
+                    dummy_seen.set()
+            finally:
+                await gen.aclose()
+
+        box: dict[str, BaseException] = {}
+
+        def call() -> None:
+            try:
+                client.get_render(height=8, width=8, **_camera_kwargs(), timeout=8.0)
+            except BaseException as e:  # noqa: BLE001
+                box["err"] = e
+
+        thread = threading.Thread(target=call)
+        # Queue a dummy BEFORE the producer starts (so its very first window
+        # yields it immediately), then drain it: the producer is then parked
+        # in its (10-second) post-window delay when the request is pushed --
+        # the exact state the flush must break out of.
+        conn.queue_message(_messages.GuiCloseModalMessage(uuid="dummy"))
+        future = asyncio.run_coroutine_threadsafe(collect_until_request(), loop)
+        try:
+            assert dummy_seen.wait(timeout=5.0)
+            time.sleep(0.3)  # Let the producer re-enter its post-yield delay.
+
+            start = time.monotonic()
+            thread.start()
+            # Pre-fix (no flush), the window surfaces only after the full 10s
+            # delay and this times out.
+            arrival, window = future.result(timeout=5.0)
+            assert arrival - start < 5.0
+            request = next(
+                m for m in window if isinstance(m, _messages.GetRenderRequestMessage)
+            )
+            # Unblock the caller: empty payload is the failure sentinel.
+            for cb in list(
+                conn._incoming_handlers.get(_messages.GetRenderResponseMessage, [])
+            ):
+                cb(
+                    client.client_id,
+                    _messages.GetRenderResponseMessage(b"", request.render_uuid),
+                )
+        finally:
+            future.cancel()
+            thread.join(timeout=10.0)
+            server._connected_clients.pop(client.client_id, None)
+            server._websock_server._client_state_from_id.pop(client.client_id, None)
+        assert not thread.is_alive()
+        assert isinstance(box.get("err"), RuntimeError)  # empty-payload sentinel
+
+
+def test_render_decode_runs_on_caller_thread_not_dispatch_thread() -> None:
+    """The payload must be decoded on the get_render() caller's thread. It
+    used to be decoded inside the response callback, which the server runs on
+    its asyncio event loop -- stalling message handling for every client for
+    the duration of a large PNG/JPEG decode."""
+    import imageio.v3 as iio
+
+    payload = _jpeg_payload(8, 8)
+    decode_threads: list[threading.Thread] = []
+    real_imread = iio.imread
+
+    def spy_imread(*args: object, **kwargs: object) -> np.ndarray:
+        decode_threads.append(threading.current_thread())
+        return real_imread(*args, **kwargs)  # type: ignore[arg-type]
+
+    class _Conn(WebsockMessageHandler):
+        def __init__(self) -> None:
+            super().__init__()
+            self.sent: list[object] = []
+
+        def get_message_buffer(self):  # pragma: no cover - unused
+            raise NotImplementedError()
+
+        def queue_message(self, message) -> None:
+            self.sent.append(message)
+
+    with _server() as server:
+        conn = _Conn()
+        client = ClientHandle.__new__(ClientHandle)
+        client.client_id = 810_003
+        client._websock_connection = conn  # type: ignore[assignment]
+        client._viser_server = server
+        server._connected_clients[client.client_id] = cast(viser.ClientHandle, client)
+
+        result: dict[str, object] = {}
+
+        def call() -> None:
+            result["thread"] = threading.current_thread()
+            try:
+                result["out"] = client.get_render(
+                    height=8, width=8, **_camera_kwargs(), timeout=5.0
+                )
+            except BaseException as e:  # noqa: BLE001
+                result["err"] = e
+
+        thread = threading.Thread(target=call)
+        try:
+            with pytest.MonkeyPatch.context() as mp:
+                mp.setattr("imageio.v3.imread", spy_imread)
+                thread.start()
+                # Wait for the request, then deliver the response from THIS
+                # (dispatch-stand-in) thread.
+                deadline = time.monotonic() + 5.0
+                cb = None
+                uuid = None
+                while time.monotonic() < deadline:
+                    handlers = conn._incoming_handlers.get(
+                        _messages.GetRenderResponseMessage, []
+                    )
+                    requests = [
+                        m
+                        for m in conn.sent
+                        if isinstance(m, _messages.GetRenderRequestMessage)
+                    ]
+                    if handlers and requests:
+                        cb, uuid = handlers[0], requests[0].render_uuid
+                        break
+                    time.sleep(0.002)
+                assert cb is not None and uuid is not None, "request never sent"
+                cb(client.client_id, _messages.GetRenderResponseMessage(payload, uuid))
+                thread.join(timeout=8.0)
+        finally:
+            server._connected_clients.pop(client.client_id, None)
+
+        assert not thread.is_alive()
+        assert "err" not in result, f"caller raised: {result.get('err')!r}"
+        assert cast(np.ndarray, result["out"]).shape == (8, 8, 3)
+        # Decoded exactly once, on the caller's thread -- never on the thread
+        # that delivered the response (the event loop, in production).
+        assert decode_threads == [result["thread"]], (
+            f"decode ran on {decode_threads}, expected only the get_render "
+            f"caller thread {result['thread']}"
+        )
+        assert threading.current_thread() not in decode_threads

--- a/tests/test_get_render_latency.py
+++ b/tests/test_get_render_latency.py
@@ -75,7 +75,17 @@ def _make_buffered_client(
     ``server._connected_clients`` / ``_client_state_from_id`` afterwards."""
     loop = server._websock_server._background_event_loop
     assert loop is not None
-    buffer = AsyncMessageBuffer(loop, persistent_messages=False)
+
+    # Construct the buffer ON the server's event loop: before Python 3.10,
+    # asyncio.Event() binds its loop at construction time, so building the
+    # buffer on the test thread attaches its events to the wrong loop and
+    # the window generator explodes with "attached to a different loop".
+    # (The real client path constructs buffers inside the ws handler, i.e.
+    # on the loop, so it never hits this.)
+    async def _make_buffer() -> AsyncMessageBuffer:
+        return AsyncMessageBuffer(loop, persistent_messages=False)
+
+    buffer = asyncio.run_coroutine_threadsafe(_make_buffer(), loop).result(timeout=5.0)
     client_state = _ClientHandleState(buffer, loop)
     conn = WebsockClientConnection(client_id, client_state)
     client = ClientHandle.__new__(ClientHandle)

--- a/tests/test_get_render_latency.py
+++ b/tests/test_get_render_latency.py
@@ -23,7 +23,7 @@ import io
 import threading
 import time
 from contextlib import contextmanager
-from typing import Generator, cast
+from typing import Callable, Generator, cast
 
 import numpy as np
 import pytest
@@ -347,3 +347,149 @@ def test_render_decode_runs_on_caller_thread_not_dispatch_thread() -> None:
             f"caller thread {result['thread']}"
         )
         assert threading.current_thread() not in decode_threads
+
+
+class _RecordingConn(WebsockMessageHandler):
+    """A connection with a real handler registry that records queued messages
+    instead of buffering them."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.sent: list[object] = []
+
+    def get_message_buffer(self):  # pragma: no cover - unused
+        raise NotImplementedError()
+
+    def queue_message(self, message) -> None:
+        self.sent.append(message)
+
+
+def _wait_for_request(
+    conn: _RecordingConn, timeout: float = 5.0
+) -> tuple[Callable, str]:
+    """Wait until get_render() registered its handler and queued its request;
+    return (response callback, request uuid)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        handlers = conn._incoming_handlers.get(_messages.GetRenderResponseMessage, [])
+        requests = [
+            m for m in conn.sent if isinstance(m, _messages.GetRenderRequestMessage)
+        ]
+        if handlers and requests:
+            return handlers[0], requests[0].render_uuid
+        time.sleep(0.002)
+    raise AssertionError("get_render never registered/queued its request")
+
+
+def test_get_render_raw_transport_round_trip() -> None:
+    """transport_format="raw" requests format "raw" on the wire and returns
+    the unencoded RGBA payload reshaped to (H, W, 4) -- no image decode --
+    as a writable array. A payload whose size doesn't match the requested
+    dimensions raises instead of returning garbage."""
+    height, width = 4, 6
+    with _server() as server:
+        conn = _RecordingConn()
+        client = ClientHandle.__new__(ClientHandle)
+        client.client_id = 810_004
+        client._websock_connection = conn  # type: ignore[assignment]
+        client._viser_server = server
+        server._connected_clients[client.client_id] = cast(viser.ClientHandle, client)
+        try:
+            result: dict[str, object] = {}
+
+            def call() -> None:
+                try:
+                    result["out"] = client.get_render(
+                        height=height,
+                        width=width,
+                        **_camera_kwargs(),
+                        transport_format="raw",
+                        timeout=5.0,
+                    )
+                except BaseException as e:  # noqa: BLE001
+                    result["err"] = e
+
+            thread = threading.Thread(target=call)
+            thread.start()
+            cb, uuid = _wait_for_request(conn)
+            request = next(
+                m for m in conn.sent if isinstance(m, _messages.GetRenderRequestMessage)
+            )
+            assert request.format == "raw"
+            pixels = np.arange(height * width * 4, dtype=np.uint8).reshape(
+                height, width, 4
+            )
+            cb(
+                client.client_id,
+                _messages.GetRenderResponseMessage(pixels.tobytes(), uuid),
+            )
+            thread.join(timeout=8.0)
+            assert not thread.is_alive()
+            assert "err" not in result, f"caller raised: {result.get('err')!r}"
+            out = cast(np.ndarray, result["out"])
+            assert out.shape == (height, width, 4)
+            assert out.dtype == np.uint8
+            assert np.array_equal(out, pixels)
+            assert out.flags.writeable
+
+            # Size-mismatched payload (e.g. a client bug) must raise, not
+            # reshape-crash or return garbage.
+            result.clear()
+            thread = threading.Thread(target=call)
+            conn.sent.clear()
+            thread.start()
+            cb, uuid = _wait_for_request(conn)
+            cb(
+                client.client_id,
+                _messages.GetRenderResponseMessage(b"\x00" * 17, uuid),
+            )
+            thread.join(timeout=8.0)
+            assert not thread.is_alive()
+            err = result.get("err")
+            assert isinstance(err, RuntimeError) and "expected" in str(err)
+        finally:
+            server._connected_clients.pop(client.client_id, None)
+
+
+def test_get_render_flushes_broadcast_buffer_first() -> None:
+    """Scene updates made before get_render() ride the BROADCAST buffer while
+    the render request rides the per-client buffer. get_render() must flush
+    the broadcast buffer (before its own request) so a still-windowed scene
+    update can't be overtaken by the request and captured stale."""
+    with _server() as server:
+        broadcast = server._websock_server._broadcast_buffer
+        conn = _RecordingConn()
+        client = ClientHandle.__new__(ClientHandle)
+        client.client_id = 810_005
+        client._websock_connection = conn  # type: ignore[assignment]
+        client._viser_server = server
+        server._connected_clients[client.client_id] = cast(viser.ClientHandle, client)
+        try:
+            # A scene update sits in the (windowed) broadcast buffer.
+            server.scene.add_frame("/pending")
+            assert not broadcast.flush_event.is_set()
+
+            def call() -> None:
+                try:
+                    client.get_render(
+                        height=8, width=8, **_camera_kwargs(), timeout=0.5
+                    )
+                except BaseException:  # noqa: BLE001
+                    pass
+
+            thread = threading.Thread(target=call)
+            thread.start()
+            _wait_for_request(conn)
+            # The flush signal must have been raised on the broadcast buffer
+            # no later than the request was queued.
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline and not broadcast.flush_event.is_set():
+                time.sleep(0.002)
+            assert broadcast.flush_event.is_set(), (
+                "get_render() must flush the broadcast buffer so pending "
+                "scene updates aren't overtaken by the render request"
+            )
+            thread.join(timeout=5.0)
+            assert not thread.is_alive()
+        finally:
+            server._connected_clients.pop(client.client_id, None)

--- a/tests/test_get_render_latency.py
+++ b/tests/test_get_render_latency.py
@@ -389,29 +389,101 @@ def _wait_for_request(
     raise AssertionError("get_render never registered/queued its request")
 
 
-def test_get_render_default_transport_is_deflate_rgb() -> None:
-    """The default transport is "deflate_rgb": lossless, no image codec on
-    either end, and adaptively deflate-compressed on the wire (typical 3D
-    scenes: 100x+), keeping bandwidth reasonable in the common case. The
-    worst case for incompressible content is uncompressed pixels; jpeg
-    stays available for slow links with such scenes."""
+def test_get_render_default_transport_is_auto() -> None:
+    """The default transport is "auto": lossless compressed pixels when the
+    frame compresses well (typical 3D scenes; much faster than JPEG on both
+    ends), JPEG otherwise. Measured on 720p frames, the fixed alternatives
+    each have a content class where they lose badly -- deflate grinds at
+    100-270ms on high-entropy frames (dense colored point clouds, splats,
+    photo textures) or ships them as multi-MB payloads, while JPEG wastes
+    30-45ms of codec work on frames that deflate 100x+ in ~13ms -- so only
+    the per-frame choice is never meaningfully slower than either."""
     import inspect
 
     from viser._viser import CameraHandle
 
     for fn in (ClientHandle.get_render, CameraHandle.get_render):
         default = inspect.signature(fn).parameters["transport_format"].default
-        assert default == "deflate_rgb", f"{fn.__qualname__} default is {default!r}"
+        assert default == "auto", f"{fn.__qualname__} default is {default!r}"
+
+
+def test_get_render_auto_transport_round_trip() -> None:
+    """The "auto" transport decodes both of its per-frame encodings to an
+    (H, W, 3) RGB array: flag 1 (deflate-compressed RGBA, alpha dropped,
+    lossless) and flag 2 (JPEG bytes). Unknown flags raise."""
+    import zlib
+
+    height, width = 4, 6
+    with _server() as server:
+        conn = _RecordingConn()
+        client = ClientHandle.__new__(ClientHandle)
+        client.client_id = 810_006
+        client._websock_connection = conn  # type: ignore[assignment]
+        client._viser_server = server
+        server._connected_clients[client.client_id] = cast(viser.ClientHandle, client)
+        try:
+            result: dict[str, object] = {}
+
+            def call() -> None:
+                try:
+                    # transport_format deliberately omitted: exercises the
+                    # "auto" default end to end.
+                    result["out"] = client.get_render(
+                        height=height,
+                        width=width,
+                        **_camera_kwargs(),
+                        timeout=5.0,
+                    )
+                except BaseException as e:  # noqa: BLE001
+                    result["err"] = e
+
+            def run_once(payload: bytes) -> object:
+                result.clear()
+                conn.sent.clear()
+                thread = threading.Thread(target=call)
+                thread.start()
+                cb, uuid = _wait_for_request(conn)
+                request = next(
+                    m
+                    for m in conn.sent
+                    if isinstance(m, _messages.GetRenderRequestMessage)
+                )
+                assert request.format == "auto"
+                cb(
+                    client.client_id,
+                    _messages.GetRenderResponseMessage(payload, uuid),
+                )
+                thread.join(timeout=8.0)
+                assert not thread.is_alive()
+                return result.get("out", result.get("err"))
+
+            pixels = np.arange(height * width * 4, dtype=np.uint8).reshape(
+                height, width, 4
+            )
+            compressor = zlib.compressobj(wbits=-15)
+            deflated = compressor.compress(pixels.tobytes()) + compressor.flush()
+            out = run_once(b"\x01" + deflated)
+            assert isinstance(out, np.ndarray), f"caller raised: {out!r}"
+            assert out.shape == (height, width, 3)
+            assert np.array_equal(out, pixels[:, :, :3])  # lossless
+
+            out = run_once(b"\x02" + _jpeg_payload(height, width))
+            assert isinstance(out, np.ndarray), f"caller raised: {out!r}"
+            assert out.shape == (height, width, 3)
+
+            err = run_once(b"\x07" + b"???")
+            assert isinstance(err, RuntimeError) and "unknown" in str(err)
+        finally:
+            server._connected_clients.pop(client.client_id, None)
 
 
 def test_get_render_deflate_transport_round_trip() -> None:
-    """The DEFAULT transport requests deflate_rgb on the wire and returns the
-    RGBA payload (1-byte flag + pixels, optionally deflate-compressed)
-    reshaped, alpha dropped, to a writable (H, W, 3) array -- no image
-    decode. deflate_rgba keeps all four channels. Size-mismatched or corrupt
-    payloads raise instead of returning garbage. (transport_format is
-    deliberately omitted in the first call: this also pins the default end
-    to end.)"""
+    """transport_format="deflate_rgb" requests deflate_rgb on the wire and
+    returns the RGBA payload (1-byte flag + pixels, optionally
+    deflate-compressed) reshaped, alpha dropped, to a writable (H, W, 3)
+    array -- no image decode. deflate_rgba keeps all four channels.
+    Size-mismatched or corrupt payloads raise instead of returning
+    garbage."""
     import zlib
 
     height, width = 4, 6
@@ -431,6 +503,7 @@ def test_get_render_deflate_transport_round_trip() -> None:
                         height=height,
                         width=width,
                         **_camera_kwargs(),
+                        transport_format="deflate_rgb",
                         timeout=5.0,
                     )
                 except BaseException as e:  # noqa: BLE001

--- a/tests/test_get_render_latency.py
+++ b/tests/test_get_render_latency.py
@@ -134,7 +134,11 @@ def test_concurrent_get_render_requests_both_survive_and_resolve() -> None:
         def call(height: int) -> None:
             try:
                 out = client.get_render(
-                    height=height, width=height, **_camera_kwargs(), timeout=6.0
+                    height=height,
+                    width=height,
+                    **_camera_kwargs(),
+                    transport_format="jpeg",
+                    timeout=6.0,
                 )
                 with results_lock:
                     results[height] = out
@@ -303,7 +307,11 @@ def test_render_decode_runs_on_caller_thread_not_dispatch_thread() -> None:
             result["thread"] = threading.current_thread()
             try:
                 result["out"] = client.get_render(
-                    height=8, width=8, **_camera_kwargs(), timeout=5.0
+                    height=8,
+                    width=8,
+                    **_camera_kwargs(),
+                    transport_format="jpeg",
+                    timeout=5.0,
                 )
             except BaseException as e:  # noqa: BLE001
                 result["err"] = e
@@ -382,10 +390,13 @@ def _wait_for_request(
 
 
 def test_get_render_raw_transport_round_trip() -> None:
-    """transport_format="raw" requests format "raw" on the wire and returns
-    the unencoded RGBA payload reshaped to (H, W, 4) -- no image decode --
-    as a writable array. A payload whose size doesn't match the requested
-    dimensions raises instead of returning garbage."""
+    """The DEFAULT transport requests format "raw_rgb" on the wire and
+    returns the unencoded RGBA payload reshaped, alpha dropped, to a
+    writable (H, W, 3) array -- no image decode. raw_rgba keeps all four
+    channels. A payload whose size doesn't match the requested dimensions
+    raises instead of returning garbage. (transport_format is deliberately
+    omitted in the first call: this test also pins raw_rgb as the
+    default.)"""
     height, width = 4, 6
     with _server() as server:
         conn = _RecordingConn()
@@ -403,7 +414,6 @@ def test_get_render_raw_transport_round_trip() -> None:
                         height=height,
                         width=width,
                         **_camera_kwargs(),
-                        transport_format="raw",
                         timeout=5.0,
                     )
                 except BaseException as e:  # noqa: BLE001
@@ -415,7 +425,7 @@ def test_get_render_raw_transport_round_trip() -> None:
             request = next(
                 m for m in conn.sent if isinstance(m, _messages.GetRenderRequestMessage)
             )
-            assert request.format == "raw"
+            assert request.format == "raw_rgb"
             pixels = np.arange(height * width * 4, dtype=np.uint8).reshape(
                 height, width, 4
             )
@@ -427,8 +437,43 @@ def test_get_render_raw_transport_round_trip() -> None:
             assert not thread.is_alive()
             assert "err" not in result, f"caller raised: {result.get('err')!r}"
             out = cast(np.ndarray, result["out"])
-            assert out.shape == (height, width, 4)
+            assert out.shape == (height, width, 3)
             assert out.dtype == np.uint8
+            assert np.array_equal(out, pixels[:, :, :3])
+            assert out.flags.writeable
+
+            # raw_rgba keeps the alpha channel.
+            result.clear()
+            conn.sent.clear()
+
+            def call_rgba() -> None:
+                try:
+                    result["out"] = client.get_render(
+                        height=height,
+                        width=width,
+                        **_camera_kwargs(),
+                        transport_format="raw_rgba",
+                        timeout=5.0,
+                    )
+                except BaseException as e:  # noqa: BLE001
+                    result["err"] = e
+
+            thread = threading.Thread(target=call_rgba)
+            thread.start()
+            cb, uuid = _wait_for_request(conn)
+            request = next(
+                m for m in conn.sent if isinstance(m, _messages.GetRenderRequestMessage)
+            )
+            assert request.format == "raw_rgba"
+            cb(
+                client.client_id,
+                _messages.GetRenderResponseMessage(pixels.tobytes(), uuid),
+            )
+            thread.join(timeout=8.0)
+            assert not thread.is_alive()
+            assert "err" not in result, f"caller raised: {result.get('err')!r}"
+            out = cast(np.ndarray, result["out"])
+            assert out.shape == (height, width, 4)
             assert np.array_equal(out, pixels)
             assert out.flags.writeable
 

--- a/tests/test_get_render_latency.py
+++ b/tests/test_get_render_latency.py
@@ -405,10 +405,12 @@ def test_get_render_default_transport_is_jpeg() -> None:
 
 def test_get_render_raw_transport_round_trip() -> None:
     """transport_format="raw_rgb" requests raw_rgb on the wire and returns
-    the unencoded RGBA payload reshaped, alpha dropped, to a writable
-    (H, W, 3) array -- no image decode. raw_rgba keeps all four channels.
-    A payload whose size doesn't match the requested dimensions raises
-    instead of returning garbage."""
+    the RGBA payload (1-byte flag + pixels, optionally deflate-compressed)
+    reshaped, alpha dropped, to a writable (H, W, 3) array -- no image
+    decode. raw_rgba keeps all four channels. Size-mismatched or corrupt
+    payloads raise instead of returning garbage."""
+    import zlib
+
     height, width = 4, 6
     with _server() as server:
         conn = _RecordingConn()
@@ -444,7 +446,7 @@ def test_get_render_raw_transport_round_trip() -> None:
             )
             cb(
                 client.client_id,
-                _messages.GetRenderResponseMessage(pixels.tobytes(), uuid),
+                _messages.GetRenderResponseMessage(b"\x00" + pixels.tobytes(), uuid),
             )
             thread.join(timeout=8.0)
             assert not thread.is_alive()
@@ -478,9 +480,13 @@ def test_get_render_raw_transport_round_trip() -> None:
                 m for m in conn.sent if isinstance(m, _messages.GetRenderRequestMessage)
             )
             assert request.format == "raw_rgba"
+            # Deliver deflate-compressed (flag 1), as the client does for
+            # compressible content.
+            compressor = zlib.compressobj(wbits=-15)
+            deflated = compressor.compress(pixels.tobytes()) + compressor.flush()
             cb(
                 client.client_id,
-                _messages.GetRenderResponseMessage(pixels.tobytes(), uuid),
+                _messages.GetRenderResponseMessage(b"\x01" + deflated, uuid),
             )
             thread.join(timeout=8.0)
             assert not thread.is_alive()
@@ -490,21 +496,27 @@ def test_get_render_raw_transport_round_trip() -> None:
             assert np.array_equal(out, pixels)
             assert out.flags.writeable
 
-            # Size-mismatched payload (e.g. a client bug) must raise, not
-            # reshape-crash or return garbage.
-            result.clear()
-            thread = threading.Thread(target=call)
-            conn.sent.clear()
-            thread.start()
-            cb, uuid = _wait_for_request(conn)
-            cb(
-                client.client_id,
-                _messages.GetRenderResponseMessage(b"\x00" * 17, uuid),
-            )
-            thread.join(timeout=8.0)
-            assert not thread.is_alive()
-            err = result.get("err")
-            assert isinstance(err, RuntimeError) and "expected" in str(err)
+            # Size-mismatched (flag 0) and corrupt-compressed (flag 1)
+            # payloads must raise, not reshape-crash or return garbage.
+            for bad_payload, match in [
+                (b"\x00" * 17, "expected"),
+                (b"\x01" + b"not deflate data", "corrupt"),
+            ]:
+                result.clear()
+                thread = threading.Thread(target=call)
+                conn.sent.clear()
+                thread.start()
+                cb, uuid = _wait_for_request(conn)
+                cb(
+                    client.client_id,
+                    _messages.GetRenderResponseMessage(bad_payload, uuid),
+                )
+                thread.join(timeout=8.0)
+                assert not thread.is_alive()
+                err = result.get("err")
+                assert isinstance(err, RuntimeError) and match in str(err), (
+                    f"payload {bad_payload[:8]!r}: got {err!r}"
+                )
         finally:
             server._connected_clients.pop(client.client_id, None)
 

--- a/tests/test_get_render_latency.py
+++ b/tests/test_get_render_latency.py
@@ -389,14 +389,26 @@ def _wait_for_request(
     raise AssertionError("get_render never registered/queued its request")
 
 
+def test_get_render_default_transport_is_jpeg() -> None:
+    """The default transport stays "jpeg": raw is 10-20x larger on the wire
+    (width * height * 4 bytes), so making it the default would silently
+    regress callers capturing over slow or remote links (e.g. share URLs).
+    Raw is opt-in for local connections."""
+    import inspect
+
+    from viser._viser import CameraHandle
+
+    for fn in (ClientHandle.get_render, CameraHandle.get_render):
+        default = inspect.signature(fn).parameters["transport_format"].default
+        assert default == "jpeg", f"{fn.__qualname__} default is {default!r}"
+
+
 def test_get_render_raw_transport_round_trip() -> None:
-    """The DEFAULT transport requests format "raw_rgb" on the wire and
-    returns the unencoded RGBA payload reshaped, alpha dropped, to a
-    writable (H, W, 3) array -- no image decode. raw_rgba keeps all four
-    channels. A payload whose size doesn't match the requested dimensions
-    raises instead of returning garbage. (transport_format is deliberately
-    omitted in the first call: this test also pins raw_rgb as the
-    default.)"""
+    """transport_format="raw_rgb" requests raw_rgb on the wire and returns
+    the unencoded RGBA payload reshaped, alpha dropped, to a writable
+    (H, W, 3) array -- no image decode. raw_rgba keeps all four channels.
+    A payload whose size doesn't match the requested dimensions raises
+    instead of returning garbage."""
     height, width = 4, 6
     with _server() as server:
         conn = _RecordingConn()
@@ -414,6 +426,7 @@ def test_get_render_raw_transport_round_trip() -> None:
                         height=height,
                         width=width,
                         **_camera_kwargs(),
+                        transport_format="raw_rgb",
                         timeout=5.0,
                     )
                 except BaseException as e:  # noqa: BLE001

--- a/tests/test_get_render_latency.py
+++ b/tests/test_get_render_latency.py
@@ -454,8 +454,10 @@ def test_get_render_jpeg_quality_reaches_the_wire() -> None:
 def test_get_render_flushes_broadcast_buffer_first() -> None:
     """Scene updates made before get_render() ride the BROADCAST buffer while
     the render request rides the per-client buffer. get_render() must flush
-    the broadcast buffer (before its own request) so a still-windowed scene
-    update can't be overtaken by the request and captured stale."""
+    the broadcast buffer BEFORE queueing its own request, so a still-windowed
+    scene update is (best-effort) on the wire ahead of the request instead of
+    being overtaken and captured stale. The ordering is pinned in-band: the
+    flush call is recorded into the same log as the queued request."""
     with _server() as server:
         broadcast = server._websock_server._broadcast_buffer
         conn = _RecordingConn()
@@ -464,6 +466,13 @@ def test_get_render_flushes_broadcast_buffer_first() -> None:
         client._websock_connection = conn  # type: ignore[assignment]
         client._viser_server = server
         server._connected_clients[client.client_id] = cast(viser.ClientHandle, client)
+        orig_flush = server.flush
+
+        def recording_flush() -> None:
+            conn.sent.append("broadcast-flush")
+            orig_flush()
+
+        server.flush = recording_flush  # type: ignore[method-assign]
         try:
             # A scene update sits in the (windowed) broadcast buffer.
             server.scene.add_frame("/pending")
@@ -480,16 +489,26 @@ def test_get_render_flushes_broadcast_buffer_first() -> None:
             thread = threading.Thread(target=call)
             thread.start()
             _wait_for_request(conn)
-            # The flush signal must have been raised on the broadcast buffer
-            # no later than the request was queued.
+            # ORDERING: the broadcast flush must be recorded before the
+            # request in the same in-band log. (A flush anywhere later in
+            # the call would not protect a still-windowed scene update.)
+            flush_index = conn.sent.index("broadcast-flush")
+            request_index = next(
+                i
+                for i, m in enumerate(conn.sent)
+                if isinstance(m, _messages.GetRenderRequestMessage)
+            )
+            assert flush_index < request_index, (
+                "get_render() must flush the broadcast buffer BEFORE queueing "
+                f"its request (flush at {flush_index}, request at {request_index})"
+            )
+            # And the signal actually reaches the broadcast buffer.
             deadline = time.monotonic() + 2.0
             while time.monotonic() < deadline and not broadcast.flush_event.is_set():
                 time.sleep(0.002)
-            assert broadcast.flush_event.is_set(), (
-                "get_render() must flush the broadcast buffer so pending "
-                "scene updates aren't overtaken by the render request"
-            )
+            assert broadcast.flush_event.is_set()
             thread.join(timeout=5.0)
             assert not thread.is_alive()
         finally:
+            server.flush = orig_flush  # type: ignore[method-assign]
             server._connected_clients.pop(client.client_id, None)

--- a/tests/test_get_render_latency.py
+++ b/tests/test_get_render_latency.py
@@ -524,9 +524,10 @@ def test_get_render_deflate_transport_round_trip() -> None:
 
 
 def test_get_render_jpeg_quality_reaches_the_wire() -> None:
-    """jpeg_quality must land in the request's quality field (the client
-    passes it to toBlob; omitting it there silently encoded at Chrome's
-    0.92 default -- larger, no faster), and out-of-range values raise."""
+    """The request's quality field carries the fixed JPEG quality (80); the
+    client passes it to toBlob, where omitting it silently encoded at
+    Chrome's 0.92 default -- measured strictly slower to encode AND decode,
+    and ~50% larger."""
     with _server() as server:
         conn = _RecordingConn()
         client = ClientHandle.__new__(ClientHandle)
@@ -535,8 +536,6 @@ def test_get_render_jpeg_quality_reaches_the_wire() -> None:
         client._viser_server = server
         server._connected_clients[client.client_id] = cast(viser.ClientHandle, client)
         try:
-            with pytest.raises(ValueError, match="jpeg_quality"):
-                client.get_render(height=8, width=8, **_camera_kwargs(), jpeg_quality=0)
 
             def call() -> None:
                 try:
@@ -545,7 +544,6 @@ def test_get_render_jpeg_quality_reaches_the_wire() -> None:
                         width=8,
                         **_camera_kwargs(),
                         transport_format="jpeg",
-                        jpeg_quality=55,
                         timeout=2.0,
                     )
                 except BaseException:  # noqa: BLE001
@@ -557,7 +555,7 @@ def test_get_render_jpeg_quality_reaches_the_wire() -> None:
             request = next(
                 m for m in conn.sent if isinstance(m, _messages.GetRenderRequestMessage)
             )
-            assert request.quality == 55
+            assert request.quality == 80
             cb(
                 client.client_id,
                 _messages.GetRenderResponseMessage(_jpeg_payload(8, 8), uuid),

--- a/tests/test_handle_lifecycle_bugs.py
+++ b/tests/test_handle_lifecycle_bugs.py
@@ -1092,6 +1092,8 @@ def test_get_render_timeout_exits_do_not_double_unregister() -> None:
             wxyz=(1.0, 0.0, 0.0, 0.0),
             position=(0.0, 0.0, 0.0),
             fov=1.0,
+            # Explicit: Case B below delivers a JPEG payload.
+            transport_format="jpeg",
             timeout=timeout,
         )
 


### PR DESCRIPTION
Speed up `get_render()` ~2.5x by flushing render requests past message-buffer windowing, capturing in the same frame that scene updates are applied, and moving image encode/decode off the event-loop and frame-loop hot paths, plus fixes for concurrent-capture races and new unit/e2e coverage.