### PR TITLE
Pre-release fixes: playback version warning, O(1) same-name re-add, line_width compat

### DIFF
--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -192,18 +192,25 @@ def _compute_precision_digits(x: float) -> int:
     return digits
 
 
-def _compute_slider_precision_digits(min: float, max: float, step: float) -> int:
-    """Display digits for a slider's value grid. A slider's legal values are
-    ``min + k * step`` clamped to ``max``, so their decimal digits are bounded
-    by the most precise of the three -- ``step`` alone is NOT enough: with
-    ``min=0.5, step=1.0`` every legal value ends in .5, and a step-derived
-    precision of 0 made the companion number box display 2.5 as "3" and
-    reject typed decimals."""
-    return builtins.max(
-        _compute_precision_digits(min),
-        _compute_precision_digits(max),
-        _compute_precision_digits(step),
-    )
+def _compute_precision_digits_covering(
+    *values: float | tuple[float, ...] | np.ndarray | None,
+) -> int:
+    """Display digits covering every provided value (Nones skipped, tuples /
+    arrays elementwise). Numeric widgets limit displayed AND typed decimals
+    to their ``precision`` via ``decimalScale``, so precision derived from
+    ``step`` alone rounded away legitimate values: a slider's legal values
+    are ``min + k * step`` clamped to ``max`` (with ``min=0.5, step=1.0``
+    the box displayed 2.5 as "3" and rejected typed decimals), and a number
+    input's creation-time value/bounds may be finer than an explicit step
+    (``initial_value=0.25, step=0.5`` displayed as "0.2")."""
+    digits = 0
+    for value in values:
+        if value is None:
+            continue
+        for x in np.atleast_1d(np.asarray(value, dtype=np.float64)):
+            if np.isfinite(x):
+                digits = builtins.max(digits, _compute_precision_digits(float(x)))
+    return digits
 
 
 @dataclasses.dataclass
@@ -2166,7 +2173,9 @@ class GuiApi:
                         hint=hint,
                         min=min,
                         max=max,
-                        precision=_compute_precision_digits(step),
+                        precision=_compute_precision_digits_covering(
+                            value, min, max, step
+                        ),
                         step=step,
                         disabled=disabled,
                         visible=visible,
@@ -2244,7 +2253,9 @@ class GuiApi:
                         min=min,
                         max=max,
                         step=step,
-                        precision=_compute_precision_digits(step),
+                        precision=_compute_precision_digits_covering(
+                            initial_value, min, max, step
+                        ),
                         disabled=disabled,
                         visible=visible,
                     ),
@@ -2320,7 +2331,9 @@ class GuiApi:
                         min=min,
                         max=max,
                         step=step,
-                        precision=_compute_precision_digits(step),
+                        precision=_compute_precision_digits_covering(
+                            initial_value, min, max, step
+                        ),
                         disabled=disabled,
                         visible=visible,
                     ),
@@ -2541,7 +2554,9 @@ class GuiApi:
                         min=min,
                         max=max,
                         step=step,
-                        precision=_compute_slider_precision_digits(min, max, step),
+                        precision=_compute_precision_digits_covering(
+                            value, min, max, step
+                        ),
                         visible=visible,
                         disabled=disabled,
                         _marks=_build_slider_marks(marks),
@@ -2646,7 +2661,9 @@ class GuiApi:
                         visible=visible,
                         disabled=disabled,
                         fixed_endpoints=fixed_endpoints,
-                        precision=_compute_slider_precision_digits(min, max, step),
+                        precision=_compute_precision_digits_covering(
+                            initial_value, min, max, step
+                        ),
                         _marks=_build_slider_marks(marks),
                     ),
                 ),

--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -192,6 +192,20 @@ def _compute_precision_digits(x: float) -> int:
     return digits
 
 
+def _compute_slider_precision_digits(min: float, max: float, step: float) -> int:
+    """Display digits for a slider's value grid. A slider's legal values are
+    ``min + k * step`` clamped to ``max``, so their decimal digits are bounded
+    by the most precise of the three -- ``step`` alone is NOT enough: with
+    ``min=0.5, step=1.0`` every legal value ends in .5, and a step-derived
+    precision of 0 made the companion number box display 2.5 as "3" and
+    reject typed decimals."""
+    return builtins.max(
+        _compute_precision_digits(min),
+        _compute_precision_digits(max),
+        _compute_precision_digits(step),
+    )
+
+
 @dataclasses.dataclass
 class _RootGuiContainer:
     _children: dict[str, SupportsRemoveProtocol]
@@ -2527,7 +2541,7 @@ class GuiApi:
                         min=min,
                         max=max,
                         step=step,
-                        precision=_compute_precision_digits(step),
+                        precision=_compute_slider_precision_digits(min, max, step),
                         visible=visible,
                         disabled=disabled,
                         _marks=_build_slider_marks(marks),
@@ -2632,7 +2646,7 @@ class GuiApi:
                         visible=visible,
                         disabled=disabled,
                         fixed_endpoints=fixed_endpoints,
-                        precision=_compute_precision_digits(step),
+                        precision=_compute_slider_precision_digits(min, max, step),
                         _marks=_build_slider_marks(marks),
                     ),
                 ),

--- a/src/viser/_gui_handles.py
+++ b/src/viser/_gui_handles.py
@@ -890,11 +890,13 @@ class GuiTabHandle:
 
     def __enter__(self) -> GuiTabHandle:
         if self._container_id_restore is not None:
-            # See GuiFolderHandle.__enter__: a single restore slot can't nest
-            # the same tab inside itself.
+            # See GuiFolderHandle.__enter__: a single restore slot can't
+            # support overlapping `with` blocks on the same handle.
             raise RuntimeError(
-                "This GuiTabHandle is already active as a context; it cannot "
-                "be re-entered inside itself."
+                "This GuiTabHandle is already active as a context -- either "
+                "nested inside its own `with` block, or entered concurrently "
+                "from another thread. A handle supports only one active "
+                "`with` block at a time (sequential re-entry is fine)."
             )
         self._container_id_restore = (
             self._parent._impl.gui_api._snapshot_container_context()
@@ -1396,13 +1398,17 @@ class GuiFolderHandle(_GuiHandle[None], GuiFolderProps):
 
     def __enter__(self) -> Self:
         if self._container_id_restore is not None:
-            # A single restore slot can't nest the SAME handle inside itself;
-            # doing so would strand the container pointer inside this folder,
-            # silently misplacing every later element. (Sequential re-entry --
-            # `with f: ...` twice -- is fine; __exit__ clears the slot.)
+            # A single restore slot can't support overlapping `with` blocks on
+            # the SAME handle: self-nesting would strand the container pointer
+            # inside this folder, silently misplacing every later element, and
+            # a concurrent enter from another thread would corrupt the other
+            # block's restore. (Sequential re-entry -- `with f: ...` twice --
+            # is fine; __exit__ clears the slot.)
             raise RuntimeError(
-                "This GuiFolderHandle is already active as a context; it "
-                "cannot be re-entered inside itself."
+                "This GuiFolderHandle is already active as a context -- either "
+                "nested inside its own `with` block, or entered concurrently "
+                "from another thread. A handle supports only one active "
+                "`with` block at a time (sequential re-entry is fine)."
             )
         self._container_id_restore = self._impl.gui_api._snapshot_container_context()
         self._impl.gui_api._set_container_uuid(self._impl.uuid)

--- a/src/viser/_scene_api.py
+++ b/src/viser/_scene_api.py
@@ -1172,7 +1172,7 @@ class SceneApi:
         )
         return LineSegmentsHandle._make(self, message, name, wxyz, position, visible)
 
-    @deprecated_positional_shim
+    @overload
     def add_arrows(
         self,
         name: str,
@@ -1186,6 +1186,41 @@ class SceneApi:
         wxyz: tuple[float, float, float, float] | np.ndarray = (1.0, 0.0, 0.0, 0.0),
         position: tuple[float, float, float] | np.ndarray = (0.0, 0.0, 0.0),
         visible: bool = True,
+    ) -> ArrowsHandle: ...
+
+    @overload
+    @deprecated("The `line_width` parameter is deprecated and has no effect.")
+    def add_arrows(
+        self,
+        name: str,
+        points: np.ndarray,
+        colors: np.ndarray | RgbTupleOrArray,
+        *,
+        line_width: Never,
+        shaft_radius: float = 0.02,
+        head_radius: float = 0.05,
+        head_length: float = 0.1,
+        scale: float | tuple[float, float, float] = 1.0,
+        wxyz: tuple[float, float, float, float] | np.ndarray = (1.0, 0.0, 0.0, 0.0),
+        position: tuple[float, float, float] | np.ndarray = (0.0, 0.0, 0.0),
+        visible: bool = True,
+    ) -> ArrowsHandle: ...
+
+    @deprecated_positional_shim
+    def add_arrows(  # pyright: ignore[reportInconsistentOverload]
+        self,
+        name: str,
+        points: np.ndarray,
+        colors: np.ndarray | RgbTupleOrArray,
+        *,
+        shaft_radius: float = 0.02,
+        head_radius: float = 0.05,
+        head_length: float = 0.1,
+        scale: float | tuple[float, float, float] = 1.0,
+        wxyz: tuple[float, float, float, float] | np.ndarray = (1.0, 0.0, 0.0, 0.0),
+        position: tuple[float, float, float] | np.ndarray = (0.0, 0.0, 0.0),
+        visible: bool = True,
+        **_deprecated_kwargs,
     ) -> ArrowsHandle:
         """Add arrows to the scene.
 
@@ -1212,6 +1247,22 @@ class SceneApi:
         Returns:
             Handle for manipulating scene node.
         """
+        if "line_width" in _deprecated_kwargs:
+            # Accepted-and-ignored rather than remapped: unlike the spline /
+            # line-segment APIs, arrows have no thickness equivalent -- the
+            # old prop only affected a client fallback rendering path that no
+            # longer exists.
+            warnings.warn(
+                "The `line_width` parameter is deprecated and has no effect: "
+                "arrows no longer have a line-width fallback rendering path.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            _deprecated_kwargs.pop("line_width")
+        if _deprecated_kwargs:
+            raise TypeError(
+                f"Unexpected keyword arguments: {list(_deprecated_kwargs.keys())}"
+            )
         points_array = np.asarray(points, dtype=np.float32)
         if (
             points_array.ndim != 3

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -1520,6 +1520,35 @@ class ArrowsHandle(
 ):
     """Handle for arrow objects."""
 
+    @property
+    @deprecated("The 'line_width' property is deprecated and has no effect.")
+    def line_width(self) -> float:
+        """Deprecated; arrows no longer have a line-width fallback rendering
+        path.
+
+        .. deprecated::
+            Reads return the legacy default (1.0); writes warn and are
+            ignored.
+        """
+        warnings.warn(
+            "The 'line_width' property is deprecated and has no effect: "
+            "arrows no longer have a line-width fallback rendering path.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return 1.0
+
+    @line_width.setter
+    @deprecated("The 'line_width' property is deprecated and has no effect.")
+    def line_width(self, value: float) -> None:
+        del value
+        warnings.warn(
+            "The 'line_width' property is deprecated and has no effect: "
+            "arrows no longer have a line-width fallback rendering path.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
 
 class SplineCatmullRomHandle(
     SceneNodeHandle,

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -312,8 +312,8 @@ class SceneNodeHandle(AssignablePropsBase[_SceneNodeHandleState]):
                 #    namespaces -- a late joiner would apply the OLD pose to the
                 #    NEW node. Purge them (mirrors the remove()/GC sweep); the
                 #    new node's own state is queued below.
-                api._websock_interface.get_message_buffer().remove_from_buffer(
-                    lambda m: m.targets_entity_state("scene", name),
+                api._websock_interface.get_message_buffer().remove_entity_state_from_buffer(
+                    "scene", name
                 )
                 # 3. LIVE clients keep interaction bindings across a same-name
                 #    create (deliberate, for reconnect replays), so the buffer
@@ -979,10 +979,18 @@ class CameraFrustumHandle(
     @deprecated("The 'line_width' property is deprecated. Use 'thickness' instead.")
     def line_width(self, value: float) -> None:
         warnings.warn(
-            "The 'line_width' property is deprecated. Use 'thickness' instead.",
+            "The 'line_width' property is deprecated; assigning it forces "
+            "thickness_units='screen' so the value keeps its historical "
+            "pixel meaning. Use 'thickness' with 'thickness_units' instead.",
             DeprecationWarning,
             stacklevel=2,
         )
+        # line_width was always screen-space pixels; pin the units so the
+        # assigned value keeps that meaning even on a handle created with
+        # the new world-space thickness defaults. Units first: on a live
+        # client the transient (old thickness, "screen") state renders as a
+        # briefly-thin line rather than a world-units-wide ribbon.
+        self.thickness_units = "screen"
         self.thickness = value
 
     _image: np.ndarray | None
@@ -1491,10 +1499,18 @@ class LineSegmentsHandle(
     @deprecated("The 'line_width' property is deprecated. Use 'thickness' instead.")
     def line_width(self, value: float) -> None:
         warnings.warn(
-            "The 'line_width' property is deprecated. Use 'thickness' instead.",
+            "The 'line_width' property is deprecated; assigning it forces "
+            "thickness_units='screen' so the value keeps its historical "
+            "pixel meaning. Use 'thickness' with 'thickness_units' instead.",
             DeprecationWarning,
             stacklevel=2,
         )
+        # line_width was always screen-space pixels; pin the units so the
+        # assigned value keeps that meaning even on a handle created with
+        # the new world-space thickness defaults. Units first: on a live
+        # client the transient (old thickness, "screen") state renders as a
+        # briefly-thin line rather than a world-units-wide ribbon.
+        self.thickness_units = "screen"
         self.thickness = value
 
 
@@ -1531,10 +1547,18 @@ class SplineCatmullRomHandle(
     @deprecated("The 'line_width' property is deprecated. Use 'thickness' instead.")
     def line_width(self, value: float) -> None:
         warnings.warn(
-            "The 'line_width' property is deprecated. Use 'thickness' instead.",
+            "The 'line_width' property is deprecated; assigning it forces "
+            "thickness_units='screen' so the value keeps its historical "
+            "pixel meaning. Use 'thickness' with 'thickness_units' instead.",
             DeprecationWarning,
             stacklevel=2,
         )
+        # line_width was always screen-space pixels; pin the units so the
+        # assigned value keeps that meaning even on a handle created with
+        # the new world-space thickness defaults. Units first: on a live
+        # client the transient (old thickness, "screen") state renders as a
+        # briefly-thin line rather than a world-units-wide ribbon.
+        self.thickness_units = "screen"
         self.thickness = value
 
     @property
@@ -1593,10 +1617,18 @@ class SplineCubicBezierHandle(
     @deprecated("The 'line_width' property is deprecated. Use 'thickness' instead.")
     def line_width(self, value: float) -> None:
         warnings.warn(
-            "The 'line_width' property is deprecated. Use 'thickness' instead.",
+            "The 'line_width' property is deprecated; assigning it forces "
+            "thickness_units='screen' so the value keeps its historical "
+            "pixel meaning. Use 'thickness' with 'thickness_units' instead.",
             DeprecationWarning,
             stacklevel=2,
         )
+        # line_width was always screen-space pixels; pin the units so the
+        # assigned value keeps that meaning even on a handle created with
+        # the new world-space thickness defaults. Units first: on a live
+        # client the transient (old thickness, "screen") state renders as a
+        # briefly-thin line rather than a world-units-wide ribbon.
+        self.thickness_units = "screen"
         self.thickness = value
 
     @property

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -953,6 +953,42 @@ class _RaycastSupportedSceneNodeHandle(SceneNodeHandle):
         self._impl._last_published_click_bindings = bindings
 
 
+class _SupportsThickness(Protocol):
+    """Line-style props shared by every handle carrying the deprecated
+    ``line_width`` alias."""
+
+    thickness: float
+    thickness_units: Literal["screen", "world"]
+
+
+def _get_deprecated_line_width(handle: _SupportsThickness) -> float:
+    """Shared body of the deprecated ``line_width`` getters."""
+    warnings.warn(
+        "The 'line_width' property is deprecated. Use 'thickness' instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    return handle.thickness
+
+
+def _set_deprecated_line_width(handle: _SupportsThickness, value: float) -> None:
+    """Shared body of the deprecated ``line_width`` setters."""
+    warnings.warn(
+        "The 'line_width' property is deprecated; assigning it forces "
+        "thickness_units='screen' so the value keeps its historical "
+        "pixel meaning. Use 'thickness' with 'thickness_units' instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    # line_width was always screen-space pixels; pin the units so the
+    # assigned value keeps that meaning even on a handle created with the
+    # new world-space thickness defaults. Units first: on a live client the
+    # transient (old thickness, "screen") state renders as a briefly-thin
+    # line rather than a world-units-wide ribbon.
+    handle.thickness_units = "screen"
+    handle.thickness = value
+
+
 class CameraFrustumHandle(
     _RaycastSupportedSceneNodeHandle,
     _messages.CameraFrustumProps,
@@ -968,30 +1004,12 @@ class CameraFrustumHandle(
             Use 'thickness' instead; it is interpreted in the units given
             by 'thickness_units'.
         """
-        warnings.warn(
-            "The 'line_width' property is deprecated. Use 'thickness' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.thickness
+        return _get_deprecated_line_width(self)
 
     @line_width.setter
     @deprecated("The 'line_width' property is deprecated. Use 'thickness' instead.")
     def line_width(self, value: float) -> None:
-        warnings.warn(
-            "The 'line_width' property is deprecated; assigning it forces "
-            "thickness_units='screen' so the value keeps its historical "
-            "pixel meaning. Use 'thickness' with 'thickness_units' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        # line_width was always screen-space pixels; pin the units so the
-        # assigned value keeps that meaning even on a handle created with
-        # the new world-space thickness defaults. Units first: on a live
-        # client the transient (old thickness, "screen") state renders as a
-        # briefly-thin line rather than a world-units-wide ribbon.
-        self.thickness_units = "screen"
-        self.thickness = value
+        _set_deprecated_line_width(self, value)
 
     _image: np.ndarray | None
     _jpeg_quality: int | None
@@ -1488,30 +1506,12 @@ class LineSegmentsHandle(
             Use 'thickness' instead; it is interpreted in the units given
             by 'thickness_units'.
         """
-        warnings.warn(
-            "The 'line_width' property is deprecated. Use 'thickness' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.thickness
+        return _get_deprecated_line_width(self)
 
     @line_width.setter
     @deprecated("The 'line_width' property is deprecated. Use 'thickness' instead.")
     def line_width(self, value: float) -> None:
-        warnings.warn(
-            "The 'line_width' property is deprecated; assigning it forces "
-            "thickness_units='screen' so the value keeps its historical "
-            "pixel meaning. Use 'thickness' with 'thickness_units' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        # line_width was always screen-space pixels; pin the units so the
-        # assigned value keeps that meaning even on a handle created with
-        # the new world-space thickness defaults. Units first: on a live
-        # client the transient (old thickness, "screen") state renders as a
-        # briefly-thin line rather than a world-units-wide ribbon.
-        self.thickness_units = "screen"
-        self.thickness = value
+        _set_deprecated_line_width(self, value)
 
 
 class ArrowsHandle(
@@ -1536,30 +1536,12 @@ class SplineCatmullRomHandle(
             Use 'thickness' instead; it is interpreted in the units given
             by 'thickness_units'.
         """
-        warnings.warn(
-            "The 'line_width' property is deprecated. Use 'thickness' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.thickness
+        return _get_deprecated_line_width(self)
 
     @line_width.setter
     @deprecated("The 'line_width' property is deprecated. Use 'thickness' instead.")
     def line_width(self, value: float) -> None:
-        warnings.warn(
-            "The 'line_width' property is deprecated; assigning it forces "
-            "thickness_units='screen' so the value keeps its historical "
-            "pixel meaning. Use 'thickness' with 'thickness_units' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        # line_width was always screen-space pixels; pin the units so the
-        # assigned value keeps that meaning even on a handle created with
-        # the new world-space thickness defaults. Units first: on a live
-        # client the transient (old thickness, "screen") state renders as a
-        # briefly-thin line rather than a world-units-wide ribbon.
-        self.thickness_units = "screen"
-        self.thickness = value
+        _set_deprecated_line_width(self, value)
 
     @property
     @deprecated("The 'positions' property is deprecated. Use 'points' instead.")
@@ -1606,30 +1588,12 @@ class SplineCubicBezierHandle(
             Use 'thickness' instead; it is interpreted in the units given
             by 'thickness_units'.
         """
-        warnings.warn(
-            "The 'line_width' property is deprecated. Use 'thickness' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.thickness
+        return _get_deprecated_line_width(self)
 
     @line_width.setter
     @deprecated("The 'line_width' property is deprecated. Use 'thickness' instead.")
     def line_width(self, value: float) -> None:
-        warnings.warn(
-            "The 'line_width' property is deprecated; assigning it forces "
-            "thickness_units='screen' so the value keeps its historical "
-            "pixel meaning. Use 'thickness' with 'thickness_units' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        # line_width was always screen-space pixels; pin the units so the
-        # assigned value keeps that meaning even on a handle created with
-        # the new world-space thickness defaults. Units first: on a live
-        # client the transient (old thickness, "screen") state renders as a
-        # briefly-thin line rather than a world-units-wide ribbon.
-        self.thickness_units = "screen"
-        self.thickness = value
+        _set_deprecated_line_width(self, value)
 
     @property
     @deprecated(

--- a/src/viser/_tunnel.py
+++ b/src/viser/_tunnel.py
@@ -67,7 +67,8 @@ class ViserTunnel:
         def call_on_disconnect() -> None:
             try:
                 self._disconnect_event.wait()
-            except EOFError:
+            except (EOFError, BrokenPipeError, ConnectionResetError):
+                # Manager already gone; see wait_job in on_connect.
                 return
             callback()
 
@@ -93,7 +94,10 @@ class ViserTunnel:
                 # race-free.
                 if self._shared_state["status"] != "connected":
                     return
-            except EOFError:
+            except (EOFError, BrokenPipeError, ConnectionResetError):
+                # Manager already gone (interpreter teardown after a failed
+                # tunnel) -- the same trio close() tolerates when it sets
+                # _connect_event; the proxy read can raise any of them.
                 return
             callback(self._shared_state["max_conn_count"])
 

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -298,17 +298,34 @@ class CameraHandle:
                 "Camera look_at cannot equal position (zero look distance)."
             )
         z /= z_norm
-        y = tf.SO3.exp(z * np.pi) @ self._state.up_direction
-        y = y - np.dot(z, y) * z
-        y_norm = np.linalg.norm(y)
+
+        def perpendicular_part(up_candidate: np.ndarray) -> tuple[np.ndarray, float]:
+            y_c = tf.SO3.exp(z * np.pi) @ up_candidate
+            y_c = y_c - np.dot(z, y_c) * z
+            return y_c, float(np.linalg.norm(y_c))
+
+        y, y_norm = perpendicular_part(self._state.up_direction)
         if y_norm == 0.0:
-            # No component of up_direction is perpendicular to the view: it is
-            # zero, or parallel to (look_at - position). Reject rather than
-            # store/broadcast a NaN basis.
-            raise ValueError(
-                "Camera up_direction must be nonzero and not parallel to the "
-                "view direction (look_at - position)."
-            )
+            if np.linalg.norm(self._state.up_direction) == 0.0:
+                # A zero up vector carries no information at all; reject
+                # rather than store/broadcast a NaN basis.
+                raise ValueError("Camera up_direction must be nonzero.")
+            # up_direction is parallel to the view direction -- e.g. the
+            # canonical top-down pose (+Z up, looking straight down). The
+            # client's orbit controls clamp the pole instead of failing, so
+            # raising here broke camera setups that worked pre-1.1: degrade
+            # the same way. Prefer the previous orientation's up vector for
+            # continuity (matching the "minimize impact on orbit controls"
+            # policy above); fall back to the world axis least aligned with
+            # the view when that is also degenerate (e.g. a never-updated
+            # zeroed state). The client echoes its own resolved pose back,
+            # so any residual mismatch is transient.
+            prev_up = -tf.SO3(self._state.wxyz).as_matrix()[:, 1]
+            y, y_norm = perpendicular_part(prev_up)
+            if not np.isfinite(y_norm) or y_norm < 1e-8:
+                axis_fallback = np.zeros(3)
+                axis_fallback[np.argmin(np.abs(z))] = 1.0
+                y, y_norm = perpendicular_part(axis_fallback)
         y /= y_norm
         x = np.cross(y, z)
         # Cast to float64 explicitly: newer numpy stubs type np.cross() as

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -1448,10 +1448,10 @@ class ViserServer(DeprecatedAttributeShim if not TYPE_CHECKING else object):
             # including scene-adjacent Set*Message variants that target a
             # removed scene node by `name` but aren't entity-declared. The
             # per-message taxonomy is Message.targets_entity_state -- the ONE
-            # definition, shared with the same-name-replacement purge -- with
-            # set-based id matching inlined here so the sweep stays a single
-            # pass over the buffer rather than per-name predicate calls.
-            # Skip the walk entirely when nothing was tombstoned this round.
+            # definition, shared with the same-name-replacement purge --
+            # materialized as the buffer's entity-state index, so the sweep
+            # touches only the tombstoned entities' buckets rather than
+            # walking the whole buffer.
             #
             # These deletes are NOT floor-gated, unlike the tombstones above:
             # an update targeting a removed entity is dead weight for EVERY
@@ -1463,29 +1463,16 @@ class ViserServer(DeprecatedAttributeShim if not TYPE_CHECKING else object):
             # "update /x": a ghost node other clients don't have. push()
             # already purges pending updates on Remove with no floor gate;
             # this sweep follows the same reasoning.
-            if removed_ids_by_type:
-                for msg_id, message in buffer.message_from_id.items():
-                    phase = message.lifecycle_phase
-                    if phase in ("update_dict", "update_simple"):
-                        assert (
-                            message.entity_type is not None
-                            and message.entity_id_field is not None
+            for entity_type, entity_ids in removed_ids_by_type.items():
+                for entity_id in entity_ids:
+                    remove_message_ids.extend(
+                        buffer.ids_from_entity_state_key.get(
+                            (entity_type, entity_id), ()
                         )
-                        entity_id = getattr(message, message.entity_id_field)
-                        if entity_id in removed_ids_by_type.get(
-                            message.entity_type, ()
-                        ):
-                            remove_message_ids.append(msg_id)
-                    elif phase is None:
-                        name = getattr(message, "name", None)
-                        if name is not None and name in removed_ids_by_type.get(
-                            "scene", ()
-                        ):
-                            remove_message_ids.append(msg_id)
+                    )
 
             for msg_id in remove_message_ids:
-                message = buffer.message_from_id.pop(msg_id)
-                buffer.id_from_redundancy_key.pop(message.redundancy_key(), None)
+                buffer.pop_message_locked(msg_id)
 
     def get_host(self) -> str:
         """Returns the host address of the Viser server.

--- a/src/viser/client/package-lock.json
+++ b/src/viser/client/package-lock.json
@@ -116,6 +116,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -408,29 +409,6 @@
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
@@ -1133,6 +1111,7 @@
       "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.3.tgz",
       "integrity": "sha512-OdTAQ0lsXjEqfea0KyXJ1rV9cZb/Rtqv5l3luG2m8Sx5BTGMqXas6mKHtdj4LwIiUKeFkIkZYjNmH6ri1HXjSA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
         "clsx": "^2.1.1",
@@ -1165,6 +1144,7 @@
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.3.tgz",
       "integrity": "sha512-nmspxbFSjFkimRXYhgAujnyBwGeAWDSP1WKHFR+Yl5x3Q0IkmsiOTE9yJPjMjmjffZfunFXQFwQDl1OF3m42Pw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^18.x || ^19.x"
       }
@@ -1439,6 +1419,7 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.3.0.tgz",
       "integrity": "sha512-myPe3YL/C8+Eq939/4qIVEPBW/uxV0iiUbmjfwrs9sGKYDG8ib8Dz3Okq7BQt8P+0k4igedONbjXMQy84aDFmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.32.0",
@@ -2223,6 +2204,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -2483,6 +2465,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2517,6 +2500,7 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.0.tgz",
       "integrity": "sha512-AaGkvloQhxdrfMm/HbY8cpOz1K1jkEELn6zjFoY3yhAiC7zhhZE19+gDBybYwKk+GqXmWKxqDCB43NqyW3+QZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -2599,6 +2583,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -2975,6 +2960,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3326,6 +3312,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -4335,6 +4322,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6162,6 +6150,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "devOptional": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -8172,6 +8161,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8181,6 +8171,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -8775,6 +8766,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.49.0.tgz",
       "integrity": "sha512-3IVq0cGJ6H7fKXXEdVt+RcYvRCt8beYY9K1760wGQwSAHZcS9eot1zDG5axUbcp/kWRi5zKIIDX8MoKv/TzvZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9376,7 +9368,8 @@
       "version": "0.183.2",
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
       "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -9468,6 +9461,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9704,6 +9698,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9878,7 +9873,8 @@
       "version": "1.6.32",
       "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.32.tgz",
       "integrity": "sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/uplot-react": {
       "version": "1.2.4",
@@ -10055,6 +10051,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -10762,7 +10759,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10780,7 +10776,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10798,7 +10793,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10816,7 +10810,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10834,7 +10827,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10852,7 +10844,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10870,7 +10861,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10888,7 +10878,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10906,7 +10895,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10924,7 +10912,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10942,7 +10929,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10960,7 +10946,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10978,7 +10963,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10996,7 +10980,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11014,7 +10997,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11032,7 +11014,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11050,7 +11031,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11068,7 +11048,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11086,7 +11065,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11104,7 +11082,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11122,7 +11099,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11140,7 +11116,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11158,7 +11133,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11176,7 +11150,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11194,7 +11167,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11212,7 +11184,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11251,50 +11222,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/vitest/node_modules/esbuild": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.1",
-        "@esbuild/android-arm": "0.28.1",
-        "@esbuild/android-arm64": "0.28.1",
-        "@esbuild/android-x64": "0.28.1",
-        "@esbuild/darwin-arm64": "0.28.1",
-        "@esbuild/darwin-x64": "0.28.1",
-        "@esbuild/freebsd-arm64": "0.28.1",
-        "@esbuild/freebsd-x64": "0.28.1",
-        "@esbuild/linux-arm": "0.28.1",
-        "@esbuild/linux-arm64": "0.28.1",
-        "@esbuild/linux-ia32": "0.28.1",
-        "@esbuild/linux-loong64": "0.28.1",
-        "@esbuild/linux-mips64el": "0.28.1",
-        "@esbuild/linux-ppc64": "0.28.1",
-        "@esbuild/linux-riscv64": "0.28.1",
-        "@esbuild/linux-s390x": "0.28.1",
-        "@esbuild/linux-x64": "0.28.1",
-        "@esbuild/netbsd-arm64": "0.28.1",
-        "@esbuild/netbsd-x64": "0.28.1",
-        "@esbuild/openbsd-arm64": "0.28.1",
-        "@esbuild/openbsd-x64": "0.28.1",
-        "@esbuild/openharmony-arm64": "0.28.1",
-        "@esbuild/sunos-x64": "0.28.1",
-        "@esbuild/win32-arm64": "0.28.1",
-        "@esbuild/win32-ia32": "0.28.1",
-        "@esbuild/win32-x64": "0.28.1"
-      }
-    },
     "node_modules/vitest/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -11314,6 +11241,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11560,6 +11488,7 @@
       "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/viser/client/package-lock.json
+++ b/src/viser/client/package-lock.json
@@ -116,7 +116,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -409,6 +408,29 @@
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
@@ -1111,7 +1133,6 @@
       "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.3.tgz",
       "integrity": "sha512-OdTAQ0lsXjEqfea0KyXJ1rV9cZb/Rtqv5l3luG2m8Sx5BTGMqXas6mKHtdj4LwIiUKeFkIkZYjNmH6ri1HXjSA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
         "clsx": "^2.1.1",
@@ -1144,7 +1165,6 @@
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.3.tgz",
       "integrity": "sha512-nmspxbFSjFkimRXYhgAujnyBwGeAWDSP1WKHFR+Yl5x3Q0IkmsiOTE9yJPjMjmjffZfunFXQFwQDl1OF3m42Pw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^18.x || ^19.x"
       }
@@ -1419,7 +1439,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.3.0.tgz",
       "integrity": "sha512-myPe3YL/C8+Eq939/4qIVEPBW/uxV0iiUbmjfwrs9sGKYDG8ib8Dz3Okq7BQt8P+0k4igedONbjXMQy84aDFmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.32.0",
@@ -2204,7 +2223,6 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -2465,7 +2483,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2500,7 +2517,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.0.tgz",
       "integrity": "sha512-AaGkvloQhxdrfMm/HbY8cpOz1K1jkEELn6zjFoY3yhAiC7zhhZE19+gDBybYwKk+GqXmWKxqDCB43NqyW3+QZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -2583,7 +2599,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -2960,7 +2975,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3312,7 +3326,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -4322,7 +4335,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6150,7 +6162,6 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "devOptional": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -8161,7 +8172,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8171,7 +8181,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -8766,7 +8775,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.49.0.tgz",
       "integrity": "sha512-3IVq0cGJ6H7fKXXEdVt+RcYvRCt8beYY9K1760wGQwSAHZcS9eot1zDG5axUbcp/kWRi5zKIIDX8MoKv/TzvZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9368,8 +9376,7 @@
       "version": "0.183.2",
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
       "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -9461,7 +9468,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9698,7 +9704,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9873,8 +9878,7 @@
       "version": "1.6.32",
       "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.32.tgz",
       "integrity": "sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/uplot-react": {
       "version": "1.2.4",
@@ -10051,7 +10055,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -10759,6 +10762,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10776,6 +10780,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10793,6 +10798,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10810,6 +10816,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10827,6 +10834,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10844,6 +10852,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10861,6 +10870,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10878,6 +10888,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10895,6 +10906,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10912,6 +10924,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10929,6 +10942,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10946,6 +10960,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10963,6 +10978,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10980,6 +10996,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10997,6 +11014,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11014,6 +11032,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11031,6 +11050,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11048,6 +11068,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11065,6 +11086,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11082,6 +11104,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11099,6 +11122,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11116,6 +11140,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11133,6 +11158,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11150,6 +11176,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11167,6 +11194,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11184,6 +11212,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11222,6 +11251,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/vitest/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -11241,7 +11314,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11488,7 +11560,6 @@
       "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/viser/client/src/App.tsx
+++ b/src/viser/client/src/App.tsx
@@ -209,6 +209,10 @@ function ViewerRoot() {
     camera: null,
     backgroundMaterial: null,
     cameraControl: null,
+    // Must match the server-side default in _viser.py (pinned by
+    // tests/test_initial_camera_defaults.py) and the initial maxDistance
+    // prop in CameraControls.tsx.
+    configuredMaxOrbitDistance: 1e4,
 
     // Scene management.
     nodeRefFromName,
@@ -512,8 +516,18 @@ function AppLayout({
             height: "100%",
           })}
         >
-          {dockFloating ? (
-            <ControlPanelDockSurface onDockStateChange={setControlDock}>
+          {/* The wrapper is keyed on messageSource (constant for the app's
+          lifetime), NOT on dockFloating: flipping the element type at the
+          canvas's tree position (rotating a phone across the mobile
+          breakpoint, or a runtime control_layout change) remounted the
+          entire R3F canvas subtree -- new WebGL context, full GPU-state
+          re-upload, camera snapped back to the initial pose. The surface
+          stays mounted and toggles `enabled` instead. */}
+          {messageSource === "websocket" ? (
+            <ControlPanelDockSurface
+              enabled={dockFloating}
+              onDockStateChange={setControlDock}
+            >
               {canvasContent}
             </ControlPanelDockSurface>
           ) : (

--- a/src/viser/client/src/CameraControls.tsx
+++ b/src/viser/client/src/CameraControls.tsx
@@ -187,6 +187,24 @@ export function SynchronizedCameraControls() {
 
   const viewerMutable = viewer.mutable.current;
 
+  // Effective-maxDistance reconciliation: camera-controls clamps every user
+  // dolly to [minDistance, maxDistance], but server-driven placement
+  // (setLookAt/setPosition, the initial camera) does NOT clamp -- so a
+  // camera legitimately parked beyond the configured bound (large-coordinate
+  // scenes under the 1e4 default) was TELEPORTED to the boundary by the
+  // first scroll tick. Ratchet the effective bound to the current distance
+  // while outside the configured one: zooming in works smoothly, zooming
+  // further out stays blocked, and the configured clamp restores as soon as
+  // the camera comes back inside it.
+  useFrame(() => {
+    const controls = viewerMutable.cameraControl;
+    if (controls === null) return;
+    const configured = viewerMutable.configuredMaxOrbitDistance;
+    const effective =
+      controls.distance > configured ? controls.distance : configured;
+    if (controls.maxDistance !== effective) controls.maxDistance = effective;
+  });
+
   // Crosshair visibility state: separate counter for keyboard and flag for pointer interactions.
   const [keyboardCrosshairCounter, setKeyboardCrosshairCounter] = useState(0);
   const [pointerInteractionActive, setPointerInteractionActive] =

--- a/src/viser/client/src/ControlPanel/ControlPanelDock.tsx
+++ b/src/viser/client/src/ControlPanel/ControlPanelDock.tsx
@@ -48,13 +48,25 @@ export interface ControlDockState {
   leftRegionWidthPx: number;
 }
 
+/** Stable empty registry for the disabled dock surface (identity matters:
+ * a fresh {} per render would churn the DockManager's reconciliation). */
+const EMPTY_PANES: PaneRegistry = {};
+
 export function ControlPanelDockSurface({
   children,
   onDockStateChange,
+  enabled = true,
 }: {
   /** Center content (the canvas layers), inset when the panel is docked. */
   children: React.ReactNode;
   onDockStateChange?: (state: ControlDockState) => void;
+  /** When false (mobile view), the DockManager stays mounted as a
+   * passthrough container with no panes -- the element structure around the
+   * canvas must NOT change when the viewport crosses the mobile breakpoint,
+   * or the entire R3F canvas subtree remounts (new WebGL context, camera
+   * reset to initial pose). The mobile bottom-sheet ControlPanel renders its
+   * own chrome outside this surface. */
+  enabled?: boolean;
 }) {
   const viewer = React.useContext(ViewerContext)!;
   const controlWidthString = viewer.useGui(
@@ -140,7 +152,7 @@ export function ControlPanelDockSurface({
       <GuiDockContext.Provider value={guiDockValue}>
         <DockManager
           initialLayout={initialLayout}
-          panes={panes}
+          panes={enabled ? panes : EMPTY_PANES}
           // Resize the 3D canvas's GL backbuffer synchronously as a docked
           // region's width handle is dragged, so the scene tracks the divider
           // instead of trailing R3F's async ResizeObserver by a frame.
@@ -149,11 +161,18 @@ export function ControlPanelDockSurface({
           }
         >
           {children}
-          <ControlPanelDockSync
-            widthPx={widthPx}
-            onDockStateChange={onDockStateChange}
-          />
-          <StandalonePanelSync registerTabGroup={registerTabGroup} />
+          {/* Sync nodes are dropped (not the wrapper) when disabled: they
+          are siblings AFTER `children`, so toggling them cannot reparent
+          the canvas subtree. */}
+          {enabled && (
+            <ControlPanelDockSync
+              widthPx={widthPx}
+              onDockStateChange={onDockStateChange}
+            />
+          )}
+          {enabled && (
+            <StandalonePanelSync registerTabGroup={registerTabGroup} />
+          )}
         </DockManager>
       </GuiDockContext.Provider>
     </div>

--- a/src/viser/client/src/FilePlayback.tsx
+++ b/src/viser/client/src/FilePlayback.tsx
@@ -17,6 +17,8 @@ import { ViewerContext } from "./ViewerContext";
 import { defaultEnvironmentState } from "./EnvironmentState";
 import { isFormElement } from "./utils/isFormElement";
 import { PlaybackScenePanel } from "./PlaybackScenePanel";
+import { VISER_VERSION } from "./VersionInfo";
+import { notifications } from "@mantine/notifications";
 
 /** Toggle `paused` on spacebar, unless a form control is focused -- so typing a
  * space in the playback time/speed inputs doesn't toggle playback. */
@@ -128,6 +130,23 @@ function PlaybackInterface({
   useEffect(() => {
     deserialize(setStatus).then((data) => {
       console.log(loadedLogPrefix, data.viserVersion);
+      // Recordings aren't version-checked like live connections are, and the
+      // message format can drift between releases; warn instead of playing a
+      // mismatched file back silently wrong. (Embeds from as_html() bundle the
+      // client build that wrote them, so this only fires for .viser files.)
+      if (data.viserVersion !== VISER_VERSION) {
+        notifications.show({
+          id: "playback-version-mismatch",
+          title: "Version mismatch",
+          message:
+            `This recording was saved with Viser version ` +
+            `'${data.viserVersion}', but the viewer is version ` +
+            `'${VISER_VERSION}'. Playback may be incorrect.`,
+          color: "yellow",
+          autoClose: false,
+          withCloseButton: true,
+        });
+      }
       setRecording(data);
     });
   }, [reloadKey]);

--- a/src/viser/client/src/Line.tsx
+++ b/src/viser/client/src/Line.tsx
@@ -109,14 +109,18 @@ export const Line: ForwardRefComponent<LineProps, Line2 | LineSegments2> =
       // smooth edge falloff, depth-tested but not depth-written, on top of
       // the opaque depth-anchoring core.
       const showFringe = (worldUnits ?? false) && !(dashed ?? false);
-      const fringeMatRef = React.useRef<LineMaterial>(null);
-      React.useLayoutEffect(() => {
-        const mat = fringeMatRef.current;
+      // The fringe define is applied via callback ref rather than an effect
+      // keyed on showFringe: the fringe material remounts when the
+      // segments/dashed JSX branch flips while showFringe stays true, and an
+      // effect keyed on showFringe would skip the fresh material -- leaving
+      // it without VISER_LINE_FRINGE, rendered as a transparent duplicate of
+      // the core instead of the antialiasing skirt.
+      const setFringeMatRef = React.useCallback((mat: LineMaterial | null) => {
         if (!mat) return;
         mat.defines.VISER_LINE_FRINGE = "";
         mat.worldUnits = true;
         mat.needsUpdate = true;
-      }, [showFringe]);
+      }, []);
 
       const effectiveColor = vertexColors ? 0xffffff : color;
 
@@ -156,7 +160,7 @@ export const Line: ForwardRefComponent<LineProps, Line2 | LineSegments2> =
       // the core only.
       const fringeMaterialJsx = (
         <lineMaterial
-          ref={fringeMatRef}
+          ref={setFringeMatRef}
           color={effectiveColor}
           vertexColors={Boolean(vertexColors)}
           resolution={[size.width, size.height]}

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -671,9 +671,13 @@ function useMessageHandler() {
       }
       case "SetCameraMaxOrbitDistanceMessage": {
         const cameraControls = viewerMutable.cameraControl!;
+        viewerMutable.configuredMaxOrbitDistance = message.max_orbit_distance;
         cameraControls.maxDistance = message.max_orbit_distance;
         // camera-controls only enforces the bound on the next dolly, so a camera
-        // already parked beyond the new limit would stay there. Pull it in now.
+        // already parked beyond the new limit would stay there. Pull it in now
+        // -- SMOOTHLY: an explicit server-set bound is an intentional pull-in,
+        // unlike the default bound, which the per-frame reconciliation in
+        // SynchronizedCameraControls relaxes instead of teleporting through.
         if (cameraControls.distance > message.max_orbit_distance) {
           cameraControls.dollyTo(message.max_orbit_distance, true);
         }

--- a/src/viser/client/src/ViewerContext.ts
+++ b/src/viser/client/src/ViewerContext.ts
@@ -47,6 +47,14 @@ export type ViewerMutable = {
   camera: THREE.PerspectiveCamera | null;
   backgroundMaterial: THREE.ShaderMaterial | null;
   cameraControl: CameraControls | null;
+  /** Server-configured max orbit distance. The camera-controls instance's
+   * own `maxDistance` is an EFFECTIVE bound that ratchets up to the current
+   * distance whenever the camera is placed beyond this configured value
+   * (server-set pose, initial camera): camera-controls clamps every user
+   * dolly to [min, max], so a hard bound teleported such cameras to the
+   * boundary on the first scroll tick. See the per-frame reconciliation in
+   * SynchronizedCameraControls. */
+  configuredMaxOrbitDistance: number;
 
   // Scene management.
   nodeRefFromName: {

--- a/src/viser/client/src/dock/dock-ux-spec.md
+++ b/src/viser/client/src/dock/dock-ux-spec.md
@@ -485,11 +485,15 @@ chevron included, reappears automatically.
   high-water marks (P6/D52). Clients never sync layouts with each
   other.
 
-### 3.6 Mobile (no dock surface)
+### 3.6 Mobile (dock surface disabled)
 
 Below the mobile breakpoint (Mantine `xs`, ~576px width) the dock
-surface does not mount at all: no regions, rails, floating windows, or
-drag/dock. The control panel renders as the bottom sheet, and
+surface is disabled: no panes, regions, rails, floating windows, or
+drag/dock. (The surface's passthrough container itself stays mounted —
+the canvas subtree must keep its position in the element tree, because
+swapping the wrapper when the viewport crosses the breakpoint remounted
+the entire WebGL canvas and snapped the camera back to its initial
+pose.) The control panel renders as the bottom sheet, and
 standalone panels render inside it as an ACCORDION of bar-like
 sections (D45): ONE identity row per panel, two states (P9: identity
 never renders twice; P13: the bar is the header with the body
@@ -502,7 +506,7 @@ start COLLAPSED (the sheet is wayfinding chrome on a small screen);
 several may be open at once. `visible` is honored (hidden panels render
 no section); sections sort by server-side `order`. The geometry axes
 (position/width/height) do not apply off the dock surface — they replay
-when the viewport widens and the dock remounts — while a fresh collapse
+when the viewport widens and the dock re-enables — while a fresh collapse
 command toggles the panel's sheet section (surface-specific watermark,
 never shared with the dock's).
 

--- a/src/viser/infra/_async_message_buffer.py
+++ b/src/viser/infra/_async_message_buffer.py
@@ -5,9 +5,42 @@ import contextlib
 import dataclasses
 import threading
 from asyncio.events import AbstractEventLoop
-from typing import AsyncGenerator, Callable, Dict, Generator, List, Sequence
+from typing import (
+    AsyncGenerator,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+)
 
 from ._messages import Message
+
+
+def _entity_state_key(message: Message) -> Optional[Tuple[str, str]]:
+    """The (entity_type, entity_id) coordinates under which a message is
+    indexed in ``AsyncMessageBuffer.ids_from_entity_state_key``, or None for
+    messages that carry no per-entity state.
+
+    This is the materialized form of ``Message.targets_entity_state``: a
+    message is indexed under exactly the keys for which that predicate
+    returns True (update messages under their declared entity, phase-less
+    name-keyed messages under ``("scene", name)``). The two must never
+    disagree -- the index exists so per-entity purges don't scan the buffer,
+    not to redefine the taxonomy."""
+    phase = message.lifecycle_phase
+    if phase in ("update_dict", "update_simple"):
+        if message.entity_type is not None and message.entity_id_field is not None:
+            return (message.entity_type, getattr(message, message.entity_id_field))
+        return None
+    if phase is None:
+        name = getattr(message, "name", None)
+        if name is not None:
+            return ("scene", name)
+    return None
 
 
 @dataclasses.dataclass
@@ -24,6 +57,14 @@ class AsyncMessageBuffer:
     message_counter: int = 0
     message_from_id: Dict[int, Message] = dataclasses.field(default_factory=dict)
     id_from_redundancy_key: Dict[str, int] = dataclasses.field(default_factory=dict)
+    ids_from_entity_state_key: Dict[Tuple[str, str], Set[int]] = dataclasses.field(
+        default_factory=dict
+    )
+    """Buffered per-entity state messages, indexed by ``_entity_state_key``.
+    Keeps same-name replacement, remove-time update purges, and the GC sweep
+    O(per-entity messages) instead of O(buffer). Maintained under
+    ``buffer_lock`` by every path that inserts into or deletes from
+    ``message_from_id``."""
 
     buffer_lock: threading.Lock = dataclasses.field(default_factory=threading.Lock)
     """Lock to prevent race conditions when pushing messages from different threads."""
@@ -66,17 +107,52 @@ class AsyncMessageBuffer:
             with self.buffer_lock:
                 self._sanctioned_dead_writes -= 1
 
+    def pop_message_locked(self, message_id: int) -> Optional[Message]:
+        """Delete one message from the buffer and every index that refers to
+        it, returning the message (or None if the id is absent). The caller
+        must hold ``buffer_lock``: this is THE single deletion primitive, so
+        the redundancy and entity-state indices cannot drift from
+        ``message_from_id``."""
+        message = self.message_from_id.pop(message_id, None)
+        if message is None:
+            return None
+        # Unmap the redundancy slot only if it still points at THIS message:
+        # slots for colliding keys point at the newest holder, and a blind
+        # pop here would orphan that newer message's mapping.
+        redundancy_key = message.redundancy_key()
+        if self.id_from_redundancy_key.get(redundancy_key) == message_id:
+            del self.id_from_redundancy_key[redundancy_key]
+        entity_key = _entity_state_key(message)
+        if entity_key is not None:
+            ids = self.ids_from_entity_state_key.get(entity_key)
+            if ids is not None:
+                ids.discard(message_id)
+                if not ids:
+                    del self.ids_from_entity_state_key[entity_key]
+        return message
+
     def remove_from_buffer(self, match_fn: Callable[[Message], bool]) -> None:
         """Remove messages that match some condition."""
 
         with self.buffer_lock:
             # Remove messages that match the condition.
-            for id, message in filter(
-                lambda kv_pair: match_fn(self.message_from_id[kv_pair[0]]),
-                tuple(self.message_from_id.items()),
-            ):
-                self.message_from_id.pop(id)
-                self.id_from_redundancy_key.pop(message.redundancy_key())
+            for id in [
+                id for id, message in self.message_from_id.items() if match_fn(message)
+            ]:
+                self.pop_message_locked(id)
+
+    def remove_entity_state_from_buffer(self, entity_type: str, entity_id: str) -> None:
+        """Purge every buffered message carrying per-entity state for one
+        entity -- exactly the messages ``targets_entity_state`` matches, via
+        the entity-state index rather than a full-buffer scan. Used by
+        same-name scene node replacement, where a per-add O(buffer) scan
+        made re-add loops quadratic in scene size."""
+        with self.buffer_lock:
+            ids = self.ids_from_entity_state_key.get((entity_type, entity_id))
+            if not ids:
+                return
+            for message_id in tuple(ids):
+                self.pop_message_locked(message_id)
 
     def push(self, message: Message) -> None:
         """Push a new message to our buffer, and remove old redundant ones."""
@@ -126,25 +202,33 @@ class AsyncMessageBuffer:
             # On Remove, drop pending Updates for the same entity so a
             # removed entity leaves no residue in the buffer. (Create+Remove
             # coalesce via the redundancy key below; Updates use a separate
-            # namespace, so they need explicit purging.)
+            # namespace, so they need explicit purging.) Resolved through the
+            # entity-state index; only the update phases are purged here --
+            # phase-less name-keyed messages in the same index bucket are
+            # left for remove()'s own explicit empty-binding broadcasts.
             if purge_entity_type is not None:
-                stale_ids = [
-                    mid
-                    for mid, m in self.message_from_id.items()
-                    if m.lifecycle_phase in ("update_dict", "update_simple")
-                    and m.entity_type == purge_entity_type
-                    and m.entity_id_field is not None
-                    and getattr(m, m.entity_id_field, None) == purge_entity_id
-                ]
-                for mid in stale_ids:
-                    stale = self.message_from_id.pop(mid)
-                    stale_key = stale.redundancy_key()
-                    if stale_key is not None:
-                        self.id_from_redundancy_key.pop(stale_key, None)
+                assert purge_entity_id is not None
+                indexed_ids = self.ids_from_entity_state_key.get(
+                    (purge_entity_type, purge_entity_id)
+                )
+                if indexed_ids:
+                    stale_ids = [
+                        mid
+                        for mid in indexed_ids
+                        if self.message_from_id[mid].lifecycle_phase
+                        in ("update_dict", "update_simple")
+                    ]
+                    for mid in stale_ids:
+                        self.pop_message_locked(mid)
 
             new_message_id = self.message_counter
             self.message_from_id[new_message_id] = message
             self.message_counter += 1
+            entity_key = _entity_state_key(message)
+            if entity_key is not None:
+                self.ids_from_entity_state_key.setdefault(entity_key, set()).add(
+                    new_message_id
+                )
 
             # If an existing message with the same key already exists in our buffer, we
             # don't need the old one anymore. :-)
@@ -152,8 +236,8 @@ class AsyncMessageBuffer:
                 redundancy_key is not None
                 and redundancy_key in self.id_from_redundancy_key
             ):
-                old_message_id = self.id_from_redundancy_key.pop(redundancy_key)
-                self.message_from_id.pop(old_message_id)
+                old_message_id = self.id_from_redundancy_key[redundancy_key]
+                self.pop_message_locked(old_message_id)
             self.id_from_redundancy_key[redundancy_key] = new_message_id
 
             # Pulse message event to notify consumers that a new message is
@@ -287,10 +371,7 @@ class AsyncMessageBuffer:
                         # If we're not persisting messages, remove them from
                         # the buffer.
                         with self.buffer_lock:
-                            message = self.message_from_id.pop(last_sent_id, None)
-                            if message is not None:
-                                redundancy_key = message.redundancy_key()
-                                self.id_from_redundancy_key.pop(redundancy_key, None)
+                            message = self.pop_message_locked(last_sent_id)
 
                     if (
                         message is not None

--- a/src/viser/infra/_async_message_buffer.py
+++ b/src/viser/infra/_async_message_buffer.py
@@ -20,29 +20,6 @@ from typing import (
 from ._messages import Message
 
 
-def _entity_state_key(message: Message) -> Optional[Tuple[str, str]]:
-    """The (entity_type, entity_id) coordinates under which a message is
-    indexed in ``AsyncMessageBuffer.ids_from_entity_state_key``, or None for
-    messages that carry no per-entity state.
-
-    This is the materialized form of ``Message.targets_entity_state``: a
-    message is indexed under exactly the keys for which that predicate
-    returns True (update messages under their declared entity, phase-less
-    name-keyed messages under ``("scene", name)``). The two must never
-    disagree -- the index exists so per-entity purges don't scan the buffer,
-    not to redefine the taxonomy."""
-    phase = message.lifecycle_phase
-    if phase in ("update_dict", "update_simple"):
-        if message.entity_type is not None and message.entity_id_field is not None:
-            return (message.entity_type, getattr(message, message.entity_id_field))
-        return None
-    if phase is None:
-        name = getattr(message, "name", None)
-        if name is not None:
-            return ("scene", name)
-    return None
-
-
 @dataclasses.dataclass
 class AsyncMessageBuffer:
     """Async iterable for keeping a persistent buffer of messages.
@@ -60,11 +37,11 @@ class AsyncMessageBuffer:
     ids_from_entity_state_key: Dict[Tuple[str, str], Set[int]] = dataclasses.field(
         default_factory=dict
     )
-    """Buffered per-entity state messages, indexed by ``_entity_state_key``.
-    Keeps same-name replacement, remove-time update purges, and the GC sweep
-    O(per-entity messages) instead of O(buffer). Maintained under
-    ``buffer_lock`` by every path that inserts into or deletes from
-    ``message_from_id``."""
+    """Buffered per-entity state messages, indexed by
+    ``Message.entity_state_key()``. Keeps same-name replacement, remove-time
+    update purges, and the GC sweep O(per-entity messages) instead of
+    O(buffer). Maintained under ``buffer_lock`` by every path that inserts
+    into or deletes from ``message_from_id``."""
 
     buffer_lock: threading.Lock = dataclasses.field(default_factory=threading.Lock)
     """Lock to prevent race conditions when pushing messages from different threads."""
@@ -122,7 +99,7 @@ class AsyncMessageBuffer:
         redundancy_key = message.redundancy_key()
         if self.id_from_redundancy_key.get(redundancy_key) == message_id:
             del self.id_from_redundancy_key[redundancy_key]
-        entity_key = _entity_state_key(message)
+        entity_key = message.entity_state_key()
         if entity_key is not None:
             ids = self.ids_from_entity_state_key.get(entity_key)
             if ids is not None:
@@ -184,10 +161,9 @@ class AsyncMessageBuffer:
                 stacklevel=4,
             )
 
-        # Add message to buffer.
+        # Pre-compute per-message keys outside the lock.
         redundancy_key = message.redundancy_key()
-
-        # Pre-compute entity coordinates outside the lock.
+        entity_key = message.entity_state_key()
         purge_entity_type: str | None = None
         purge_entity_id: str | None = None
         if (
@@ -203,32 +179,27 @@ class AsyncMessageBuffer:
             # removed entity leaves no residue in the buffer. (Create+Remove
             # coalesce via the redundancy key below; Updates use a separate
             # namespace, so they need explicit purging.) Resolved through the
-            # entity-state index; only the update phases are purged here --
-            # phase-less name-keyed messages in the same index bucket are
-            # left for remove()'s own explicit empty-binding broadcasts.
+            # entity-state index; the phase-less name-keyed messages that
+            # share the bucket are left for remove()'s own explicit
+            # empty-binding broadcasts.
             if purge_entity_type is not None:
                 assert purge_entity_id is not None
                 indexed_ids = self.ids_from_entity_state_key.get(
                     (purge_entity_type, purge_entity_id)
                 )
                 if indexed_ids:
-                    stale_ids = [
-                        mid
-                        for mid in indexed_ids
-                        if self.message_from_id[mid].lifecycle_phase
-                        in ("update_dict", "update_simple")
-                    ]
-                    for mid in stale_ids:
-                        self.pop_message_locked(mid)
+                    for mid in tuple(indexed_ids):
+                        if self.message_from_id[mid].lifecycle_phase is not None:
+                            self.pop_message_locked(mid)
 
             new_message_id = self.message_counter
             self.message_from_id[new_message_id] = message
             self.message_counter += 1
-            entity_key = _entity_state_key(message)
             if entity_key is not None:
-                self.ids_from_entity_state_key.setdefault(entity_key, set()).add(
-                    new_message_id
-                )
+                ids = self.ids_from_entity_state_key.get(entity_key)
+                if ids is None:
+                    ids = self.ids_from_entity_state_key[entity_key] = set()
+                ids.add(new_message_id)
 
             # If an existing message with the same key already exists in our buffer, we
             # don't need the old one anymore. :-)

--- a/src/viser/infra/_messages.py
+++ b/src/viser/infra/_messages.py
@@ -219,25 +219,31 @@ class Message(abc.ABC):
     # the attribute without static errors.
     include_in_scene_serialization: ClassVar[bool]
 
+    def entity_state_key(self) -> Optional[Tuple[str, str]]:
+        """The (entity_type, entity_id) this message carries PER-ENTITY state
+        for, or None for messages that carry none: update messages
+        (``update_dict``/``update_simple``) key to their declared entity;
+        phase-less messages carrying a ``name`` key to ``("scene", name)``
+        (name-keyed adjacency exists only for SCENE nodes -- interaction
+        bindings etc.; other entity families key by uuid fields that never
+        collide with a scene name). The ONE definition of this taxonomy: the
+        buffer's entity-state index, the same-name-replacement purge, and the
+        connect-time garbage collector's sweep all resolve through it."""
+        phase = self.lifecycle_phase
+        if phase in ("update_dict", "update_simple"):
+            if self.entity_type is not None and self.entity_id_field is not None:
+                return (self.entity_type, getattr(self, self.entity_id_field))
+            return None
+        if phase is None:
+            name = getattr(self, "name", None)
+            if name is not None:
+                return ("scene", name)
+        return None
+
     def targets_entity_state(self, entity_type: str, entity_id: str) -> bool:
-        """True for messages that carry PER-ENTITY state for the given entity:
-        update messages declared against it (``update_dict``/``update_simple``
-        with a matching entity id), plus phase-less name-keyed messages whose
-        ``name`` matches (e.g. scene interaction-binding messages). The ONE
-        definition of this taxonomy -- the same-name-replacement purge and the
-        connect-time garbage collector's sweep must never disagree on it."""
-        if self.lifecycle_phase in ("update_dict", "update_simple"):
-            return (
-                self.entity_type == entity_type
-                and self.entity_id_field is not None
-                and getattr(self, self.entity_id_field, None) == entity_id
-            )
-        if self.lifecycle_phase is None:
-            # Name-keyed adjacency exists only for SCENE nodes (interaction
-            # bindings etc.); other entity families key by uuid fields that
-            # never collide with a scene name.
-            return entity_type == "scene" and getattr(self, "name", None) == entity_id
-        return False
+        """True when this message carries per-entity state for the given
+        entity; the predicate form of :meth:`entity_state_key`."""
+        return self.entity_state_key() == (entity_type, entity_id)
 
     def as_serializable_dict(
         self, binary_buffers: Optional[List[memoryview]] = None

--- a/tests/e2e/test_canvas_stability.py
+++ b/tests/e2e/test_canvas_stability.py
@@ -1,0 +1,109 @@
+"""E2E tests for canvas/camera stability under layout and bound changes.
+
+1. Crossing the mobile breakpoint must NOT remount the WebGL canvas or reset
+   the camera: the dock surface now stays mounted as a passthrough container
+   and toggles its panes instead of swapping the element wrapping the canvas
+   (regression: rotating a phone or resizing across ~576px recreated the
+   WebGL context and snapped the camera to its initial pose).
+
+2. A camera legitimately placed beyond the configured max orbit distance
+   (large-coordinate scenes under the 1e4 default) must not be TELEPORTED to
+   the bound by the first scroll tick: the effective bound ratchets to the
+   current distance while outside the configured one.
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+from playwright.sync_api import Page
+
+import viser
+
+
+def _wait_for(predicate, timeout: float = 5.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def _sole_client(server: viser.ViserServer) -> viser.ClientHandle:
+    assert _wait_for(lambda: len(server.get_clients()) == 1)
+    return next(iter(server.get_clients().values()))
+
+
+def test_mobile_breakpoint_crossing_preserves_canvas_and_camera(
+    viser_server: viser.ViserServer,
+    viser_page: Page,
+) -> None:
+    viser_server.scene.add_box("/box", dimensions=(1, 1, 1), color=(255, 0, 0))
+    client = _sole_client(viser_server)
+
+    # Move the camera off its initial pose, and wait for the client echo.
+    client.camera.position = (3.0, 3.0, 3.0)
+    client.camera.look_at = (0.0, 0.0, 0.0)
+    assert _wait_for(
+        lambda: np.allclose(client.camera.position, (3.0, 3.0, 3.0), atol=0.3)
+    )
+
+    viser_page.evaluate("window.__canvasBefore = document.querySelector('canvas')")
+
+    # Cross to mobile and back (phone rotation / window resize).
+    viser_page.set_viewport_size({"width": 390, "height": 844})
+    viser_page.wait_for_timeout(700)
+    viser_page.set_viewport_size({"width": 1280, "height": 720})
+    viser_page.wait_for_timeout(700)
+
+    assert viser_page.evaluate(
+        "window.__canvasBefore === document.querySelector('canvas')"
+    ), "canvas element was remounted across the mobile breakpoint"
+    assert np.allclose(client.camera.position, (3.0, 3.0, 3.0), atol=0.5), (
+        f"camera reset across the breakpoint: {client.camera.position}"
+    )
+
+
+def test_camera_beyond_max_orbit_distance_does_not_snap_on_scroll(
+    viser_server: viser.ViserServer,
+    viser_page: Page,
+) -> None:
+    viser_server.scene.add_box("/box", dimensions=(1, 1, 1), color=(255, 0, 0))
+    client = _sole_client(viser_server)
+
+    # Park the camera far beyond the 1e4 default bound, as a large-coordinate
+    # scene would.
+    far = 5.0e4
+    client.camera.position = (0.0, far, far)
+    client.camera.look_at = (0.0, 0.0, 0.0)
+    start_dist = float(np.linalg.norm(np.array([0.0, far, far])))
+    assert _wait_for(
+        lambda: (
+            abs(float(np.linalg.norm(client.camera.position)) - start_dist)
+            < start_dist * 0.05
+        )
+    )
+
+    # One scroll tick inward. Pre-fix this teleported to distance 1e4.
+    viser_page.mouse.move(640, 360)
+    viser_page.mouse.wheel(0, -120)
+    viser_page.wait_for_timeout(800)
+
+    dist = float(np.linalg.norm(client.camera.position))
+    assert dist < start_dist, "scroll-in did not move the camera"
+    assert dist > start_dist * 0.5, (
+        f"camera teleported toward the max-orbit bound: {dist:.0f} "
+        f"(started at {start_dist:.0f})"
+    )
+
+    # Scrolling outward must still be blocked at the ratcheted bound: the
+    # camera cannot walk further out than where the server parked it.
+    before_out = float(np.linalg.norm(client.camera.position))
+    viser_page.mouse.wheel(0, 120)
+    viser_page.wait_for_timeout(800)
+    after_out = float(np.linalg.norm(client.camera.position))
+    assert after_out <= before_out * 1.05, (
+        f"zoom-out escaped the ratcheted bound: {after_out:.0f} from {before_out:.0f}"
+    )

--- a/tests/e2e/test_slider_precision.py
+++ b/tests/e2e/test_slider_precision.py
@@ -1,0 +1,53 @@
+"""E2E tests for the slider number box's display precision.
+
+Complement to ``test_bug_slider_precision.py`` (integer sliders must not emit
+fractional values): precision is fed by the server-computed ``precision``
+prop, which must cover the slider's VALUE GRID (``min + k * step``, clamped
+to ``max``), not just ``step``. Regression: with ``min=0.5, step=1.0`` every
+legal value ends in .5, but a step-derived precision of 0 displayed 2.5 as
+"3" and swallowed the "." keystroke, so exact values could not be typed.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+import viser
+
+from .utils import find_gui_input
+
+
+def test_offgrid_slider_displays_and_accepts_exact_values(
+    viser_server: viser.ViserServer,
+    viser_page: Page,
+) -> None:
+    handle = viser_server.gui.add_slider(
+        "frac", min=0.5, max=9.5, step=1.0, initial_value=2.5
+    )
+
+    box = find_gui_input(viser_page, "frac")
+    box.wait_for(state="visible", timeout=5_000)
+    # The initial value must DISPLAY exactly (regression: showed "3").
+    expect(box).to_have_value("2.5", timeout=5_000)
+
+    # Typing an exact on-grid value must be accepted (regression: rejected
+    # decimals) and must round-trip to the server.
+    box.click()
+    box.press("Control+a")
+    box.fill("4.5")
+    box.press("Enter")
+    expect(box).to_have_value("4.5")
+    viser_page.wait_for_timeout(400)
+    assert handle.value == 4.5, f"server value is {handle.value}, expected 4.5"
+
+
+def test_integer_slider_box_stays_integer_display(
+    viser_server: viser.ViserServer,
+    viser_page: Page,
+) -> None:
+    """Integer grids keep precision 0: whole-number display, and (per the
+    sibling test) fractional input stays rejected."""
+    viser_server.gui.add_slider("int", min=0, max=10, step=1, initial_value=5)
+    box = find_gui_input(viser_page, "int")
+    box.wait_for(state="visible", timeout=5_000)
+    expect(box).to_have_value("5", timeout=5_000)

--- a/tests/infra_utils.py
+++ b/tests/infra_utils.py
@@ -43,3 +43,15 @@ def make_synthetic_client(server: viser.ViserServer, client_id: int) -> ClientHa
         client_id, _ClientHandleState(buffer, server._event_loop)
     )
     return ClientHandle(conn, server)
+
+
+def assert_entity_index_consistent(buffer: AsyncMessageBuffer) -> None:
+    """The buffer's entity-state index must be exactly the index recomputed
+    from its contents via ``Message.entity_state_key()`` -- no stale ids, no
+    missing ids, no empty buckets."""
+    expected: dict = {}
+    for mid, message in buffer.message_from_id.items():
+        key = message.entity_state_key()
+        if key is not None:
+            expected.setdefault(key, set()).add(mid)
+    assert buffer.ids_from_entity_state_key == expected

--- a/tests/test_entity_lifecycle_contracts.py
+++ b/tests/test_entity_lifecycle_contracts.py
@@ -326,36 +326,31 @@ def test_same_name_readd_purges_stale_state_only() -> None:
     the buffer's entity-state index; the sibling invariant tests in
     test_message_buffer.py pin the index itself, this pins the end-to-end
     replacement path."""
-    from .test_message_buffer import _assert_entity_index_consistent
+    from .infra_utils import assert_entity_index_consistent, broadcast_messages
+    from .utils import viser_server
 
-    server = viser.ViserServer()
-    buf = server._websock_server._broadcast_buffer
+    with viser_server() as server:
+        bystander = server.scene.add_frame("/bystander")
+        bystander.position = (7.0, 8.0, 9.0)
 
-    bystander = server.scene.add_frame("/bystander")
-    bystander.position = (7.0, 8.0, 9.0)
+        target = server.scene.add_frame("/target")
+        target.position = (9.0, 9.0, 9.0)
+        server.scene.add_frame("/target")  # Same-name replacement.
 
-    target = server.scene.add_frame("/target")
-    target.position = (9.0, 9.0, 9.0)
-    server.scene.add_frame("/target")  # Same-name replacement.
+        def positions_for(name: str) -> list:
+            return [
+                m.position
+                for m in broadcast_messages(server)
+                if isinstance(m, SetPositionMessage) and m.name == name
+            ]
 
-    target_positions = [
-        m.position
-        for m in buf.message_from_id.values()
-        if isinstance(m, SetPositionMessage) and m.name == "/target"
-    ]
-    # The old pose is purged; what remains is the replacement's forced
-    # default-pose broadcast (which live clients need, since they keep node
-    # state across same-name creates).
-    assert target_positions == [(0.0, 0.0, 0.0)]
+        # The old pose is purged; what remains is the replacement's forced
+        # default-pose broadcast (which live clients need, since they keep
+        # node state across same-name creates).
+        assert positions_for("/target") == [(0.0, 0.0, 0.0)]
+        assert positions_for("/bystander") == [(7.0, 8.0, 9.0)]
 
-    bystander_positions = [
-        m.position
-        for m in buf.message_from_id.values()
-        if isinstance(m, SetPositionMessage) and m.name == "/bystander"
-    ]
-    assert bystander_positions == [(7.0, 8.0, 9.0)]
-
-    _assert_entity_index_consistent(buf)
+        assert_entity_index_consistent(server._websock_server._broadcast_buffer)
 
 
 @patch.object(viser._client_autobuild, "ensure_client_is_built", lambda: None)

--- a/tests/test_entity_lifecycle_contracts.py
+++ b/tests/test_entity_lifecycle_contracts.py
@@ -299,18 +299,23 @@ def test_gc_two_pass_purges_update_buffered_after_tombstone() -> None:
     # Wipe any startup traffic so we control the ordering exactly.
     buf.message_from_id.clear()
     buf.id_from_redundancy_key.clear()
+    buf.ids_from_entity_state_key.clear()
 
     remove = RemoveSceneNodeMessage(name="/ghost")
     update = SceneNodeUpdateMessage(name="/ghost", updates={"visible": False})
-    # Remove at low id, Update at high id -- the reorder scenario.
-    buf.message_from_id[10] = remove
-    buf.id_from_redundancy_key[remove.redundancy_key()] = 10
-    buf.message_from_id[20] = update
-    buf.id_from_redundancy_key[update.redundancy_key()] = 20
+    # Remove first, Update after: the update lands at a HIGHER id than the
+    # tombstone -- exactly the ordering push()'s remove-time purge cannot
+    # see. Pushed through the real write path so the buffer's entity-state
+    # index (which the GC's second pass consults) is populated.
+    buf.push(remove)
+    buf.push(update)
+    remove_id = next(mid for mid, m in buf.message_from_id.items() if m is remove)
+    update_id = next(mid for mid, m in buf.message_from_id.items() if m is update)
+    assert remove_id < update_id
 
     server._run_garbage_collector(force=True)
-    assert 10 not in buf.message_from_id, "tombstone not purged"
-    assert 20 not in buf.message_from_id, "late update survived tombstone"
+    assert remove_id not in buf.message_from_id, "tombstone not purged"
+    assert update_id not in buf.message_from_id, "late update survived tombstone"
 
 
 @patch.object(viser._client_autobuild, "ensure_client_is_built", lambda: None)

--- a/tests/test_entity_lifecycle_contracts.py
+++ b/tests/test_entity_lifecycle_contracts.py
@@ -319,6 +319,46 @@ def test_gc_two_pass_purges_update_buffered_after_tombstone() -> None:
 
 
 @patch.object(viser._client_autobuild, "ensure_client_is_built", lambda: None)
+def test_same_name_readd_purges_stale_state_only() -> None:
+    """Same-name replacement purges the OLD node's buffered per-entity state
+    (a late joiner must never apply the old pose to the new node) while
+    leaving other nodes' buffered state untouched. The purge goes through
+    the buffer's entity-state index; the sibling invariant tests in
+    test_message_buffer.py pin the index itself, this pins the end-to-end
+    replacement path."""
+    from .test_message_buffer import _assert_entity_index_consistent
+
+    server = viser.ViserServer()
+    buf = server._websock_server._broadcast_buffer
+
+    bystander = server.scene.add_frame("/bystander")
+    bystander.position = (7.0, 8.0, 9.0)
+
+    target = server.scene.add_frame("/target")
+    target.position = (9.0, 9.0, 9.0)
+    server.scene.add_frame("/target")  # Same-name replacement.
+
+    target_positions = [
+        m.position
+        for m in buf.message_from_id.values()
+        if isinstance(m, SetPositionMessage) and m.name == "/target"
+    ]
+    # The old pose is purged; what remains is the replacement's forced
+    # default-pose broadcast (which live clients need, since they keep node
+    # state across same-name creates).
+    assert target_positions == [(0.0, 0.0, 0.0)]
+
+    bystander_positions = [
+        m.position
+        for m in buf.message_from_id.values()
+        if isinstance(m, SetPositionMessage) and m.name == "/bystander"
+    ]
+    assert bystander_positions == [(7.0, 8.0, 9.0)]
+
+    _assert_entity_index_consistent(buf)
+
+
+@patch.object(viser._client_autobuild, "ensure_client_is_built", lambda: None)
 def test_gc_purges_set_position_after_scene_remove() -> None:
     """Scene-node pose ``Set*Message`` variants (declared ``update_simple``)
     must be purged when their target scene node has a tombstone, so a reused

--- a/tests/test_gui_validation.py
+++ b/tests/test_gui_validation.py
@@ -129,3 +129,30 @@ def test_slider_precision_covers_value_grid() -> None:
             "f", min=0.5, max=9.5, step=1.0, initial_value=(1.5, 2.5)
         )
         assert precision_of(m) == 1
+
+
+@patch.object(viser._client_autobuild, "ensure_client_is_built", lambda: None)
+def test_number_and_vector_precision_covers_creation_values() -> None:
+    """Number/vector inputs aren't grid-bound, so display precision must
+    also cover the creation-time value and bounds when an explicit step is
+    coarser than them: add_number(initial_value=0.25, step=0.5) displayed
+    the value as "0.2"."""
+    with viser_server() as server:
+
+        def precision_of(handle) -> int:
+            return handle._impl.props.precision
+
+        n = server.gui.add_number("a", initial_value=0.25, step=0.5)
+        assert precision_of(n) == 2
+        # Auto-computed step already covers value/bounds; stays tight.
+        n = server.gui.add_number("b", initial_value=2)
+        assert precision_of(n) == 0
+        n = server.gui.add_number("c", initial_value=1.0, min=0.05, step=1.0)
+        assert precision_of(n) == 2
+
+        v = server.gui.add_vector2("d", initial_value=(0.25, 1.0), step=0.5)
+        assert precision_of(v) == 2
+        v = server.gui.add_vector3(
+            "e", initial_value=(1.0, 2.0, 3.0), min=(0.125, 0.0, 0.0), step=0.5
+        )
+        assert precision_of(v) == 3

--- a/tests/test_gui_validation.py
+++ b/tests/test_gui_validation.py
@@ -14,6 +14,8 @@ import pytest
 import viser
 import viser._client_autobuild
 
+from .utils import viser_server
+
 
 @patch.object(viser._client_autobuild, "ensure_client_is_built", lambda: None)
 def test_add_dropdown_rejects_empty_options() -> None:
@@ -45,51 +47,51 @@ def test_folder_context_rejects_overlapping_entry() -> None:
     second enter -- self-nesting or a concurrent enter from another thread --
     raises instead of corrupting the first block's restore slot. Sequential
     re-entry stays legal."""
-    server = viser.ViserServer()
-    folder = server.gui.add_folder("F")
+    with viser_server() as server:
+        folder = server.gui.add_folder("F")
 
-    # Self-nesting.
-    with folder:
-        with pytest.raises(RuntimeError, match="one active"):
-            with folder:
-                pass
-
-    # Concurrent entry from another thread while the block is held open.
-    entered = threading.Event()
-    release = threading.Event()
-
-    def hold_open() -> None:
+        # Self-nesting.
         with folder:
-            entered.set()
-            release.wait(timeout=5.0)
+            with pytest.raises(RuntimeError, match="one active"):
+                with folder:
+                    pass
 
-    thread = threading.Thread(target=hold_open)
-    thread.start()
-    try:
-        assert entered.wait(timeout=5.0)
-        with pytest.raises(RuntimeError, match="another thread"):
+        # Concurrent entry from another thread while the block is held open.
+        entered = threading.Event()
+        release = threading.Event()
+
+        def hold_open() -> None:
             with folder:
-                pass
-    finally:
-        release.set()
-        thread.join(timeout=5.0)
-    assert not thread.is_alive()
+                entered.set()
+                release.wait(timeout=5.0)
 
-    # Sequential re-entry after both blocks closed works, and elements land
-    # in the folder.
-    with folder:
-        button = server.gui.add_button("ok")
-    assert button._impl.parent_container_id == folder._impl.uuid
+        thread = threading.Thread(target=hold_open)
+        thread.start()
+        try:
+            assert entered.wait(timeout=5.0)
+            with pytest.raises(RuntimeError, match="another thread"):
+                with folder:
+                    pass
+        finally:
+            release.set()
+            thread.join(timeout=5.0)
+        assert not thread.is_alive()
+
+        # Sequential re-entry after both blocks closed works, and elements
+        # land in the folder.
+        with folder:
+            button = server.gui.add_button("ok")
+        assert button._impl.parent_container_id == folder._impl.uuid
 
 
 @patch.object(viser._client_autobuild, "ensure_client_is_built", lambda: None)
 def test_tab_context_rejects_overlapping_entry() -> None:
     """Same overlapping-entry contract for tab handles."""
-    server = viser.ViserServer()
-    tab = server.gui.add_tab_group().add_tab("T")
-    with tab:
-        with pytest.raises(RuntimeError, match="one active"):
-            with tab:
-                pass
-    with tab:  # Sequential re-entry is fine.
-        server.gui.add_button("ok")
+    with viser_server() as server:
+        tab = server.gui.add_tab_group().add_tab("T")
+        with tab:
+            with pytest.raises(RuntimeError, match="one active"):
+                with tab:
+                    pass
+        with tab:  # Sequential re-entry is fine.
+            server.gui.add_button("ok")

--- a/tests/test_gui_validation.py
+++ b/tests/test_gui_validation.py
@@ -2,8 +2,11 @@
 
 Empty options previously produced a raw ``IndexError`` from ``options[0]``;
 these now raise a descriptive ``ValueError``.
+
+Also: container-context misuse (overlapping ``with`` blocks on one handle).
 """
 
+import threading
 from unittest.mock import patch
 
 import pytest
@@ -34,3 +37,59 @@ def test_dropdown_options_setter_rejects_empty() -> None:
         dropdown.options = []
     # The prior (valid) options should be untouched after the rejected assignment.
     assert dropdown.options == ("a", "b")
+
+
+@patch.object(viser._client_autobuild, "ensure_client_is_built", lambda: None)
+def test_folder_context_rejects_overlapping_entry() -> None:
+    """A container handle supports one active ``with`` block at a time: a
+    second enter -- self-nesting or a concurrent enter from another thread --
+    raises instead of corrupting the first block's restore slot. Sequential
+    re-entry stays legal."""
+    server = viser.ViserServer()
+    folder = server.gui.add_folder("F")
+
+    # Self-nesting.
+    with folder:
+        with pytest.raises(RuntimeError, match="one active"):
+            with folder:
+                pass
+
+    # Concurrent entry from another thread while the block is held open.
+    entered = threading.Event()
+    release = threading.Event()
+
+    def hold_open() -> None:
+        with folder:
+            entered.set()
+            release.wait(timeout=5.0)
+
+    thread = threading.Thread(target=hold_open)
+    thread.start()
+    try:
+        assert entered.wait(timeout=5.0)
+        with pytest.raises(RuntimeError, match="another thread"):
+            with folder:
+                pass
+    finally:
+        release.set()
+        thread.join(timeout=5.0)
+    assert not thread.is_alive()
+
+    # Sequential re-entry after both blocks closed works, and elements land
+    # in the folder.
+    with folder:
+        button = server.gui.add_button("ok")
+    assert button._impl.parent_container_id == folder._impl.uuid
+
+
+@patch.object(viser._client_autobuild, "ensure_client_is_built", lambda: None)
+def test_tab_context_rejects_overlapping_entry() -> None:
+    """Same overlapping-entry contract for tab handles."""
+    server = viser.ViserServer()
+    tab = server.gui.add_tab_group().add_tab("T")
+    with tab:
+        with pytest.raises(RuntimeError, match="one active"):
+            with tab:
+                pass
+    with tab:  # Sequential re-entry is fine.
+        server.gui.add_button("ok")

--- a/tests/test_gui_validation.py
+++ b/tests/test_gui_validation.py
@@ -95,3 +95,37 @@ def test_tab_context_rejects_overlapping_entry() -> None:
                     pass
         with tab:  # Sequential re-entry is fine.
             server.gui.add_button("ok")
+
+
+@patch.object(viser._client_autobuild, "ensure_client_is_built", lambda: None)
+def test_slider_precision_covers_value_grid() -> None:
+    """Slider display precision must cover the value grid min + k*step (and
+    the clamped max), not just the step: with min=0.5, step=1.0 every legal
+    value ends in .5, and step-derived precision of 0 made the client's
+    number box display 2.5 as "3" and reject typed decimals."""
+    with viser_server() as server:
+
+        def precision_of(handle) -> int:
+            return handle._impl.props.precision
+
+        # Off-grid min: the original regression.
+        s = server.gui.add_slider("a", min=0.5, max=9.5, step=1.0, initial_value=2.5)
+        assert precision_of(s) == 1
+        # Integer grid stays integer (no float-noise regression).
+        s = server.gui.add_slider("b", min=0, max=10, step=1, initial_value=5)
+        assert precision_of(s) == 0
+        # Step finer than min/max.
+        s = server.gui.add_slider("c", min=0, max=1, step=0.01, initial_value=0.5)
+        assert precision_of(s) == 2
+        # Fractional min finer than step.
+        s = server.gui.add_slider("d", min=0.05, max=1.05, step=0.1, initial_value=0.05)
+        assert precision_of(s) == 2
+        # Off-grid max is a legal (clamped) value.
+        s = server.gui.add_slider("e", min=0, max=9.5, step=1, initial_value=0)
+        assert precision_of(s) == 1
+
+        # Multi-slider uses the same rule.
+        m = server.gui.add_multi_slider(
+            "f", min=0.5, max=9.5, step=1.0, initial_value=(1.5, 2.5)
+        )
+        assert precision_of(m) == 1

--- a/tests/test_handle_lifecycle_bugs.py
+++ b/tests/test_handle_lifecycle_bugs.py
@@ -974,9 +974,12 @@ def test_numpy_bool_serializes() -> None:
 
 
 def test_camera_update_rejects_degenerate_basis() -> None:
-    """A degenerate camera basis (zero look distance, or up parallel to the
-    view direction) raises instead of storing a NaN quaternion that every
-    later camera read and on_update callback would silently see."""
+    """Garbage camera input (zero look distance, zero up vector, non-finite
+    values) raises instead of storing a NaN quaternion that every later
+    camera read and on_update callback would silently see. An up vector
+    PARALLEL to the view direction, however, is a legitimate pose (the
+    canonical top-down camera with default +Z up) and must degrade to a
+    finite basis like the client's pole clamp, not raise."""
     from viser._viser import CameraHandle, _CameraHandleState
 
     ch = CameraHandle.__new__(CameraHandle)
@@ -1000,6 +1003,9 @@ def test_camera_update_rejects_degenerate_basis() -> None:
         ch._update_wxyz()
     ch._state.look_at = np.array([2.0, 0.0, 0.0])
     ch._state.up_direction = np.array([1.0, 0.0, 0.0])  # parallel to view
+    ch._update_wxyz()  # Degrades (even from the zeroed wxyz state), no raise.
+    assert np.all(np.isfinite(ch._state.wxyz))
+    ch._state.up_direction = np.zeros(3)
     with pytest.raises(ValueError, match="up_direction must be nonzero"):
         ch._update_wxyz()
     ch._state.up_direction = np.array([0.0, 0.0, 1.0])
@@ -1501,3 +1507,39 @@ def test_writes_after_stop_do_not_raise() -> None:
     with server.atomic():  # atomic_end() wake-up path
         f.position = (4.0, 5.0, 6.0)
     server.flush()  # flush() wake-up path
+
+
+def test_camera_topdown_pose_succeeds_and_sends_messages() -> None:
+    """The canonical top-down setup -- position above the target, look_at
+    straight down, default +Z up -- must apply cleanly: pre-1.1 this worked
+    (the client's orbit controls clamp the pole), and rejecting it broke
+    existing bird's-eye camera code, silently when inside exception-isolated
+    on_client_connect callbacks."""
+    from viser._viser import CameraHandle
+
+    sent: list[str] = []
+
+    class _Conn:
+        def queue_message(self, message) -> None:
+            sent.append(type(message).__name__)
+
+    class _Client:
+        _websock_connection = _Conn()
+
+    ch = CameraHandle(_Client())  # type: ignore[arg-type]
+    s = ch._state
+    s.position = np.array([2.0, 2.0, 2.0])
+    s.look_at = np.array([0.0, 0.0, 0.0])
+    s.up_direction = np.array([0.0, 0.0, 1.0])
+    s.wxyz = np.array([1.0, 0.0, 0.0, 0.0])
+    s.update_timestamp = 1.0
+
+    ch.position = (0.0, 0.0, 5.0)
+    ch.look_at = (0.0, 0.0, 0.0)
+
+    assert np.all(np.isfinite(s.wxyz))
+    assert np.allclose(s.position, [0.0, 0.0, 5.0])
+    assert np.allclose(s.look_at, [0.0, 0.0, 0.0])
+    # Both axes reached the wire; nothing was rolled back half-way.
+    assert "SetCameraPositionMessage" in sent
+    assert "SetCameraLookAtMessage" in sent

--- a/tests/test_line_width_deprecation.py
+++ b/tests/test_line_width_deprecation.py
@@ -130,3 +130,47 @@ def test_unknown_kwargs_still_rejected(server: viser.ViserServer) -> None:
             colors=(255, 0, 0),
             line_widht=3.0,  # type: ignore
         )
+
+
+_ARROW_POINTS = np.array([[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]])
+
+
+def test_add_arrows_line_width_warns_and_is_ignored(
+    server: viser.ViserServer,
+) -> None:
+    """Arrows have no thickness equivalent (the old prop only fed a client
+    fallback rendering path that no longer exists), so the deprecated kwarg
+    is accepted with a warning rather than raising TypeError like an unknown
+    kwarg would."""
+    with pytest.warns(DeprecationWarning, match="line_width"):
+        handle = server.scene.add_arrows(
+            "/arrows",
+            points=_ARROW_POINTS,
+            colors=(255, 0, 0),
+            line_width=2.0,  # pyright: ignore[reportArgumentType]
+        )
+    assert handle.name == "/arrows"
+
+
+def test_arrows_handle_line_width_alias_warns_and_noops(
+    server: viser.ViserServer,
+) -> None:
+    handle = server.scene.add_arrows(
+        "/arrows2", points=_ARROW_POINTS, colors=(255, 0, 0)
+    )
+    with pytest.warns(DeprecationWarning, match="no effect"):
+        handle.line_width = 3.0
+    with pytest.warns(DeprecationWarning, match="no effect"):
+        assert handle.line_width == 1.0
+
+
+def test_add_arrows_unknown_kwargs_still_rejected(
+    server: viser.ViserServer,
+) -> None:
+    with pytest.raises(TypeError, match="Unexpected keyword"):
+        server.scene.add_arrows(
+            "/arrows3",
+            points=_ARROW_POINTS,
+            colors=(255, 0, 0),
+            line_widht=3.0,  # type: ignore
+        )

--- a/tests/test_line_width_deprecation.py
+++ b/tests/test_line_width_deprecation.py
@@ -105,6 +105,23 @@ def test_handle_line_width_alias(server: viser.ViserServer) -> None:
     assert handle.thickness == 0.07
 
 
+def test_handle_line_width_setter_forces_screen_units(
+    server: viser.ViserServer,
+) -> None:
+    """Assigning the deprecated alias keeps its historical pixel meaning:
+    even on a handle created with world-space thickness, the setter pins
+    thickness_units to "screen" so a v1.0.x "3 px" intent doesn't become 3
+    world units."""
+    handle = server.scene.add_line_segments(
+        "/segments-world", points=_SEGMENT_POINTS, colors=(255, 0, 0)
+    )
+    assert handle.thickness_units == "world"
+    with pytest.warns(DeprecationWarning, match="screen"):
+        handle.line_width = 3.0
+    assert handle.thickness == 3.0
+    assert handle.thickness_units == "screen"
+
+
 def test_unknown_kwargs_still_rejected(server: viser.ViserServer) -> None:
     with pytest.raises(TypeError, match="Unexpected keyword"):
         server.scene.add_line_segments(

--- a/tests/test_message_buffer.py
+++ b/tests/test_message_buffer.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from typing import Dict, Generator, Set, Tuple
+from typing import Generator
 
 from viser import _messages as vm
-from viser.infra._async_message_buffer import AsyncMessageBuffer, _entity_state_key
+from viser.infra._async_message_buffer import AsyncMessageBuffer
 
+from .infra_utils import assert_entity_index_consistent
 from .thread_isolation import run_isolated
 
 
@@ -64,25 +65,6 @@ def _sync_buffer() -> Generator[AsyncMessageBuffer, None, None]:
         loop.close()
 
 
-def _assert_entity_index_consistent(buffer: AsyncMessageBuffer) -> None:
-    """The entity-state index must be exactly the index recomputed from the
-    buffer's contents -- no stale ids, no missing ids, no empty buckets --
-    and bucket membership must agree with ``Message.targets_entity_state``,
-    the taxonomy the index materializes."""
-    expected: Dict[Tuple[str, str], Set[int]] = {}
-    for mid, message in buffer.message_from_id.items():
-        key = _entity_state_key(message)
-        if key is not None:
-            expected.setdefault(key, set()).add(mid)
-    assert buffer.ids_from_entity_state_key == expected
-
-    probes = set(buffer.ids_from_entity_state_key) | {("scene", "/never-added")}
-    for probe in probes:
-        for mid, message in buffer.message_from_id.items():
-            in_bucket = mid in buffer.ids_from_entity_state_key.get(probe, set())
-            assert in_bucket == message.targets_entity_state(*probe)
-
-
 def _frame_message(name: str) -> vm.FrameMessage:
     return vm.FrameMessage(
         name=name,
@@ -107,17 +89,17 @@ def test_entity_state_index_tracks_buffer_mutations() -> None:
         buffer.push(vm.SetSceneNodeClickBindingsMessage("/a", bindings=()))
         buffer.push(_frame_message("/b"))
         buffer.push(vm.SetPositionMessage("/b", (0.0, 1.0, 0.0)))
-        _assert_entity_index_consistent(buffer)
+        assert_entity_index_consistent(buffer)
 
         # Redundancy replacement: a second position update for /a supersedes
         # the first in-place; the index must drop the replaced id.
         buffer.push(vm.SetPositionMessage("/a", (2.0, 0.0, 0.0)))
-        _assert_entity_index_consistent(buffer)
+        assert_entity_index_consistent(buffer)
         assert len(buffer.ids_from_entity_state_key[("scene", "/a")]) == 3
 
         # Remove-phase push purges /a's pending updates (but not bindings).
         buffer.push(vm.RemoveSceneNodeMessage("/a"))
-        _assert_entity_index_consistent(buffer)
+        assert_entity_index_consistent(buffer)
 
         # Predicate-based removal keeps the index consistent too.
         buffer.remove_from_buffer(
@@ -126,7 +108,7 @@ def test_entity_state_index_tracks_buffer_mutations() -> None:
                 and m.lifecycle_phase == "update_simple"
             )
         )
-        _assert_entity_index_consistent(buffer)
+        assert_entity_index_consistent(buffer)
 
 
 def test_remove_entity_state_matches_predicate_purge() -> None:
@@ -154,7 +136,7 @@ def test_remove_entity_state_matches_predicate_purge() -> None:
         buffer.remove_entity_state_from_buffer("scene", "/a")
 
         assert before - set(buffer.message_from_id) == expected_removed
-        _assert_entity_index_consistent(buffer)
+        assert_entity_index_consistent(buffer)
         # /a's create and /b's messages survive.
         survivors = {type(m).__name__ for m in buffer.message_from_id.values()}
         assert "FrameMessage" in survivors
@@ -165,7 +147,7 @@ def test_remove_entity_state_matches_predicate_purge() -> None:
 
         # Purging an entity with no state is a no-op.
         buffer.remove_entity_state_from_buffer("scene", "/never-added")
-        _assert_entity_index_consistent(buffer)
+        assert_entity_index_consistent(buffer)
 
 
 def test_remove_phase_push_purges_updates_but_not_bindings() -> None:
@@ -183,4 +165,4 @@ def test_remove_phase_push_purges_updates_but_not_bindings() -> None:
         assert "SetPositionMessage" not in kinds
         assert "SetSceneNodeClickBindingsMessage" in kinds
         assert "RemoveSceneNodeMessage" in kinds
-        _assert_entity_index_consistent(buffer)
+        assert_entity_index_consistent(buffer)

--- a/tests/test_message_buffer.py
+++ b/tests/test_message_buffer.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+from typing import Dict, Generator, Set, Tuple
 
 from viser import _messages as vm
-from viser.infra._async_message_buffer import AsyncMessageBuffer
+from viser.infra._async_message_buffer import AsyncMessageBuffer, _entity_state_key
 
 from .thread_isolation import run_isolated
 
@@ -49,3 +51,136 @@ def test_replay_marker_precedes_live_messages() -> None:
 # test_disconnect_releases_gc_cursor_promptly moved to
 # tests/e2e/test_broadcast_gc_disconnect.py: it drives a real browser, which
 # the browserless `build` CI job (pytest --ignore=tests/e2e) can't run.
+
+
+@contextlib.contextmanager
+def _sync_buffer() -> Generator[AsyncMessageBuffer, None, None]:
+    """A buffer usable from synchronous test code: push() only schedules
+    wakeups on the (never-run) loop, so a fresh non-running loop suffices."""
+    loop = asyncio.new_event_loop()
+    try:
+        yield AsyncMessageBuffer(loop, persistent_messages=True)
+    finally:
+        loop.close()
+
+
+def _assert_entity_index_consistent(buffer: AsyncMessageBuffer) -> None:
+    """The entity-state index must be exactly the index recomputed from the
+    buffer's contents -- no stale ids, no missing ids, no empty buckets --
+    and bucket membership must agree with ``Message.targets_entity_state``,
+    the taxonomy the index materializes."""
+    expected: Dict[Tuple[str, str], Set[int]] = {}
+    for mid, message in buffer.message_from_id.items():
+        key = _entity_state_key(message)
+        if key is not None:
+            expected.setdefault(key, set()).add(mid)
+    assert buffer.ids_from_entity_state_key == expected
+
+    probes = set(buffer.ids_from_entity_state_key) | {("scene", "/never-added")}
+    for probe in probes:
+        for mid, message in buffer.message_from_id.items():
+            in_bucket = mid in buffer.ids_from_entity_state_key.get(probe, set())
+            assert in_bucket == message.targets_entity_state(*probe)
+
+
+def _frame_message(name: str) -> vm.FrameMessage:
+    return vm.FrameMessage(
+        name=name,
+        props=vm.FrameProps(
+            show_axes=True,
+            axes_length=0.5,
+            axes_radius=0.025,
+            origin_radius=0.05,
+            origin_color=(230, 180, 30),
+            scale=1.0,
+        ),
+    )
+
+
+def test_entity_state_index_tracks_buffer_mutations() -> None:
+    """The index stays consistent through pushes, redundancy replacement,
+    remove-phase update purges, and predicate removal."""
+    with _sync_buffer() as buffer:
+        buffer.push(_frame_message("/a"))
+        buffer.push(vm.SetPositionMessage("/a", (1.0, 0.0, 0.0)))
+        buffer.push(vm.SetOrientationMessage("/a", (1.0, 0.0, 0.0, 0.0)))
+        buffer.push(vm.SetSceneNodeClickBindingsMessage("/a", bindings=()))
+        buffer.push(_frame_message("/b"))
+        buffer.push(vm.SetPositionMessage("/b", (0.0, 1.0, 0.0)))
+        _assert_entity_index_consistent(buffer)
+
+        # Redundancy replacement: a second position update for /a supersedes
+        # the first in-place; the index must drop the replaced id.
+        buffer.push(vm.SetPositionMessage("/a", (2.0, 0.0, 0.0)))
+        _assert_entity_index_consistent(buffer)
+        assert len(buffer.ids_from_entity_state_key[("scene", "/a")]) == 3
+
+        # Remove-phase push purges /a's pending updates (but not bindings).
+        buffer.push(vm.RemoveSceneNodeMessage("/a"))
+        _assert_entity_index_consistent(buffer)
+
+        # Predicate-based removal keeps the index consistent too.
+        buffer.remove_from_buffer(
+            lambda m: (
+                getattr(m, "name", None) == "/b"
+                and m.lifecycle_phase == "update_simple"
+            )
+        )
+        _assert_entity_index_consistent(buffer)
+
+
+def test_remove_entity_state_matches_predicate_purge() -> None:
+    """remove_entity_state_from_buffer removes exactly the messages
+    ``targets_entity_state`` matches for that entity (the same-name
+    replacement purge's contract, previously an O(buffer) predicate scan),
+    leaving creates and other entities untouched."""
+    with _sync_buffer() as buffer:
+        buffer.push(_frame_message("/a"))
+        buffer.push(vm.SetPositionMessage("/a", (1.0, 0.0, 0.0)))
+        buffer.push(vm.SetOrientationMessage("/a", (1.0, 0.0, 0.0, 0.0)))
+        buffer.push(vm.SetSceneNodeVisibilityMessage("/a", visible=False))
+        buffer.push(vm.SetSceneNodeClickBindingsMessage("/a", bindings=()))
+        buffer.push(_frame_message("/b"))
+        buffer.push(vm.SetPositionMessage("/b", (0.0, 1.0, 0.0)))
+
+        expected_removed = {
+            mid
+            for mid, m in buffer.message_from_id.items()
+            if m.targets_entity_state("scene", "/a")
+        }
+        assert len(expected_removed) == 4
+        before = set(buffer.message_from_id)
+
+        buffer.remove_entity_state_from_buffer("scene", "/a")
+
+        assert before - set(buffer.message_from_id) == expected_removed
+        _assert_entity_index_consistent(buffer)
+        # /a's create and /b's messages survive.
+        survivors = {type(m).__name__ for m in buffer.message_from_id.values()}
+        assert "FrameMessage" in survivors
+        assert any(
+            getattr(m, "name", None) == "/b" and isinstance(m, vm.SetPositionMessage)
+            for m in buffer.message_from_id.values()
+        )
+
+        # Purging an entity with no state is a no-op.
+        buffer.remove_entity_state_from_buffer("scene", "/never-added")
+        _assert_entity_index_consistent(buffer)
+
+
+def test_remove_phase_push_purges_updates_but_not_bindings() -> None:
+    """push()ing a remove purges the entity's pending update messages while
+    leaving phase-less binding messages for remove()'s own explicit
+    empty-binding broadcasts -- the pre-index behavior, preserved."""
+    with _sync_buffer() as buffer:
+        buffer.push(_frame_message("/a"))
+        buffer.push(vm.SetPositionMessage("/a", (1.0, 0.0, 0.0)))
+        buffer.push(vm.SetSceneNodeClickBindingsMessage("/a", bindings=()))
+
+        buffer.push(vm.RemoveSceneNodeMessage("/a"))
+
+        kinds = {type(m).__name__ for m in buffer.message_from_id.values()}
+        assert "SetPositionMessage" not in kinds
+        assert "SetSceneNodeClickBindingsMessage" in kinds
+        assert "RemoveSceneNodeMessage" in kinds
+        _assert_entity_index_consistent(buffer)


### PR DESCRIPTION
Fixes from a pre-release regression audit:

- Playback of a `.viser` recording saved with a different viser version now shows a version-mismatch notification instead of silently rendering with possible format drift.
- Same-name scene node re-adds purge the old node's buffered state through a new entity-keyed buffer index instead of an O(buffer) scan, keeping re-add-per-frame loops constant-time in scene size (~4.5ms → ~0.5ms per re-add at 2k nodes).
- The deprecated `line_width` handle setter now forces `thickness_units="screen"` so assigned values keep their historical pixel meaning on handles created with world-space defaults.
- `add_arrows` accepts the removed `line_width` argument with a deprecation warning instead of raising `TypeError`, and `ArrowsHandle.line_width` warns instead of silently writing a dead attribute.
- Share tunnel teardown threads tolerate `BrokenPipeError`/`ConnectionResetError` from dead manager proxies, matching `close()` and avoiding spurious tracebacks at interpreter exit after a failed tunnel.
- The line fringe material's antialiasing define is applied via callback ref so it survives material remounts from `segments`/`dashed` branch flips.
- Folder/tab context-guard errors now explain that the handle may be entered concurrently from another thread, not just self-nested.
- The per-entity message taxonomy is consolidated into a single `Message.entity_state_key()` definition, with new tests covering the buffer index, the re-add purge, overlapping container-context entry, and the arrows/line-width deprecations.