### PR TITLE
docs: fix two references left behind by refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ The web client is implemented using [React](https://react.dev/), with:
 - [Vite](https://vitejs.dev/) / [Rollup](https://rollupjs.org/) for bundling
 - [three.js](https://threejs.org/) via [react-three-fiber](https://github.com/pmndrs/react-three-fiber) and [drei](https://github.com/pmndrs/drei)
 - [Mantine](https://mantine.dev/) for UI components
-- [zustand](https://github.com/pmndrs/zustand) for state management
 - [vanilla-extract](https://vanilla-extract.style/) for stylesheets
 
 Thanks to the authors of these projects for open-sourcing their work!

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -167,7 +167,7 @@ LabelAnchor = Literal[
 ]
 
 
-# Entity lifecycle markers. See architecture_hardening.md for design rationale.
+# Entity lifecycle markers.
 EntityType: TypeAlias = Literal["gui", "scene", "command", "notification", "modal"]
 """Kinds of removable entities in the protocol."""
 


### PR DESCRIPTION
Noticed these while reading through the codebase at v1.1.0 — both are one-liners, happy to split or drop either.

- `_messages.py` points at `architecture_hardening.md` for the entity-lifecycle rationale, but that file isn't in the repo (and isn't in history). The `LifecyclePhase` docstring just below already covers the coalescing rules, so I removed the pointer — if that doc is something you're planning to add, drop this hunk and I'll rebase.
- The README acknowledgements credit zustand for state management; it looks like that went away in #679 in favor of the store in `src/store.ts`.