### PR TITLE
Improve scene serialization efficiency

### DIFF
--- a/src/viser/client/src/FilePlayback.tsx
+++ b/src/viser/client/src/FilePlayback.tsx
@@ -1,14 +1,8 @@
-import * as msgpack from "@msgpack/msgpack";
-import { Message } from "./WebsocketMessages";
-import { ZSTDDecoder } from "zstddec";
 import {
-  replaceBinaryPlaceholders,
-  computeBinaryOffsets,
-} from "./BinaryMessageDecode";
-
-// Initialize zstd decoder at module load.
-const zstdDecoder = new ZSTDDecoder();
-const zstdReady = zstdDecoder.init();
+  SerializedMessages,
+  deserializeEmbeddedData,
+  deserializeZstdMsgpackFile,
+} from "./PlaybackDecode";
 
 import {
   Dispatch,
@@ -58,122 +52,6 @@ import {
   IconPlayerPauseFilled,
   IconPlayerPlayFilled,
 } from "@tabler/icons-react";
-
-/**
- * Decompress and decode a hybrid-format payload.
- *
- * Decompressed layout:
- *   [8 bytes] msgpack length (little-endian uint64)
- *   [N bytes] msgpack payload (with binary placeholders)
- *   [P bytes] padding + aligned binary buffers
- *
- * Binary placeholders are replaced with properly typed array views.
- */
-function decodeHybridPayload<T>(decompressed: Uint8Array): T {
-  const buf = decompressed.buffer as ArrayBuffer;
-  const base = decompressed.byteOffset;
-
-  // Read msgpack length from inner header.
-  const msgpackLength = Number(
-    new DataView(buf, base, 8).getBigUint64(0, true),
-  );
-
-  // Decode msgpack.
-  const msgpackData = new Uint8Array(buf, base + 8, msgpackLength);
-  const data = msgpack.decode(msgpackData) as T & {
-    binaryBufferLengths?: number[];
-  };
-
-  // Replace binary placeholders with typed array views.
-  const bufferLengths = data.binaryBufferLengths;
-  if (bufferLengths && bufferLengths.length > 0) {
-    const binaryOffsets = computeBinaryOffsets(
-      bufferLengths,
-      base + 8 + msgpackLength,
-    );
-    replaceBinaryPlaceholders(data, buf, binaryOffsets, bufferLengths);
-  }
-
-  return data;
-}
-
-/** Download, decompress, and deserialize a .viser recording file. */
-async function deserializeZstdMsgpackFile<T>(
-  fileUrl: string,
-  setStatus: (status: { downloaded: number; total: number }) => void,
-): Promise<T> {
-  const response = await fetch(fileUrl);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch the file: ${response.statusText}`);
-  }
-
-  const totalLength = parseInt(response.headers.get("Content-Length")!);
-  setStatus({ downloaded: 0, total: totalLength });
-
-  // Stream the download to track progress.
-  const reader = response.body!.getReader();
-  const chunks: Uint8Array[] = [];
-  let downloadedLength = 0;
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    chunks.push(value);
-    downloadedLength += value.length;
-    setStatus({ downloaded: downloadedLength, total: totalLength });
-  }
-
-  // Concatenate chunks into a single buffer.
-  const bytes = new Uint8Array(downloadedLength);
-  let offset = 0;
-  for (const chunk of chunks) {
-    bytes.set(chunk, offset);
-    offset += chunk.length;
-  }
-
-  // Read decompressed size from 8-byte little-endian header.
-  const view = new DataView(bytes.buffer);
-  const decompressedSize = Number(view.getBigUint64(0, true));
-  const compressedData = bytes.slice(8);
-
-  // Decompress and decode using shared hybrid format logic.
-  await zstdReady;
-  const decompressed = zstdDecoder.decode(compressedData, decompressedSize);
-  return decodeHybridPayload<T>(decompressed);
-}
-
-/** Deserialize embedded base64-encoded zstd-compressed data.
- * Used for static embedding in HTML pages (e.g., myst-nb documentation). */
-async function deserializeEmbeddedData<T>(
-  base64Data: string,
-  setStatus: (status: { downloaded: number; total: number }) => void,
-): Promise<T> {
-  // Decode base64 to Uint8Array.
-  const binaryString = atob(base64Data);
-  const bytes = new Uint8Array(binaryString.length);
-  for (let i = 0; i < binaryString.length; i++) {
-    bytes[i] = binaryString.charCodeAt(i);
-  }
-
-  // Data is already embedded, so mark download as complete.
-  setStatus({ downloaded: 1.0, total: 1.0 });
-
-  // Read decompressed size from 8-byte little-endian header.
-  const view = new DataView(bytes.buffer);
-  const decompressedSize = Number(view.getBigUint64(0, true));
-  const compressedData = bytes.slice(8);
-
-  // Decompress and decode using shared hybrid format logic.
-  await zstdReady;
-  const decompressed = zstdDecoder.decode(compressedData, decompressedSize);
-  return decodeHybridPayload<T>(decompressed);
-}
-
-export interface SerializedMessages {
-  durationSeconds: number;
-  messages: [number, Message][]; // (time in seconds, message).
-  viserVersion: string;
-}
 
 /** Shared playback UI and timing logic for recorded scenes.
  *

--- a/src/viser/client/src/PlaybackDecode.test.ts
+++ b/src/viser/client/src/PlaybackDecode.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  base64ToBytes,
+  decompressAndDecodeHybridPayload,
+  SerializedMessages,
+} from "./PlaybackDecode";
+import { MeshMessage } from "./WebsocketMessages";
+
+// A real `.viser` payload produced by the Python server, exercising the full
+// encode -> decode contract (zstd framing, msgpack header, aligned binary
+// buffers, placeholder replacement, and buffer deduplication). Regenerate
+// with:
+//
+//   import base64, numpy as np, viser
+//   server = viser.ViserServer(port=0, verbose=False)
+//   verts = np.array(
+//       [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=np.float32)
+//   faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.uint32)
+//   server.scene.add_mesh_simple("/fixture_a", verts.copy(), faces.copy())
+//   server.scene.add_mesh_simple("/fixture_b", verts.copy(), faces.copy())
+//   s = server.get_scene_serializer()
+//   s.insert_sleep(0.25)
+//   print(base64.b64encode(s.serialize()).decode())
+const FIXTURE_B64 = [
+  "mAQAAAAAAAAotS/9YJgDRQ8AZtlaPkBtmwPGh6dv5gVOC6ZVnmdenq0fF58wZ0TEPd8MLrdo2xI5",
+  "AxHZCLmJTCKnWYvDeds3o/35VANWFRZlrmplSgBKAEwAGrOndtphg4aFp3us4/qJp6PqNLmKMpzn",
+  "bKMLpd6jwl/Ur+05QxArpw4IfLC1E0PhdRkanqf9Z4t7JZ7u46SQoUm7rmPRA8YTUAmWgjgx6hME",
+  "uJUQVL04foRs3RhJk3PTvDbqWk4lB4ZWu+oLjpQBT4ZQZUjEhiupvy0dFmytJ9DwpVUMiqfjauFv",
+  "T6Qj0sHgtKJQEx/VraQmRKsN96IdG8neF4+RDonOg60Ck6zcKuSBjbi9jOPsSPOdLUURyIRn2NXZ",
+  "wl3YiB2rWcs6ub1BZQhEihETIzpJhghadsFwmDbvvQAAJI+EN4CS8QucpcQqHygGJpRJAY5J+50v",
+  "nL8tGkniUM8WGbY0Q3YQzoX+wkz0jXPrc9W2c12Lq5O63Dj2YzbT7LhUMyBggkFFVTcM/LoCPBZ2",
+  "j2FUavK5ph8Dh3nrHFGsFDEzfO3XyuPKzw1DxHcHUrtqyIb1fB5T4hKkaWtwihwO/YJOHWrVl1nI",
+  "iCgH2HAeEiQMyUBJF4t/yArn7TGVI1xJAZyEk8iDnQ+DqVVEoXEj7BzEFJ7nX2MCHwI=",
+].join("");
+
+const EXPECTED_VERTICES = [0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1];
+const EXPECTED_FACES = [0, 1, 2, 0, 2, 3];
+
+async function decodeFixture(): Promise<SerializedMessages> {
+  const bytes = base64ToBytes(FIXTURE_B64);
+  return await decompressAndDecodeHybridPayload<SerializedMessages>(bytes);
+}
+
+function meshesOf(recording: SerializedMessages): MeshMessage[] {
+  return recording.messages
+    .map(([, message]) => message)
+    .filter((message): message is MeshMessage => {
+      return message.type === "MeshMessage";
+    });
+}
+
+describe("PlaybackDecode", () => {
+  it("decodes a Python-serialized recording", async () => {
+    const recording = await decodeFixture();
+
+    expect(recording.durationSeconds).toBe(0.25);
+    expect(typeof recording.viserVersion).toBe("string");
+
+    const meshes = meshesOf(recording);
+    expect(meshes.map((m) => m.name).sort()).toEqual([
+      "/fixture_a",
+      "/fixture_b",
+    ]);
+
+    for (const mesh of meshes) {
+      expect(mesh.props.vertices).toBeInstanceOf(Float32Array);
+      expect(Array.from(mesh.props.vertices)).toEqual(EXPECTED_VERTICES);
+      expect(mesh.props.faces).toBeInstanceOf(Uint32Array);
+      expect(Array.from(mesh.props.faces)).toEqual(EXPECTED_FACES);
+    }
+  });
+
+  it("resolves deduplicated buffers to shared byte ranges", async () => {
+    const recording = await decodeFixture();
+    const meshes = meshesOf(recording);
+    expect(meshes.length).toBe(2);
+
+    // The server stores byte-identical arrays once; both messages' views must
+    // alias the same region of the shared ArrayBuffer (while remaining
+    // distinct view objects).
+    const [a, b] = meshes;
+    expect(a.props.vertices).not.toBe(b.props.vertices);
+    expect(a.props.vertices.buffer).toBe(b.props.vertices.buffer);
+    expect(a.props.vertices.byteOffset).toBe(b.props.vertices.byteOffset);
+    expect(a.props.faces.byteOffset).toBe(b.props.faces.byteOffset);
+    // Vertices and faces are different content, so they must NOT alias.
+    expect(a.props.vertices.byteOffset).not.toBe(a.props.faces.byteOffset);
+  });
+
+  it("decodes base64 identically with and without native fromBase64", () => {
+    const uint8ArrayStatics = Uint8Array as unknown as {
+      fromBase64?: (data: string) => Uint8Array;
+    };
+    const original = uint8ArrayStatics.fromBase64;
+    try {
+      // Exercise the native branch even on runtimes without fromBase64, by
+      // shimming it (Buffer is the Node-native reference decoder).
+      uint8ArrayStatics.fromBase64 ??= (data) =>
+        new Uint8Array(Buffer.from(data, "base64"));
+      const native = base64ToBytes(FIXTURE_B64);
+
+      // Exercise the real atob fallback branch by hiding the native method.
+      uint8ArrayStatics.fromBase64 = undefined;
+      const fallback = base64ToBytes(FIXTURE_B64);
+
+      expect(Array.from(fallback)).toEqual(Array.from(native));
+    } finally {
+      uint8ArrayStatics.fromBase64 = original;
+    }
+  });
+});

--- a/src/viser/client/src/PlaybackDecode.ts
+++ b/src/viser/client/src/PlaybackDecode.ts
@@ -1,0 +1,160 @@
+/**
+ * Decode logic for `.viser` recordings and embedded base64 scene payloads.
+ *
+ * Kept free of UI imports so it can be unit-tested directly; FilePlayback.tsx
+ * owns the playback interface built on top of these.
+ */
+import * as msgpack from "@msgpack/msgpack";
+import { ZSTDDecoder } from "zstddec";
+import {
+  replaceBinaryPlaceholders,
+  computeBinaryOffsets,
+} from "./BinaryMessageDecode";
+import { Message } from "./WebsocketMessages";
+
+// Initialize zstd decoder at module load.
+const zstdDecoder = new ZSTDDecoder();
+const zstdReady = zstdDecoder.init();
+
+export interface SerializedMessages {
+  durationSeconds: number;
+  messages: [number, Message][]; // (time in seconds, message).
+  viserVersion: string;
+}
+
+/**
+ * Decompress and decode a hybrid-format payload.
+ *
+ * Decompressed layout:
+ *   [8 bytes] msgpack length (little-endian uint64)
+ *   [N bytes] msgpack payload (with binary placeholders)
+ *   [P bytes] padding + aligned binary buffers
+ *
+ * Binary placeholders are replaced with properly typed array views.
+ */
+function decodeHybridPayload<T>(decompressed: Uint8Array): T {
+  const buf = decompressed.buffer as ArrayBuffer;
+  const base = decompressed.byteOffset;
+
+  // Read msgpack length from inner header.
+  const msgpackLength = Number(
+    new DataView(buf, base, 8).getBigUint64(0, true),
+  );
+
+  // Decode msgpack.
+  const msgpackData = new Uint8Array(buf, base + 8, msgpackLength);
+  const data = msgpack.decode(msgpackData) as T & {
+    binaryBufferLengths?: number[];
+  };
+
+  // Replace binary placeholders with typed array views.
+  const bufferLengths = data.binaryBufferLengths;
+  if (bufferLengths && bufferLengths.length > 0) {
+    const binaryOffsets = computeBinaryOffsets(
+      bufferLengths,
+      base + 8 + msgpackLength,
+    );
+    replaceBinaryPlaceholders(data, buf, binaryOffsets, bufferLengths);
+  }
+
+  return data;
+}
+
+/** Read the 8-byte decompressed-size header, decompress the remaining zstd
+ * payload, and decode it. Shared by the file-download and embedded-base64
+ * entry points. */
+export async function decompressAndDecodeHybridPayload<T>(
+  bytes: Uint8Array,
+): Promise<T> {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const decompressedSize = Number(view.getBigUint64(0, true));
+  // subarray (not slice): the decoder copies into WASM memory itself, so a
+  // view avoids duplicating the whole compressed payload first.
+  const compressedData = bytes.subarray(8);
+
+  await zstdReady;
+  const decompressed = zstdDecoder.decode(compressedData, decompressedSize);
+  return decodeHybridPayload<T>(decompressed);
+}
+
+/** Download, decompress, and deserialize a .viser recording file. */
+export async function deserializeZstdMsgpackFile<T>(
+  fileUrl: string,
+  setStatus: (status: { downloaded: number; total: number }) => void,
+): Promise<T> {
+  const response = await fetch(fileUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch the file: ${response.statusText}`);
+  }
+
+  const totalLength = parseInt(response.headers.get("Content-Length")!);
+  setStatus({ downloaded: 0, total: totalLength });
+
+  // Stream the download to track progress, writing chunks straight into a
+  // buffer preallocated from Content-Length (avoiding a second full-size copy
+  // to concatenate chunks). The header can be missing or wrong (e.g. behind a
+  // compressing proxy), so cap the trusted preallocation, grow on overflow,
+  // and trim at the end.
+  const maxPreallocation = 1 << 30; // 1 GiB: a lying header can't OOM us.
+  const reader = response.body!.getReader();
+  let bytes = new Uint8Array(
+    Number.isFinite(totalLength) && totalLength > 0
+      ? Math.min(totalLength, maxPreallocation)
+      : 0,
+  );
+  let downloadedLength = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (downloadedLength + value.length > bytes.length) {
+      const grown = new Uint8Array(
+        Math.max(bytes.length * 2, downloadedLength + value.length),
+      );
+      grown.set(bytes.subarray(0, downloadedLength));
+      bytes = grown;
+    }
+    bytes.set(value, downloadedLength);
+    downloadedLength += value.length;
+    setStatus({ downloaded: downloadedLength, total: totalLength });
+  }
+
+  // slice (copy) rather than subarray on a size mismatch: an overstated
+  // header would otherwise keep the oversized backing buffer alive for the
+  // whole decode. The common exact-match case stays zero-copy.
+  if (bytes.length !== downloadedLength) {
+    bytes = bytes.slice(0, downloadedLength);
+  }
+  return decompressAndDecodeHybridPayload<T>(bytes);
+}
+
+/** Decode base64 into bytes. Prefers the native `Uint8Array.fromBase64`
+ * (all evergreen browsers since ~2025); the `atob` + `charCodeAt` loop runs
+ * character-by-character in JS and is an order of magnitude slower on
+ * multi-megabyte embeds, so it's only a fallback for older browsers. */
+export function base64ToBytes(base64Data: string): Uint8Array {
+  const fromBase64 = (
+    Uint8Array as unknown as { fromBase64?: (data: string) => Uint8Array }
+  ).fromBase64;
+  if (fromBase64 !== undefined) return fromBase64(base64Data);
+  const binaryString = atob(base64Data);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/** Deserialize embedded base64-encoded zstd-compressed data.
+ * Used for static embedding in HTML pages (e.g., myst-nb documentation). */
+export async function deserializeEmbeddedData<T>(
+  base64Data: string,
+  setStatus: (status: { downloaded: number; total: number }) => void,
+): Promise<T> {
+  const bytes = base64ToBytes(base64Data);
+
+  // Data is already embedded, so mark download as complete.
+  setStatus({ downloaded: 1.0, total: 1.0 });
+
+  return decompressAndDecodeHybridPayload<T>(bytes);
+}

--- a/src/viser/infra/_infra.py
+++ b/src/viser/infra/_infra.py
@@ -7,6 +7,7 @@ import base64
 import contextlib
 import dataclasses
 import gzip
+import hashlib
 import http
 import logging
 import mimetypes
@@ -15,6 +16,7 @@ import threading
 import time
 import webbrowser
 from asyncio.events import AbstractEventLoop
+from collections import Counter
 from collections.abc import Coroutine
 from pathlib import Path
 from typing import Any, Callable, Generator, NewType, TypeVar
@@ -34,7 +36,7 @@ from websockets.typing import Subprotocol
 import viser  # Import for version checking.
 
 from ._async_message_buffer import AsyncMessageBuffer
-from ._messages import Message
+from ._messages import Message, is_binary_placeholder
 
 
 @dataclasses.dataclass
@@ -93,7 +95,43 @@ class StateSerializer:
         Returns:
             The recording as bytes.
         """
-        assert self in self._handler._record_handles, "serialize() was already called!"
+        # Unregister FIRST (under the record lock) so a message queued
+        # concurrently from another thread can't land in self._messages /
+        # self._binary_buffers while we're encoding below -- a late-arriving
+        # buffer would be missing from binaryBufferLengths and dangle.
+        with self._handler._record_lock:
+            assert self in self._handler._record_handles, (
+                "serialize() was already called!"
+            )
+            self._handler._record_handles.remove(self)
+
+        # Deduplicate identical binary buffers. Recordings often repeat large
+        # arrays byte-for-byte: a node removed and re-added mid-recording, the
+        # scene snapshot plus later re-sends, unchanged geometry alongside
+        # per-frame pose updates. zstd only catches repeats that land within
+        # its match window, so deduplicating here shrinks both the file and
+        # the decompressed payload the client must hold in memory. The client
+        # resolves placeholders through a buffer index, so two placeholders
+        # sharing an index need no client-side change (each still gets its own
+        # typed-array view). Equal bytes require equal sizes, so buffers whose
+        # size is unique in the recording skip hashing entirely.
+        size_counts = Counter(buf.nbytes for buf in self._binary_buffers)
+        unique_buffers: list[memoryview] = []
+        index_remap: list[int] = []
+        index_from_digest: dict[bytes, int] = {}
+        for buf in self._binary_buffers:
+            if size_counts[buf.nbytes] == 1:
+                index_remap.append(len(unique_buffers))
+                unique_buffers.append(buf)
+                continue
+            digest = hashlib.sha256(buf).digest()
+            if digest not in index_from_digest:
+                index_from_digest[digest] = len(unique_buffers)
+                unique_buffers.append(buf)
+            index_remap.append(index_from_digest[digest])
+        if len(unique_buffers) != len(self._binary_buffers):
+            for _, message_dict in self._messages:
+                _remap_binary_placeholder_indices(message_dict, index_remap)
 
         # Same hybrid format as the live wire path: msgpack metadata with
         # tagged placeholders for binary arrays, followed by raw aligned
@@ -103,25 +141,35 @@ class StateSerializer:
                 "durationSeconds": self._time,
                 "messages": self._messages,
                 "viserVersion": viser.__version__,
-                "binaryBufferLengths": tuple(b.nbytes for b in self._binary_buffers),
+                "binaryBufferLengths": tuple(b.nbytes for b in unique_buffers),
             }
         )
         assert isinstance(msgpack_payload, bytes)
-        with self._handler._record_lock:
-            self._handler._record_handles.remove(self)
 
-        # Build uncompressed inner payload:
+        # Uncompressed inner payload layout:
         #   [8 bytes] msgpack length (little-endian uint64)
         #   [N bytes] msgpack payload
         #   [P bytes] padding + aligned binary buffers...
         msgpack_len_header = len(msgpack_payload).to_bytes(8, "little")
         parts: list[bytes | memoryview] = [msgpack_len_header, msgpack_payload]
-        _append_aligned_buffers(parts, self._binary_buffers, 8 + len(msgpack_payload))
-        inner = b"".join(parts)
+        _append_aligned_buffers(parts, unique_buffers, 8 + len(msgpack_payload))
+        inner_size = sum(memoryview(p).nbytes for p in parts)
 
-        # Compress everything together. Recordings aren't latency-sensitive.
-        compressed = zstandard.ZstdCompressor(level=12).compress(inner)
-        return len(inner).to_bytes(8, "little") + compressed
+        # Compress everything together, streaming the parts through the
+        # compressor rather than concatenating them first -- the concatenated
+        # copy would briefly double peak memory for large scenes. Recordings
+        # aren't latency-sensitive, but threads=-1 (one per core) still helps:
+        # level-12 zstd is slow enough to be the bottleneck for big scenes.
+        compressor = zstandard.ZstdCompressor(level=12, threads=-1).compressobj(
+            size=inner_size
+        )
+        return b"".join(
+            [
+                inner_size.to_bytes(8, "little"),
+                *(compressor.compress(part) for part in parts),
+                compressor.flush(),
+            ]
+        )
 
     def as_html(self, dark_mode: bool = False) -> str:
         """Get a standalone HTML string for the serialized scene.
@@ -835,6 +883,22 @@ class WebsockServer(WebsockMessageHandler):
         # Clean up the event loop to prevent reference leaks.
         event_loop.stop()
         event_loop.close()
+
+
+def _remap_binary_placeholder_indices(obj: Any, index_remap: list[int]) -> None:
+    """Rewrite the ``__binary_index`` of every binary placeholder (see
+    ``Message.as_serializable_dict``) through ``index_remap``. Placeholder
+    dicts are mutated in place; containers are only traversed, never
+    replaced."""
+    if isinstance(obj, dict):
+        if is_binary_placeholder(obj):
+            obj["__binary_index"] = index_remap[obj["__binary_index"]]
+        else:
+            for value in obj.values():
+                _remap_binary_placeholder_indices(value, index_remap)
+    elif isinstance(obj, (list, tuple)):
+        for value in obj:
+            _remap_binary_placeholder_indices(value, index_remap)
 
 
 # Pre-allocated padding bytes for 8-byte alignment.

--- a/src/viser/infra/_infra.py
+++ b/src/viser/infra/_infra.py
@@ -163,13 +163,13 @@ class StateSerializer:
         compressor = zstandard.ZstdCompressor(level=12, threads=-1).compressobj(
             size=inner_size
         )
-        return b"".join(
-            [
-                inner_size.to_bytes(8, "little"),
-                *(compressor.compress(part) for part in parts),
-                compressor.flush(),
-            ]
-        )
+        # Explicit statements (not a starred list display): flush() must not
+        # be evaluated until every part has been fed through compress(), and
+        # Python 3.8 evaluated `[a, *gen, f()]`'s f() before consuming gen.
+        out = [inner_size.to_bytes(8, "little")]
+        out.extend(compressor.compress(part) for part in parts)
+        out.append(compressor.flush())
+        return b"".join(out)
 
     def as_html(self, dark_mode: bool = False) -> str:
         """Get a standalone HTML string for the serialized scene.

--- a/src/viser/infra/_messages.py
+++ b/src/viser/infra/_messages.py
@@ -162,6 +162,13 @@ def _prepare_for_serialization(
     return value
 
 
+def is_binary_placeholder(value: Any) -> bool:
+    """Detect the tagged placeholder dicts created above for extracted binary
+    buffers. Must stay in sync with the client's detection in
+    ``BinaryMessageDecode.ts``, which tests for the same two keys."""
+    return isinstance(value, dict) and "__binary_index" in value and "dtype" in value
+
+
 T = TypeVar("T", bound="Message")
 
 

--- a/tests/test_get_render_latency.py
+++ b/tests/test_get_render_latency.py
@@ -22,8 +22,7 @@ import asyncio
 import io
 import threading
 import time
-from contextlib import contextmanager
-from typing import Callable, Generator, cast
+from typing import Callable, cast
 
 import numpy as np
 import pytest
@@ -38,14 +37,7 @@ from viser.infra._infra import (
     _ClientHandleState,
 )
 
-
-@contextmanager
-def _server() -> Generator[viser.ViserServer, None, None]:
-    server = viser.ViserServer(port=0, verbose=False)
-    try:
-        yield server
-    finally:
-        server.stop()
+from .utils import viser_server as _server
 
 
 def _camera_kwargs() -> dict:

--- a/tests/test_handle_lifecycle_bugs.py
+++ b/tests/test_handle_lifecycle_bugs.py
@@ -16,8 +16,7 @@ import asyncio
 import threading
 import time
 import warnings
-from contextlib import contextmanager
-from typing import Generator, cast
+from typing import cast
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -28,15 +27,7 @@ from viser import _messages
 from viser.infra import ClientId
 
 from .thread_isolation import run_isolated
-
-
-@contextmanager
-def _server() -> Generator[viser.ViserServer, None, None]:
-    server = viser.ViserServer(port=0, verbose=False)
-    try:
-        yield server
-    finally:
-        server.stop()
+from .utils import viser_server as _server
 
 
 def _setup_gizmo_recorder(server: viser.ViserServer):

--- a/tests/test_scene_serializer.py
+++ b/tests/test_scene_serializer.py
@@ -1,0 +1,281 @@
+"""Tests for StateSerializer: the .viser file format round-trip, binary
+buffer deduplication, and as_html() embedding."""
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import threading
+from typing import Any
+
+import msgspec.msgpack
+import numpy as np
+import pytest
+import zstandard
+
+import viser
+from viser.infra import Message, StateSerializer
+
+from .utils import viser_server as _server
+
+
+class _FakeHandler:
+    """Minimal stand-in for WebsockMessageHandler: just the serializer
+    registry that StateSerializer.serialize() interacts with."""
+
+    def __init__(self) -> None:
+        self._record_handles: list[StateSerializer] = []
+        self._record_lock = threading.RLock()
+
+
+# Leading underscore: excluded from Message.get_subclasses(), so this test
+# type never leaks into the real message registry.
+@dataclasses.dataclass
+class _ArrayTestMessage(Message):
+    name: str
+    array: np.ndarray
+
+    def redundancy_key(self) -> str:
+        return f"_ArrayTestMessage-{self.name}"
+
+
+def _make_serializer() -> StateSerializer:
+    handler = _FakeHandler()
+    serializer = StateSerializer(handler, filter=lambda message: True)  # type: ignore[arg-type]
+    handler._record_handles.append(serializer)
+    return serializer
+
+
+def _decode_viser_bytes(data: bytes) -> tuple[dict[str, Any], list[bytes]]:
+    """Decode serialized .viser bytes the same way the client does
+    (FilePlayback.tsx + BinaryMessageDecode.ts): zstd decompress, read the
+    msgpack length header, decode metadata, then slice out the 8-byte-aligned
+    binary buffers."""
+    inner_size = int.from_bytes(data[:8], "little")
+    inner = zstandard.ZstdDecompressor().decompress(
+        data[8:], max_output_size=inner_size
+    )
+    assert len(inner) == inner_size
+
+    msgpack_length = int.from_bytes(inner[:8], "little")
+    meta = msgspec.msgpack.decode(inner[8 : 8 + msgpack_length])
+
+    buffers: list[bytes] = []
+    offset = 8 + msgpack_length
+    for length in meta["binaryBufferLengths"]:
+        offset += (8 - offset % 8) % 8  # Alignment padding.
+        assert offset % 8 == 0
+        buffers.append(inner[offset : offset + length])
+        offset += length
+    assert offset == inner_size, "binary buffers must exactly fill the payload"
+    return meta, buffers
+
+
+def _collect_placeholders(obj: Any) -> list[dict[str, Any]]:
+    """Collect binary placeholder dicts (``{"__binary_index": i, "dtype": s}``)
+    from a decoded message tree."""
+    out: list[dict[str, Any]] = []
+    if isinstance(obj, dict):
+        if "__binary_index" in obj and "dtype" in obj:
+            out.append(obj)
+        else:
+            for value in obj.values():
+                out.extend(_collect_placeholders(value))
+    elif isinstance(obj, (list, tuple)):
+        for value in obj:
+            out.extend(_collect_placeholders(value))
+    return out
+
+
+def test_serialize_round_trip() -> None:
+    """Serialized scenes must decode to the original binary contents, with
+    every placeholder index valid and durationSeconds preserved."""
+    vertices = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32
+    )
+    faces = np.array([[0, 1, 2]], dtype=np.uint32)
+    with _server() as server:
+        server.scene.add_mesh_simple("/mesh", vertices, faces)
+        serializer = server.get_scene_serializer()
+        serializer.insert_sleep(0.5)
+        data = serializer.serialize()
+
+    meta, buffers = _decode_viser_bytes(data)
+    assert meta["durationSeconds"] == 0.5
+    assert meta["viserVersion"] == viser.__version__
+
+    placeholders = [
+        p for _time, message in meta["messages"] for p in _collect_placeholders(message)
+    ]
+    assert len(placeholders) > 0
+    for placeholder in placeholders:
+        assert 0 <= placeholder["__binary_index"] < len(buffers)
+
+    # The mesh's vertex and face bytes must appear among the stored buffers.
+    stored = set(buffers)
+    assert vertices.tobytes() in stored
+    assert faces.tobytes() in stored
+
+
+def test_serialize_dedupes_identical_buffers() -> None:
+    """Byte-identical arrays serialized in different messages must be stored
+    once, with all placeholders remapped onto the shared buffer."""
+    vertices = np.random.default_rng(0).random((16, 3)).astype(np.float32)
+    faces = np.array([[0, 1, 2], [3, 4, 5]], dtype=np.uint32)
+    with _server() as server:
+        # Two nodes with byte-identical geometry (separate array copies, so
+        # dedup must key on content rather than object identity).
+        server.scene.add_mesh_simple("/a", vertices.copy(), faces.copy())
+        server.scene.add_mesh_simple("/b", vertices.copy(), faces.copy())
+        data = server.get_scene_serializer().serialize()
+
+    meta, buffers = _decode_viser_bytes(data)
+
+    # Dedup invariant: stored buffers are pairwise distinct.
+    assert len(set(buffers)) == len(buffers)
+
+    # Both meshes' placeholders resolve to the same stored vertex bytes.
+    vertex_indices = {
+        placeholder["__binary_index"]
+        for _time, message in meta["messages"]
+        for placeholder in _collect_placeholders(message)
+        if buffers[placeholder["__binary_index"]] == vertices.tobytes()
+    }
+    assert len(vertex_indices) == 1, "identical vertices must share one buffer"
+    assert faces.tobytes() in buffers
+
+
+def test_as_html_embeds_decodable_payload() -> None:
+    """The base64 payload injected by as_html() must decode as a .viser
+    recording containing the scene's messages."""
+    with _server() as server:
+        server.scene.add_box("/box", dimensions=(1.0, 1.0, 1.0))
+        html = server.scene.as_html()
+
+    marker = 'window.__VISER_EMBED_DATA__="'
+    start = html.index(marker) + len(marker)
+    end = html.index('"', start)
+    data = base64.b64decode(html[start:end])
+
+    meta, _buffers = _decode_viser_bytes(data)
+    message_types = {message["type"] for _time, message in meta["messages"]}
+    assert "BoxMessage" in message_types
+
+
+def test_dedup_keys_on_bytes_not_dtype() -> None:
+    """Arrays with identical bytes but different dtypes share one stored
+    buffer; each placeholder keeps its own dtype for the client-side view."""
+    serializer = _make_serializer()
+    serializer._insert_message(_ArrayTestMessage("f32", np.zeros(3, dtype=np.float32)))
+    serializer._insert_message(_ArrayTestMessage("u32", np.zeros(3, dtype=np.uint32)))
+    meta, buffers = _decode_viser_bytes(serializer.serialize())
+
+    assert len(buffers) == 1
+    assert buffers[0] == bytes(12)
+    (placeholder_a,) = _collect_placeholders(meta["messages"][0][1])
+    (placeholder_b,) = _collect_placeholders(meta["messages"][1][1])
+    assert placeholder_a["__binary_index"] == placeholder_b["__binary_index"] == 0
+    assert placeholder_a["dtype"] == "<f4"
+    assert placeholder_b["dtype"] == "<u4"
+
+
+def test_empty_and_noncontiguous_arrays() -> None:
+    """Zero-length arrays (all byte-identical) dedup to one empty buffer, and
+    non-contiguous arrays round-trip via their contiguous copy."""
+    serializer = _make_serializer()
+    serializer._insert_message(
+        _ArrayTestMessage("empty_f32", np.empty(0, dtype=np.float32))
+    )
+    serializer._insert_message(
+        _ArrayTestMessage("empty_u8", np.empty(0, dtype=np.uint8))
+    )
+    strided = np.arange(12, dtype=np.float32)[::2]
+    assert not strided.flags.c_contiguous
+    serializer._insert_message(_ArrayTestMessage("strided", strided))
+    meta, buffers = _decode_viser_bytes(serializer.serialize())
+
+    assert sorted(len(b) for b in buffers) == [0, 24]
+    assert np.ascontiguousarray(strided).tobytes() in buffers
+    for _time, message in meta["messages"]:
+        for placeholder in _collect_placeholders(message):
+            assert 0 <= placeholder["__binary_index"] < len(buffers)
+
+
+def test_concurrent_serializers_are_independent() -> None:
+    """Serializing one handle must not corrupt another's recorded state:
+    placeholder remapping mutates message dicts, which must never be shared
+    between serializers."""
+    vertices = np.random.default_rng(1).random((8, 3)).astype(np.float32)
+    faces = np.array([[0, 1, 2]], dtype=np.uint32)
+    with _server() as server:
+        server.scene.add_mesh_simple("/x", vertices.copy(), faces.copy())
+        server.scene.add_mesh_simple("/y", vertices.copy(), faces.copy())
+        serializer_a = server.get_scene_serializer()
+        serializer_b = server.get_scene_serializer()
+        data_a = serializer_a.serialize()
+        data_b = serializer_b.serialize()
+
+    for data in (data_a, data_b):
+        _meta, buffers = _decode_viser_bytes(data)
+        assert vertices.tobytes() in buffers
+        assert faces.tobytes() in buffers
+
+
+def test_serialize_is_deterministic() -> None:
+    """Identical recorded state must produce identical bytes (multithreaded
+    zstd included), so recordings are cacheable/diffable."""
+    array = np.random.default_rng(2).random((50_000, 3)).astype(np.float32)
+
+    def _serialize_once() -> bytes:
+        serializer = _make_serializer()
+        serializer._insert_message(_ArrayTestMessage("a", array))
+        serializer._insert_message(_ArrayTestMessage("b", array.copy()))
+        serializer.insert_sleep(1.0)
+        return serializer.serialize()
+
+    assert _serialize_once() == _serialize_once()
+
+
+def test_message_queued_during_serialize_is_excluded_cleanly() -> None:
+    """serialize() unregisters before encoding: a message queued from another
+    thread mid-serialize must be fully absent (not recorded with a dangling
+    buffer index) and the output must still decode."""
+    with _server() as server:
+        server.scene.add_frame("/pre")
+        serializer = server.get_scene_serializer()
+
+        import viser.infra._infra as infra_module
+
+        encode_entered = threading.Event()
+        writer_done = threading.Event()
+        original_encode = infra_module.msgspec.msgpack.encode
+
+        def blocking_encode(obj: Any) -> bytes:
+            # Only the serializer's metadata dict passes through here during
+            # this test window; hold it open while the writer queues.
+            encode_entered.set()
+            assert writer_done.wait(timeout=5.0)
+            return original_encode(obj)
+
+        def writer() -> None:
+            assert encode_entered.wait(timeout=5.0)
+            server.scene.add_icosphere(
+                "/racy", radius=1.0, subdivisions=1, color=(255, 0, 0)
+            )
+            writer_done.set()
+
+        thread = threading.Thread(target=writer)
+        thread.start()
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(infra_module.msgspec.msgpack, "encode", blocking_encode)
+            data = serializer.serialize()
+        thread.join(timeout=5.0)
+        assert not thread.is_alive()
+
+    meta, buffers = _decode_viser_bytes(data)  # Integrity-checked in helper.
+    names = {message.get("name") for _time, message in meta["messages"]}
+    assert "/pre" in names
+    assert "/racy" not in names
+    for _time, message in meta["messages"]:
+        for placeholder in _collect_placeholders(message):
+            assert 0 <= placeholder["__binary_index"] < len(buffers)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import functools
 import random
-from typing import Any, Callable, TypeVar, cast
+from contextlib import contextmanager
+from typing import Any, Callable, Generator, TypeVar, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -10,6 +11,7 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+import viser
 import viser.transforms as vtf
 
 T = TypeVar("T", bound=vtf.MatrixLieGroup)
@@ -138,3 +140,13 @@ def assert_arrays_close(*arrays: npt.NDArray[np.floating] | float):
         np.testing.assert_allclose(array1, array2, rtol=rtol, atol=atol)
         assert not np.any(np.isnan(array1))
         assert not np.any(np.isnan(array2))
+
+
+@contextmanager
+def viser_server() -> Generator[viser.ViserServer, None, None]:
+    """Start a ViserServer on an ephemeral port and stop it on exit."""
+    server = viser.ViserServer(port=0, verbose=False)
+    try:
+        yield server
+    finally:
+        server.stop()


### PR DESCRIPTION
- `StateSerializer.serialize()` now deduplicates byte-identical binary buffers, shrinking recordings that re-send unchanged arrays (a 20-frame recording re-adding a 4MB mesh drops from 194MB to 9.7MB) while leaving duplicate-free scenes byte-identical.
- Serialization streams message parts through a multithreaded zstd compressor instead of concatenating a full uncompressed copy first, removing a payload-sized memory spike.
- The serializer unregisters before encoding so a concurrently queued message can no longer land a dangling buffer reference in the output.
- Recording/embed decode logic moves from `FilePlayback.tsx` into a UI-free `PlaybackDecode.ts`, with embedded base64 decoded via native `Uint8Array.fromBase64` when available and one less full copy of both downloaded and compressed payloads.
- New tests cover the `.viser` format round-trip with an independent Python decoder (dedup invariants, dtype collisions, empty/non-contiguous arrays, concurrency, determinism) plus a vitest suite decoding a real Python-generated fixture end-to-end.